### PR TITLE
Add BrokerThrottleHook

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -920,6 +920,11 @@ func (cxn *brokerCxn) handleResps() {
 						if throttleUntil > cxn.throttleUntil {
 							atomic.StoreInt64(&cxn.throttleUntil, throttleUntil)
 						}
+						cxn.cl.cfg.hooks.each(func(h Hook) {
+							if h, ok := h.(BrokerThrottleHook); ok {
+								h.OnThrottle(cxn.b.meta, pr.resp.Key(), time.Duration(millis)*time.Millisecond)
+							}
+						})
 					}
 				}
 			}

--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -70,3 +70,16 @@ type BrokerReadHook interface {
 	// The bytes read does not count any tls overhead.
 	OnRead(meta BrokerMetadata, key int16, bytesRead int, readWait, timeToRead time.Duration, err error)
 }
+
+// BrokerThrottleHook is called after a response to a request is read
+// from a broker, and the response identifies throttling in effect.
+type BrokerThrottleHook interface {
+	// OnThrottle is passed the broker metadata, the key for the response that
+	// was read, and the imposed throttling interval.
+	//
+	// throttleInterval is how long of a throttle Kafka will apply to the
+	// client for this request.
+	// For Kafka < 2.0.0, the throttle is applied before issuing a response.
+	// For Kafka >= 2.0.0, the throttle is applied after issuing a response.
+	OnThrottle(meta BrokerMetadata, key int16, throttleInterval time.Duration)
+}


### PR DESCRIPTION
Innocuous change that has been smoke-tested with producer and consumer client instances running against a `5.5.2` cluster with default producer and consumer client throttling configs for over 1h.