### PR TITLE
rewrite the consumer & source code; other bug fixes

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -389,7 +389,8 @@ func AutoTopicCreation() Opt {
 // defaults to 100MiB.
 //
 // The only Kafka request that could come reasonable close to hitting this
-// limit should be produce requests.
+// limit should be produce requests, and thus this limit is only enforced for
+// produce requests.
 func BrokerMaxWriteBytes(v int32) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.maxBrokerWriteBytes = v }}
 }

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -3,6 +3,7 @@ package kgo
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -10,10 +11,10 @@ import (
 
 // Offset is a message offset in a partition.
 type Offset struct {
-	request      int64
+	at           int64
 	relative     int64
 	epoch        int32
-	currentEpoch int32 // set by us
+	currentEpoch int32 // set by us when mapping offsets to brokers
 }
 
 // NewOffsetcreates and returns an offset to use in AssignPartitions.
@@ -21,22 +22,22 @@ type Offset struct {
 // The default offset begins at the end.
 func NewOffset() Offset {
 	return Offset{
-		request: -1,
-		epoch:   -1,
+		at:    -1,
+		epoch: -1,
 	}
 }
 
 // AtStart returns a copy of the calling offset, changing the returned offset
 // to begin at the beginning of a partition.
 func (o Offset) AtStart() Offset {
-	o.request = -2
+	o.at = -2
 	return o
 }
 
 // AtEnd returns a copy of the calling offset, changing the returned offset to
 // begin at the end of a partition.
 func (o Offset) AtEnd() Offset {
-	o.request = -1
+	o.at = -1
 	return o
 }
 
@@ -65,14 +66,14 @@ func (o Offset) At(at int64) Offset {
 	if at < 0 {
 		at = -2
 	}
-	o.request = at
+	o.at = at
 	return o
 }
 
-type consumerType int8
+type consumerType uint8
 
 const (
-	consumerTypeUnset = iota
+	consumerTypeUnset consumerType = iota
 	consumerTypeDirect
 	consumerTypeGroup
 )
@@ -80,95 +81,73 @@ const (
 type consumer struct {
 	cl *Client
 
+	// mu guards this block specifically
 	mu     sync.Mutex
 	group  *groupConsumer
 	direct *directConsumer
 	typ    consumerType
 
-	// fetchMu gaurds concurrent PollFetches. While polling should happen
-	// serially, we must ensure it, especially to ensure we track updating
-	// offsets properly.
-	fetchMu sync.Mutex
+	// sessionChangeMu is grabbed when a session is stopped and held through
+	// when a session can be started again. The sole purpose is to block an
+	// assignment change running concurrently with a metadata update.
+	sessionChangeMu sync.Mutex
 
-	usingPartitions []*topicPartition
+	session atomic.Value // *consumerSession
 
-	offsetsWaitingLoad offsetsLoad
-	offsetsLoading     offsetsLoad
+	usingCursors usedCursors
 
 	sourcesReadyMu          sync.Mutex
 	sourcesReadyCond        *sync.Cond
 	sourcesReadyForDraining []*source
-	fakeReadyForDraining    []fetchSeq
-
-	// seq corresponds to the number of assigned groups or partitions.
-	//
-	// It is updated under both the sources ready mu and potentially
-	// also the consumer mu itself.
-	//
-	// Incrementing it invalidates prior assignments and fetches.
-	seq uint64
+	fakeReadyForDraining    []Fetch
 
 	// dead is set when the client closes; this being true means that any
 	// Assign does nothing (aside from unassigning everything prior).
 	dead bool
 }
 
-// fetchSeq is used for fake fetches that have no corresponding cursor.
-type fetchSeq struct {
-	Fetch
-	seq uint64
+type usedCursors map[*cursor]struct{}
+
+func (u *usedCursors) use(c *cursor) {
+	if *u == nil {
+		*u = make(map[*cursor]struct{})
+	}
+	(*u)[c] = struct{}{}
 }
 
-// unassignPrior invalidates old assignments, ensures that nothing is assigned,
-// and leaves any group.
-func (c *consumer) unassignPrior() {
-	c.assignPartitions(nil, assignInvalidateAll) // invalidate old assignments
+// unset, called under the consumer mu, transitions the group to the unset
+// state, invalidating old assignments and leaving a group if it was in one.
+func (c *consumer) unset() {
+	c.assignPartitions(nil, assignInvalidateAll)
 	if c.typ == consumerTypeGroup {
-		c.typ = consumerTypeUnset
 		c.group.leave()
 	}
+	c.typ = consumerTypeUnset
+	c.direct = nil
+	c.group = nil
 }
 
 // addSourceReadyForDraining tracks that a source needs its buffered fetch
-// consumed. If the seq this source is from is out of date, the source is
-// immediately drained.
-func (c *consumer) addSourceReadyForDraining(seq uint64, source *source) {
-	var broadcast bool
+// consumed.
+func (c *consumer) addSourceReadyForDraining(source *source) {
 	c.sourcesReadyMu.Lock()
-	if seq < c.seq {
-		source.takeBuffered()
-	} else {
-		c.sourcesReadyForDraining = append(c.sourcesReadyForDraining, source)
-		broadcast = true
-	}
+	c.sourcesReadyForDraining = append(c.sourcesReadyForDraining, source)
 	c.sourcesReadyMu.Unlock()
-	if broadcast {
-		c.sourcesReadyCond.Broadcast()
-	}
+	c.sourcesReadyCond.Broadcast()
 }
 
 // addFakeReadyForDraining saves a fake fetch that has important partition
 // errors--data loss or auth failures.
-func (c *consumer) addFakeReadyForDraining(topic string, partition int32, err error, seq uint64) {
+func (c *consumer) addFakeReadyForDraining(topic string, partition int32, err error) {
 	c.sourcesReadyMu.Lock()
-	defer c.sourcesReadyMu.Unlock()
-	if seq < c.seq {
-		return
-	}
-
-	c.fakeReadyForDraining = append(c.fakeReadyForDraining, fetchSeq{
-		Fetch{
-			Topics: []FetchTopic{{
-				Topic: topic,
-				Partitions: []FetchPartition{{
-					Partition: partition,
-					Err:       err,
-				}},
-			}},
-		},
-		seq,
-	})
-
+	c.fakeReadyForDraining = append(c.fakeReadyForDraining, Fetch{Topics: []FetchTopic{{
+		Topic: topic,
+		Partitions: []FetchPartition{{
+			Partition: partition,
+			Err:       err,
+		}},
+	}}})
+	c.sourcesReadyMu.Unlock()
 	c.sourcesReadyCond.Broadcast()
 }
 
@@ -178,48 +157,40 @@ func (c *consumer) addFakeReadyForDraining(topic string, partition int32, err er
 // It is important to check all partition errors in the returned fetches. If
 // any partition has a fatal error and actually had no records, fake fetch will
 // be injected with the error.
+//
+// It is invalid to call this multiple times concurrently.
 func (cl *Client) PollFetches(ctx context.Context) Fetches {
 	c := &cl.consumer
-	c.fetchMu.Lock()
-	defer c.fetchMu.Unlock()
 
 	var fetches Fetches
-
 	fill := func() {
 		c.sourcesReadyMu.Lock()
+		defer c.sourcesReadyMu.Unlock()
 		for _, ready := range c.sourcesReadyForDraining {
-			// If PollFetches is running concurrent with an
-			// assignment, the assignment may have invalidated
-			// some buffered fetches.
-			fetch, seq := ready.takeBuffered()
-			if seq < c.seq {
-				continue
-			}
-			fetches = append(fetches, fetch)
-		}
-		for _, ready := range c.fakeReadyForDraining {
-			fetch, seq := ready.Fetch, ready.seq
-			if seq < c.seq {
-				continue
-			}
-			fetches = append(fetches, fetch)
+			fetches = append(fetches, ready.takeBuffered())
 		}
 		c.sourcesReadyForDraining = nil
 
-		// Before releasing the sourcesReadyMu, we want to update our
-		// uncommitted. If we updated after, then we could end up with
-		// weird interactions with group invalidations where we return
-		// a stale fetch after committing in onRevoke.
+		// Before returning, we want to update our uncommitted. If we
+		// updated after, then we could end up with weird interactions
+		// with group invalidations where we return a stale fetch after
+		// committing in onRevoke.
 		//
 		// A blocking onRevoke commit, on finish, allows a new group
 		// session to start. If we returned stale fetches that did not
 		// have their uncommitted offset tracked, then we would allow
 		// duplicates.
+		//
+		// We grab the consumer mu because a concurrent client close
+		// could happen.
+		c.mu.Lock()
 		if c.typ == consumerTypeGroup && len(fetches) > 0 {
 			c.group.updateUncommitted(fetches)
 		}
+		c.mu.Unlock()
 
-		c.sourcesReadyMu.Unlock()
+		fetches = append(fetches, c.fakeReadyForDraining...)
+		c.fakeReadyForDraining = nil
 	}
 
 	fill()
@@ -252,28 +223,12 @@ func (cl *Client) PollFetches(ctx context.Context) Fetches {
 	return fetches
 }
 
-// maybeAssignPartitions assigns partitions if seq is equal to the consumer
-// seq, returning true if assignment occured. If true, this also updates seq to
-// the new seq.
-func (c *consumer) maybeAssignPartitions(seq *uint64, assignments map[string]map[int32]Offset, how assignHow) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.seq != *seq {
-		return false
-	}
-	c.assignPartitions(assignments, how)
-	*seq = c.seq
-	return true
-}
-
 // assignHow controls how assignPartitions operates.
 type assignHow int8
 
 const (
 	// This option simply assigns new offsets, doing nothing with existing
 	// offsets / active fetches / buffered fetches.
-	//
-	// This does not change the seq. All other options below bump the seq.
 	assignWithoutInvalidating assignHow = iota
 
 	// This option invalidates active fetches so they will not buffer and
@@ -310,81 +265,76 @@ func (h assignHow) String() string {
 // assignPartitions, called under the consumer's mu, is used to set new
 // cursors or add to the existing cursors.
 func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how assignHow) {
-	seq := c.seq
 
-	c.cl.cfg.logger.Log(LogLevelInfo, "assigning partitions", "how", how.String())
+	var session *consumerSession
+	var loadOffsets listOrEpochLoads
+	defer func() {
+		if session == nil { // if nil, we stopped the session
+			session = c.startNewSession()
+		}
+		loadOffsets.loadWithSessionNow(session)
+	}()
 
-	if how != assignWithoutInvalidating {
-		// In this block, we immediately want to ensure that nothing
-		// currently buffered will be returned and that no active
-		// fetches will keep their results.
-		//
-		// This lock ensures that nothing new will be buffered,
-		// and below bump the seq num on all cursors to ensure
-		// that
-		// 1) now unused cursors will not continue to loop
-		// 2) still used cursors will continue to loop at the
-		//    appropriate offset.
-		c.sourcesReadyMu.Lock()
-		c.seq++
-		seq = c.seq
+	if how == assignWithoutInvalidating {
+		session = c.guardSessionChange()
+		defer c.unguardSessionChange()
 
-		keep := c.usingPartitions[:0]
-		for _, usedPartition := range c.usingPartitions {
-			needsReset := true
+	} else {
+		loadOffsets = c.stopSession()
+
+		// First, over all cursors currently in use, we unset them or set them
+		// directly as appropriate. Anything we do not unset, we keep.
+
+		var keep usedCursors
+		for usedCursor := range c.usingCursors {
+			shouldKeep := true
 			if how == assignInvalidateAll {
-				usedPartition.cursor.setOffset(usedPartition.leaderEpoch, true, -1, -1, seq) // case 1
-				needsReset = false
-			} else {
-				if matchTopic, ok := assignments[usedPartition.cursor.topic]; ok {
-					if matchPartition, ok := matchTopic[usedPartition.cursor.partition]; ok {
-						needsReset = false
+				usedCursor.unset()
+				shouldKeep = false
+			} else { // invalidateMatching or setMatching
+				if assignTopic, ok := assignments[usedCursor.topic]; ok {
+					if assignPart, ok := assignTopic[usedCursor.partition]; ok {
 						if how == assignInvalidateMatching {
-							usedPartition.cursor.setOffset(usedPartition.leaderEpoch, true, -1, -1, seq) // case 1
-
+							usedCursor.unset()
+							shouldKeep = false
 						} else { // how == assignSetMatching
-							usedPartition.cursor.setOffset(usedPartition.leaderEpoch, true, matchPartition.request, matchPartition.epoch, seq) // case 2
-							keep = append(keep, usedPartition)
-
+							usedCursor.setOffset(cursorOffset{
+								offset:            assignPart.at,
+								lastConsumedEpoch: assignPart.epoch,
+							})
 						}
 					}
 				}
 			}
-			if needsReset {
-				usedPartition.cursor.resetOffset(seq) // case 2
-				keep = append(keep, usedPartition)
+			if shouldKeep {
+				keep.use(usedCursor)
 			}
 		}
+		c.usingCursors = keep
 
-		// Before releasing the lock, we drain any buffered (now stale)
-		// fetches that were waiting to be polled.
-		for _, ready := range c.sourcesReadyForDraining {
-			ready.takeBuffered()
+		// For any partition that was listing offsets or loading
+		// epochs, we want to ensure that if we are keeping those
+		// partitions, we re-start the list/load.
+		//
+		// Note that we do not need to unset cursors here; anything
+		// that actually resulted in a cursor is forever tracked in
+		// usedCursors. We only do not have used cursors if an
+		// assignment went straight to listing / epoch loading, and
+		// that list/epoch never finished.
+		if how == assignInvalidateAll {
+			loadOffsets = listOrEpochLoads{}
+		} else {
+			loadOffsets.filter(func(t string, p int32) bool {
+				var wasLoading bool
+				if assignTopic, ok := assignments[t]; ok {
+					if _, ok := assignTopic[p]; ok {
+						wasLoading = true
+					}
+				}
+				return how == assignInvalidateMatching && !wasLoading ||
+					how == assignSetMatching && wasLoading
+			})
 		}
-		c.fakeReadyForDraining = nil
-		c.sourcesReadyForDraining = nil
-		c.sourcesReadyMu.Unlock()
-
-		c.usingPartitions = keep
-	}
-
-	isLoading := !c.offsetsWaitingLoad.isEmpty() // stash if we are loading before we bump, which moves loading to load
-
-	// If we are invalidating or setting matching offsets, then we need to
-	// bump the seq's for loads or waiting loads that we are keeping.
-	//
-	// Otherwise, they will eventually load but not set offsets because
-	// their seq's would be out of date.
-	if how == assignInvalidateMatching || how == assignSetMatching {
-		c.bumpLoadingFetches()
-	}
-
-	// Bumping loading could have moved stuff back to load, so if we
-	// were not loading and load is non-empty, we need to refresh
-	// metadata to trigger the eventual offset load.
-	if !isLoading && !c.offsetsWaitingLoad.isEmpty() {
-		c.cl.cfg.logger.Log(LogLevelInfo, "assign invalidated offsets that were loading and bumped some back to waiting load; triggering meta update")
-		c.cl.triggerUpdateMetadata()
 	}
 
 	// This assignment could contain nothing (for the purposes of
@@ -396,24 +346,18 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 	c.cl.cfg.logger.Log(LogLevelInfo, "assign requires loading offsets")
 
 	clientTopics := c.cl.loadTopics()
-
 	for topic, partitions := range assignments {
-		topicParts := clientTopics[topic].load()
-		// clientTopics should always have all topics we are interested
-		// in. This is ensured in AssignPartitions, or in AssignGroup,
-		// or in metadata updating if consuming regex topics.
-		if topicParts == nil {
-			continue
-		}
+
+		topicParts := clientTopics[topic].load() // must be non-nil, which is ensured in Assign<> or in metadata when consuming as regex
 
 		for partition, offset := range partitions {
 			// First, if the request is exact, get rid of the relative
 			// portion. We are modifying a copy of the offset, i.e. we
 			// are appropriately not modfying 'assignments' itself.
-			if offset.request >= 0 {
-				offset.request = offset.request + offset.relative
-				if offset.request < 0 {
-					offset.request = 0
+			if offset.at >= 0 {
+				offset.at = offset.at + offset.relative
+				if offset.at < 0 {
+					offset.at = 0
 				}
 				offset.relative = 0
 			}
@@ -424,8 +368,11 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 			// Otherwise, an epoch is specified without an exact
 			// request which is useless for us, or a request is
 			// specified without a known epoch.
-			if offset.request >= 0 && offset.epoch >= 0 {
-				c.offsetsWaitingLoad.epoch.setLoadOffset(topic, partition, offset, -1, seq)
+			if offset.at >= 0 && offset.epoch >= 0 {
+				loadOffsets.addLoad(topic, partition, loadTypeEpoch, offsetLoad{
+					replica: -1,
+					Offset:  offset,
+				})
 				continue
 			}
 
@@ -437,167 +384,22 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 			// the partition, we list offsets to find out what to
 			// use.
 			part := topicParts.all[partition]
-			if offset.request >= 0 && part != nil {
-				part.cursor.setOffset(part.leaderEpoch, true, offset.request, -1, seq)
-				c.usingPartitions = append(c.usingPartitions, part)
+			if offset.at >= 0 && part != nil {
+				cursor := part.cursor
+				cursor.setOffset(cursorOffset{
+					offset:            offset.at,
+					lastConsumedEpoch: part.leaderEpoch,
+				})
+				cursor.allowUsable()
+				c.usingCursors.use(cursor)
 				continue
 			}
 
-			c.offsetsWaitingLoad.list.setLoadOffset(topic, partition, offset, -1, seq)
+			loadOffsets.addLoad(topic, partition, loadTypeList, offsetLoad{
+				replica: -1,
+				Offset:  offset,
+			})
 		}
-	}
-
-	if !c.offsetsWaitingLoad.isEmpty() {
-		if !isLoading {
-			c.cl.cfg.logger.Log(LogLevelInfo, "assign offsets waiting load nonempty; triggering meta update",
-				"need_list", c.offsetsWaitingLoad.list, "need_epoch", c.offsetsWaitingLoad.epoch)
-		} else {
-			c.cl.cfg.logger.Log(LogLevelInfo, "assign offsets waiting load nonempty; load in progress, not triggering meta update",
-				"need_list", c.offsetsWaitingLoad.list, "need_epoch", c.offsetsWaitingLoad.epoch)
-		}
-		c.cl.triggerUpdateMetadata()
-	}
-
-}
-
-// bumpLoadingFetches, called from assignOffsets, bumps the seq's for any load
-// or loading requests. We do this so that once the request eventually is
-// issued and returns, we do not ignore the return due to out of date seq's.
-//
-// For simplicity, this moves everything loading back to load; their loading
-// fetches are per-broker and we don't bump those loading seq's.
-func (c *consumer) bumpLoadingFetches() {
-	newSeq := c.seq
-	oldSeq := newSeq - 1
-
-	var matching map[string][]int32
-	switch c.typ {
-	case consumerTypeGroup:
-		matching = c.group.nowAssigned
-	case consumerTypeDirect:
-		matching = make(map[string][]int32)
-		for topic, partitions := range c.direct.using {
-			for partition := range partitions {
-				matching[topic] = append(matching[topic], partition)
-			}
-		}
-	}
-
-	for topic, partitions := range matching {
-		for _, partition := range partitions {
-			for _, loads := range []struct {
-				src offsetLoadMap
-				dst *offsetLoadMap
-			}{
-				{c.offsetsWaitingLoad.list, &c.offsetsWaitingLoad.list},
-				{c.offsetsWaitingLoad.epoch, &c.offsetsWaitingLoad.epoch},
-				{c.offsetsLoading.list, &c.offsetsWaitingLoad.list},
-				{c.offsetsLoading.epoch, &c.offsetsWaitingLoad.epoch},
-			} {
-				if existing, exists := loads.src.removeLoad(topic, partition, oldSeq); exists {
-					loads.dst.setLoadOffset(topic, partition, existing.Offset, existing.replica, newSeq)
-				}
-			}
-		}
-	}
-}
-
-// mergeInto is used by a source itself if it detects it needs to reload some
-// offsets that it was working with.
-func (o *offsetsLoad) mergeInto(c *consumer) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	isLoading := !c.offsetsWaitingLoad.isEmpty()
-	var needLoad bool
-
-	for _, loads := range []struct {
-		src offsetLoadMap
-		dst *offsetLoadMap
-	}{
-		{o.list, &c.offsetsWaitingLoad.list},
-		{o.epoch, &c.offsetsWaitingLoad.epoch},
-	} {
-		for topic, partitions := range loads.src {
-			for partition, offset := range partitions {
-				if offset.seq == c.seq {
-					loads.dst.setLoad(topic, partition, offset)
-					needLoad = true
-				}
-			}
-		}
-	}
-
-	if needLoad && !isLoading {
-		c.cl.triggerUpdateMetadata()
-	}
-}
-
-// loadingToWaitingLocked moves everything that is loading back to waiting
-// load. This is used for any failed load.
-func (o *offsetsLoad) loadingToWaiting(c *consumer) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	o.loadingToWaitingLocked(c)
-}
-
-func (o *offsetsLoad) loadingToWaitingLocked(c *consumer) {
-	if o.isEmpty() {
-		return
-	}
-
-	isLoading := !c.offsetsWaitingLoad.isEmpty()
-	var needLoad bool
-
-	// For all offsets, if the offset is the same offset that is in the
-	// load map (same seq), we remove it from the load map. Then, if the
-	// offset seq is the same as the consumer seq, we move it to the
-	// loading map.
-	for _, loads := range []struct {
-		src offsetLoadMap
-		chk offsetLoadMap
-		dst *offsetLoadMap
-	}{
-		{o.list, c.offsetsLoading.list, &c.offsetsWaitingLoad.list},
-		{o.epoch, c.offsetsLoading.epoch, &c.offsetsWaitingLoad.epoch},
-	} {
-		for topic, partitions := range loads.src {
-			for partition, offset := range partitions {
-				if _, exists := loads.chk.removeLoad(topic, partition, offset.seq); exists && offset.seq == c.seq {
-					loads.dst.setLoad(topic, partition, offset)
-					needLoad = true
-				}
-			}
-		}
-	}
-
-	if needLoad && !isLoading {
-		c.cl.triggerUpdateMetadata()
-	}
-}
-
-func (c *consumer) deletePartition(p *topicPartition) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for i, using := range c.usingPartitions {
-		if using == p {
-			// No calling setOffset here to invalidate the cursor;
-			// partition deletion does not cause a seq bump. But,
-			// the cursor has been removed from its source, meaning
-			// it will not be consumed anymore.
-			c.usingPartitions[i] = c.usingPartitions[len(c.usingPartitions)-1]
-			c.usingPartitions = c.usingPartitions[:len(c.usingPartitions)-1]
-			break
-		}
-	}
-
-	switch c.typ {
-	case consumerTypeUnset:
-		return
-	case consumerTypeDirect:
-		c.direct.deleteUsing(p.cursor.topic, p.cursor.partition)
-	case consumerTypeGroup:
 	}
 }
 
@@ -605,8 +407,6 @@ func (c *consumer) doOnMetadataUpdate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// First, call our direct or group on updates; these may set more
-	// partitions to load.
 	switch c.typ {
 	case consumerTypeUnset:
 		return
@@ -616,277 +416,655 @@ func (c *consumer) doOnMetadataUpdate() {
 		c.group.findNewAssignments(c.cl.loadTopics())
 	}
 
-	// Finally, process any updates.
-	c.resetAndLoadOffsets()
+	go c.loadSession().doOnMetadataUpdate()
 }
 
-// resetAndLoadOffsets empties offsetsWaitingLoad and tries loading them.
-func (c *consumer) resetAndLoadOffsets() {
-	// First, clear all stale (old seq) offsets.
-	for _, loads := range []offsetLoadMap{
-		c.offsetsWaitingLoad.list,
-		c.offsetsWaitingLoad.epoch,
-		c.offsetsLoading.list,
-		c.offsetsLoading.epoch,
-	} {
-		for topic, partitions := range loads {
-			for partition, offset := range partitions {
-				if offset.seq < c.seq {
-					delete(partitions, partition)
-				}
-			}
-			if len(partitions) == 0 {
-				delete(loads, topic)
-			}
-		}
-	}
-
-	c.cl.cfg.logger.Log(LogLevelDebug, "moving waiting load to loading", "waiting", c.offsetsWaitingLoad, "load", c.offsetsLoading)
-
-	// Now, move everything from the waiting load map to the loading map,
-	// clear the loading map, and load the load map.
-	for _, loads := range []struct {
-		src offsetLoadMap
-		dst *offsetLoadMap
-	}{
-		{c.offsetsWaitingLoad.list, &c.offsetsLoading.list},
-		{c.offsetsWaitingLoad.epoch, &c.offsetsLoading.epoch},
-	} {
-		for topic, partitions := range loads.src {
-			for partition, offset := range partitions {
-				// we do not remove because we clear below
-				loads.dst.setLoad(topic, partition, offset)
-			}
-		}
-	}
-
-	toLoad := c.offsetsWaitingLoad.clear()
-	if toLoad.isEmpty() {
+func (s *consumerSession) doOnMetadataUpdate() {
+	if s == nil { // no session started yet
 		return
 	}
-	c.tryOffsetLoad(toLoad)
-}
 
-func (c *consumer) tryOffsetLoad(toLoad offsetsLoad) {
-	// If any partitions do not exist in the metadata, or we cannot find
-	// the broker leader for a partition, we reload the metadata.
-	var toReload offsetsLoad
-	brokersToLoadFrom := make(map[*broker]*offsetsLoad)
+	s.listOrEpochMu.Lock()
+	defer s.listOrEpochMu.Unlock()
 
-	// For most of this function, we hold the broker mu so that we can
-	// check if topic partition leaders exist.
-	c.cl.brokersMu.RLock()
-	brokers := c.cl.brokers
-
-	// Map all waiting partition loads to the brokers that can load the
-	// offsets for those partitions.
-	topics := c.cl.loadTopics()
-
-	for _, loads := range []struct {
-		src    offsetLoadMap
-		dst    *offsetLoadMap
-		isList bool
-	}{
-		{toLoad.list, &toReload.list, true},
-		{toLoad.epoch, &toReload.epoch, false},
-	} {
-		for topic, partitions := range loads.src {
-			topicPartitions := topics[topic].load()
-
-			for partition, offset := range partitions {
-				dst := loads.dst
-
-				if topicPartition, exists := topicPartitions.all[partition]; exists {
-					brokerID := topicPartition.leader
-					if offset.replica != -1 {
-						// Fetching from followers can issue list offsets
-						// against the follower itself, not the leader.
-						brokerID = offset.replica
-					}
-					if broker := brokers[brokerID]; broker != nil {
-						brokerLoad := brokersToLoadFrom[broker]
-						if brokerLoad == nil {
-							brokerLoad = new(offsetsLoad)
-							brokersToLoadFrom[broker] = brokerLoad
-						}
-						// We have to set the offset's currentEpoch
-						// for our load requests.
-						offset.currentEpoch = topicPartition.leaderEpoch
-						if loads.isList {
-							dst = &brokerLoad.list
-						} else {
-							dst = &brokerLoad.epoch
-						}
-					}
-				}
-
-				dst.setLoad(topic, partition, offset)
-			}
-		}
+	if s.listOrEpochMetaCh == nil {
+		return // nothing waiting to load epochs / offsets
 	}
-
-	c.cl.brokersMu.RUnlock()
-
-	for broker, brokerLoad := range brokersToLoadFrom {
-		c.cl.cfg.logger.Log(LogLevelDebug, "offsets to load broker", "broker", broker.meta.NodeID, "load", brokerLoad)
-		if len(brokerLoad.list) > 0 {
-			go c.tryBrokerOffsetLoadList(broker, brokerLoad.list)
-		}
-		if len(brokerLoad.epoch) > 0 {
-			go c.tryBrokerOffsetLoadEpoch(broker, brokerLoad.epoch)
-		}
-	}
-
-	if !toReload.isEmpty() {
-		c.cl.cfg.logger.Log(LogLevelDebug, "offsets to reload", "reload", toReload)
-		// We area already under consumer mu from doOnMetadataUpdate.
-		toReload.loadingToWaitingLocked(c)
+	select {
+	case s.listOrEpochMetaCh <- struct{}{}:
+	default:
 	}
 }
 
+// offsetLoad is effectively an Offset, but also includes a potential replica
+// to directly use if a cursor had a preferred replica.
 type offsetLoad struct {
-	seq     uint64
 	replica int32 // -1 means leader
 	Offset
 }
 
 type offsetLoadMap map[string]map[int32]offsetLoad
 
-func (o *offsetLoadMap) setLoadOffset(t string, p int32, offset Offset, replica int32, seq uint64) {
-	o.setLoad(t, p, offsetLoad{seq, replica, offset})
-}
-func (o *offsetLoadMap) setLoad(t string, p int32, load offsetLoad) {
-	if *o == nil {
-		*o = make(offsetLoadMap)
+func (o offsetLoadMap) errToLoaded(err error) []loadedOffset {
+	var loaded []loadedOffset
+	for t, ps := range o {
+		for p, o := range ps {
+			loaded = append(loaded, loadedOffset{
+				topic:     t,
+				partition: p,
+				err:       err,
+				request:   o,
+			})
+		}
 	}
-	if (*o)[t] == nil {
-		(*o)[t] = make(map[int32]offsetLoad)
-	}
-	(*o)[t][p] = load
-}
-func (o offsetLoadMap) removeLoad(t string, p int32, seq uint64) (offsetLoad, bool) {
-	if o == nil {
-		return offsetLoad{}, false
-	}
-	ps := o[t]
-	if ps == nil {
-		return offsetLoad{}, false
-	}
-	existing, exists := ps[p]
-	if !exists {
-		return offsetLoad{}, false
-	}
-	if seq < existing.seq {
-		return offsetLoad{}, false
-	}
-	delete(ps, p)
-	return existing, true
+	return loaded
 }
 
-type offsetsLoad struct {
+// Combines list and epoch loads into one type for simplicity.
+type listOrEpochLoads struct {
 	list  offsetLoadMap
 	epoch offsetLoadMap
 }
 
-func (o *offsetsLoad) isEmpty() bool {
-	return o == nil || len(o.list) == 0 && len(o.epoch) == 0
-}
-func (o *offsetsLoad) clear() offsetsLoad { r := *o; *o = offsetsLoad{}; return r }
+type listOrEpochLoadType uint8
 
-func (c *consumer) tryBrokerOffsetLoadList(broker *broker, load offsetLoadMap) {
-	kresp, err := broker.waitResp(c.cl.ctx,
-		load.buildListReq(c.cl.cfg.isolationLevel))
-	if err != nil {
-		(&offsetsLoad{list: load}).loadingToWaiting(c)
+const (
+	loadTypeList listOrEpochLoadType = iota
+	loadTypeEpoch
+)
+
+// adds an offset to be loaded, ensuring it exists only in the final loadType.
+func (l *listOrEpochLoads) addLoad(t string, p int32, loadType listOrEpochLoadType, load offsetLoad) {
+	l.removeLoad(t, p)
+	dst := &l.list
+	if loadType == loadTypeEpoch {
+		dst = &l.epoch
+	}
+
+	if *dst == nil {
+		*dst = make(offsetLoadMap)
+	}
+	ps := (*dst)[t]
+	if ps == nil {
+		ps = make(map[int32]offsetLoad)
+		(*dst)[t] = ps
+	}
+	ps[p] = load
+}
+
+func (l *listOrEpochLoads) removeLoad(t string, p int32) {
+	for _, m := range []*offsetLoadMap{
+		&l.list,
+		&l.epoch,
+	} {
+		if *m == nil {
+			continue
+		}
+		ps := (*m)[t]
+		if ps == nil {
+			continue
+		}
+		delete(ps, p)
+		if len(ps) == 0 {
+			delete(*m, t)
+		}
+	}
+}
+
+func (l listOrEpochLoads) each(fn func(string, int32)) {
+	for _, m := range []offsetLoadMap{
+		l.list,
+		l.epoch,
+	} {
+		for topic, partitions := range m {
+			for partition := range partitions {
+				fn(topic, partition)
+			}
+		}
+	}
+}
+
+func (l *listOrEpochLoads) filter(keep func(string, int32) bool) {
+	for _, m := range []offsetLoadMap{
+		l.list,
+		l.epoch,
+	} {
+		for t, ps := range m {
+			for p := range ps {
+				if !keep(t, p) {
+					delete(ps, p)
+					if len(ps) == 0 {
+						delete(m, t)
+					}
+				}
+			}
+		}
+	}
+}
+
+// Merges loads into the caller; used to coalesce loads while a metadata update
+// is happening (see the only use below).
+func (dst *listOrEpochLoads) mergeFrom(src listOrEpochLoads) {
+	for _, srcs := range []struct {
+		m        offsetLoadMap
+		loadType listOrEpochLoadType
+	}{
+		{src.list, loadTypeList},
+		{src.epoch, loadTypeEpoch},
+	} {
+		for t, ps := range srcs.m {
+			for p, load := range ps {
+				dst.addLoad(t, p, srcs.loadType, load)
+			}
+		}
+	}
+}
+
+func (l listOrEpochLoads) isEmpty() bool { return len(l.list) == 0 && len(l.epoch) == 0 }
+
+func (l listOrEpochLoads) loadWithSession(s *consumerSession) {
+	if !l.isEmpty() {
+		s.incWorker()
+		go s.listOrEpoch(l, false)
+	}
+}
+
+func (l listOrEpochLoads) loadWithSessionNow(s *consumerSession) {
+	if !l.isEmpty() {
+		s.incWorker()
+		go s.listOrEpoch(l, true)
+	}
+}
+
+// A consumer session is responsible for an era of fetching records for a set
+// of cursors. The set can be added to without killing an active session, but
+// it cannot be removed from. Removing any cursor from being consumed kills the
+// current consumer session and begins a new one.
+type consumerSession struct {
+	c *consumer
+
+	ctx    context.Context
+	cancel func()
+
+	// Workers signify the number of fetch and list / epoch goroutines that
+	// are currently running within the context of this consumer session.
+	// Stopping a session only returns once workers hits zero.
+	workersMu   sync.Mutex
+	workersCond *sync.Cond
+	workers     int
+
+	listOrEpochMu           sync.Mutex
+	listOrEpochLoadsWaiting listOrEpochLoads
+	listOrEpochMetaCh       chan struct{} // non-nil if Loads is non-nil, signalled on meta update
+	listOrEpochLoadsLoading listOrEpochLoads
+}
+
+func (c *consumer) newConsumerSession() *consumerSession {
+	ctx, cancel := context.WithCancel(c.cl.ctx)
+	session := &consumerSession{
+		c: c,
+
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	session.workersCond = sync.NewCond(&session.workersMu)
+	return session
+}
+
+func (c *consumerSession) incWorker() {
+	c.workersMu.Lock()
+	defer c.workersMu.Unlock()
+	c.workers++
+}
+
+func (c *consumerSession) decWorker() {
+	c.workersMu.Lock()
+	defer c.workersMu.Unlock()
+	c.workers--
+	if c.workers == 0 {
+		c.workersCond.Broadcast()
+	}
+}
+
+// noConsumerSession exists because we cannot store nil into an atomic.Value.
+var noConsumerSession = new(consumerSession)
+
+func (c *consumer) loadSession() *consumerSession {
+	if session := c.session.Load(); session != nil {
+		return session.(*consumerSession)
+	}
+	return noConsumerSession
+}
+
+// Guards against a session being stopped, and must be paired with an unguard.
+// This returns a new session if there was no session.
+//
+// The purpose of this function is when performing additive-only changes to an
+// existing session, because additive-only changes can avoid killing a running
+// session.
+func (c *consumer) guardSessionChange() *consumerSession {
+	c.sessionChangeMu.Lock()
+
+	session := c.loadSession()
+	if session == noConsumerSession {
+		// If there is no session, we simply store one. This is fine;
+		// sources will be able to begin a fetch loop, but they will
+		// have no cursors to consume yet.
+		session = c.newConsumerSession()
+		c.session.Store(session)
+	}
+
+	return session
+}
+func (c *consumer) unguardSessionChange() {
+	c.sessionChangeMu.Unlock()
+}
+
+// Stops an active consumer session if there is one, and does not return until
+// all fetching, listing, offset for leader epoching is complete. This
+// invalidates any buffered fetches for the previous session and returns any
+// partitions that were listing offsets or loading epochs.
+func (c *consumer) stopSession() listOrEpochLoads {
+	c.sessionChangeMu.Lock()
+
+	session := c.loadSession()
+
+	if session == noConsumerSession {
+		return listOrEpochLoads{} // we had no session
+	}
+
+	// Before storing noConsumerSession, cancel our old. This pairs
+	// with the reverse ordering in source, which checks noConsumerSession
+	// then checks the session context.
+	session.cancel()
+
+	// At this point, any in progress fetches, offset lists, or epoch loads
+	// will quickly die.
+
+	c.session.Store(noConsumerSession)
+
+	// At this point, no source can be started, because the session is
+	// noConsumerSession.
+
+	session.workersMu.Lock()
+	for session.workers > 0 {
+		session.workersCond.Wait()
+	}
+	session.workersMu.Unlock()
+
+	// At this point, all fetches, lists, and loads are dead.
+
+	c.sourcesReadyMu.Lock()
+	defer c.sourcesReadyMu.Unlock()
+	for _, ready := range c.sourcesReadyForDraining {
+		ready.discardBuffered()
+	}
+	c.sourcesReadyForDraining = nil
+
+	// At this point, we have invalidated any buffered data from the prior
+	// session. We leave any fake things that were ready so that the user
+	// can act on errors. The session is dead.
+
+	session.listOrEpochLoadsWaiting.mergeFrom(session.listOrEpochLoadsLoading)
+	return session.listOrEpochLoadsWaiting
+}
+
+// Starts a new consumer session, allowing fetches to happen.
+func (c *consumer) startNewSession() *consumerSession {
+	session := c.newConsumerSession()
+	c.session.Store(session)
+
+	// At this point, sources can start consuming.
+
+	c.sessionChangeMu.Unlock()
+
+	c.cl.sinksAndSourcesMu.Lock()
+	for _, sns := range c.cl.sinksAndSources {
+		sns.source.maybeConsume()
+	}
+	c.cl.sinksAndSourcesMu.Unlock()
+
+	// At this point, any source that was not consuming becauase it saw the
+	// session was stopped has been notified to potentially start consuming
+	// again. The session is alive.
+
+	return session
+}
+
+// This function is responsible for issuing ListOffsets or
+// OffsetForLeaderEpoch. These requests's responses  are only handled within
+// the context of a consumer session.
+func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool) {
+	defer s.decWorker()
+
+	if immediate {
+		s.c.cl.triggerUpdateMetadataNow()
+	} else {
+		s.c.cl.triggerUpdateMetadata()
+	}
+
+	s.listOrEpochMu.Lock() // collapse any listOrEpochs that occur during meta update into one
+	if !s.listOrEpochLoadsWaiting.isEmpty() {
+		s.listOrEpochLoadsWaiting.mergeFrom(waiting)
+		s.listOrEpochMu.Unlock()
 		return
 	}
-	resp := kresp.(*kmsg.ListOffsetsResponse)
+	s.listOrEpochLoadsWaiting = waiting
+	s.listOrEpochMetaCh = make(chan struct{}, 1)
+	s.listOrEpochMu.Unlock()
 
-	type toSet struct {
-		topic          string
-		partition      int32
-		topicPartition *topicPartition
-		offset         int64
-		leaderEpoch    int32
-		load           offsetLoad
+	select {
+	case <-s.ctx.Done():
+		return
+	case <-s.listOrEpochMetaCh:
 	}
-	var toSets []toSet
 
+	s.listOrEpochMu.Lock()
+	loading := s.listOrEpochLoadsWaiting
+	s.listOrEpochLoadsLoading.mergeFrom(loading)
+	s.listOrEpochLoadsWaiting = listOrEpochLoads{}
+	s.listOrEpochMetaCh = nil
+	s.listOrEpochMu.Unlock()
+
+	brokerLoads := s.mapLoadsToBrokers(loading)
+
+	results := make(chan loadedOffsets, 2*len(brokerLoads)) // each broker can receive up to two requests
+
+	var issued, received int
+	for broker, brokerLoad := range brokerLoads {
+		s.c.cl.cfg.logger.Log(LogLevelDebug, "offsets to load broker", "broker", broker.meta.NodeID, "load", brokerLoad)
+		if len(brokerLoad.list) > 0 {
+			issued++
+			go s.c.cl.listOffsetsForBrokerLoad(s.ctx, broker, brokerLoad.list, results)
+		}
+		if len(brokerLoad.epoch) > 0 {
+			issued++
+			go s.c.cl.loadEpochsForBrokerLoad(s.ctx, broker, brokerLoad.epoch, results)
+		}
+	}
+
+	for received != issued {
+		select {
+		case <-s.ctx.Done():
+			// If we return early, our session was canceled. We do
+			// not move loading list or epoch loads back to
+			// waiting; the session stopping manages that.
+			return
+		case loaded := <-results:
+			received++
+			s.handleListOrEpochResults(loaded)
+		}
+	}
+}
+
+// Called within a consumer session, this function handles results from list
+// offsets or epoch loads.
+func (s *consumerSession) handleListOrEpochResults(loaded loadedOffsets) {
+	var reloads listOrEpochLoads
+	defer func() {
+		// When we are done handling results, we have finished loading
+		// all the topics and partitions. We remove them from tracking
+		// in our session.
+		s.listOrEpochMu.Lock()
+		for _, load := range loaded.loaded {
+			s.listOrEpochLoadsLoading.removeLoad(load.topic, load.partition)
+		}
+		s.listOrEpochMu.Unlock()
+
+		reloads.loadWithSession(s)
+	}()
+
+	for _, load := range loaded.loaded {
+		use := func() {
+			load.cursor.setOffset(cursorOffset{
+				offset:            load.offset,
+				lastConsumedEpoch: load.leaderEpoch,
+			})
+			load.cursor.finishUsing()
+			s.c.usingCursors.use(load.cursor)
+		}
+
+		switch load.err.(type) {
+		case *ErrDataLoss:
+			s.c.addFakeReadyForDraining(load.topic, load.partition, load.err) // signal we lost data, but set the cursor to what we can
+			use()
+
+		case nil:
+			use()
+
+		default: // from ErrorCode in a response
+			if !kerr.IsRetriable(load.err) { // non-retriable response error; signal such in a response
+				s.c.addFakeReadyForDraining(load.topic, load.partition, load.err)
+				continue
+			}
+			reloads.addLoad(load.topic, load.partition, loaded.loadType, load.request)
+		}
+	}
+}
+
+// Splits the loads into per-broker loads, mapping each partition to the broker
+// that leads that partition.
+func (s *consumerSession) mapLoadsToBrokers(loads listOrEpochLoads) map[*broker]listOrEpochLoads {
+	brokerLoads := make(map[*broker]listOrEpochLoads)
+
+	s.c.cl.brokersMu.RLock() // hold mu so we can check if partition leaders exist
+	defer s.c.cl.brokersMu.RUnlock()
+
+	brokers := s.c.cl.brokers
+	seed := brokers[unknownSeedID(0)] // must be non-nil
+
+	topics := s.c.cl.loadTopics()
+
+	for _, loads := range []struct {
+		m        offsetLoadMap
+		loadType listOrEpochLoadType
+	}{
+		{loads.list, loadTypeList},
+		{loads.epoch, loadTypeEpoch},
+	} {
+		for topic, partitions := range loads.m {
+			topicPartitions := topics[topic].load()
+			for partition, offset := range partitions {
+
+				// We default to the first seed broker if we have no loaded
+				// the broker leader for this partition (we should have).
+				// Worst case, we get an error for the partition and retry.
+				broker := seed
+				if topicPartition, exists := topicPartitions.all[partition]; exists {
+					brokerID := topicPartition.leader
+					if offset.replica != -1 {
+						// If we are fetching from a follower, we can list
+						// offsets against the follower itself. The replica
+						// being non-negative signals that.
+						brokerID = offset.replica
+					}
+					if tryBroker := brokers[brokerID]; tryBroker != nil {
+						broker = tryBroker
+					}
+					offset.currentEpoch = topicPartition.leaderEpoch // ensure we set our latest epoch for the partition
+				}
+
+				brokerLoad := brokerLoads[broker]
+				brokerLoad.addLoad(topic, partition, loads.loadType, offset)
+				brokerLoads[broker] = brokerLoad
+			}
+		}
+	}
+
+	return brokerLoads
+}
+
+// The result of ListOffsets or OffsetForLeaderEpoch for an individual
+// partition.
+type loadedOffset struct {
+	topic     string
+	partition int32
+
+	// The following three are potentially unset if the error is non-nil
+	// and not ErrDataLoss; these are what we loaded.
+	cursor      *cursor
+	offset      int64
+	leaderEpoch int32
+
+	// Any error encountered for loading this partition, or for epoch
+	// loading, potentially ErrDataLoss. If this error is not retriable, we
+	// avoid reloading the offset and instead inject a fake partition for
+	// PollFetches containing this error.
+	err error
+
+	// The original request.
+	request offsetLoad
+}
+
+// The results of ListOffsets or OffsetForLeaderEpoch for an individual broker.
+type loadedOffsets struct {
+	loaded   []loadedOffset
+	loadType listOrEpochLoadType
+}
+
+func (l *loadedOffsets) add(a loadedOffset) { l.loaded = append(l.loaded, a) }
+func (l *loadedOffsets) addAll(as []loadedOffset) loadedOffsets {
+	l.loaded = append(l.loaded, as...)
+	return *l
+}
+
+func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, load offsetLoadMap, results chan<- loadedOffsets) {
+	loaded := loadedOffsets{loadType: loadTypeList}
+
+	kresp, err := broker.waitResp(ctx, load.buildListReq(cl.cfg.isolationLevel))
+	if err != nil {
+		results <- loaded.addAll(load.errToLoaded(err))
+		return
+	}
+
+	resp := kresp.(*kmsg.ListOffsetsResponse)
 	for _, rTopic := range resp.Topics {
 		topic := rTopic.Topic
-		waitingParts, ok := load[topic]
+		loadParts, ok := load[topic]
 		if !ok {
-			continue
+			continue // should not happen: kafka replied with something we did not ask for
 		}
 
 		for _, rPartition := range rTopic.Partitions {
 			partition := rPartition.Partition
-			waitingPart, ok := waitingParts[partition]
+			loadPart, ok := loadParts[partition]
 			if !ok {
-				continue
+				continue // should not happen: kafka replied with something we did not ask for
 			}
 
-			err := kerr.ErrorForCode(rPartition.ErrorCode)
-			if err != nil {
-				if !kerr.IsRetriable(err) {
-					c.addFakeReadyForDraining(topic, partition, err, waitingPart.seq)
-					delete(waitingParts, partition)
-				}
-				continue
+			if err := kerr.ErrorForCode(rPartition.ErrorCode); err != nil {
+				loaded.add(loadedOffset{
+					topic:     topic,
+					partition: partition,
+					err:       err,
+					request:   loadPart,
+				})
+				continue // partition err: handled in results
 			}
 
-			topicPartitions := c.cl.loadTopics()[topic].load()
+			topicPartitions := cl.loadTopics()[topic].load()
 			topicPartition, ok := topicPartitions.all[partition]
 			if !ok {
-				continue // we have not yet loaded the partition
+				continue // should not happen: we have not seen this partition from a metadata response
 			}
 
-			delete(waitingParts, partition)
-			if len(waitingParts) == 0 {
+			delete(loadParts, partition)
+			if len(loadParts) == 0 {
 				delete(load, topic)
 			}
 
-			offset := rPartition.Offset + waitingPart.relative
-			if waitingPart.request >= 0 {
-				offset = waitingPart.request + waitingPart.relative
+			offset := rPartition.Offset + loadPart.relative
+			if loadPart.at >= 0 {
+				offset = loadPart.at + loadPart.relative // we obey exact requests, even if they end up past the end
 			}
 			if offset < 0 {
 				offset = 0
 			}
-			leaderEpoch := rPartition.LeaderEpoch
-			if resp.Version < 4 {
-				leaderEpoch = -1
-			}
 
-			toSets = append(toSets, toSet{
-				topic,
-				partition,
-				topicPartition,
-				offset,
-				leaderEpoch,
-				waitingPart,
+			loaded.add(loadedOffset{
+				topic:       topic,
+				partition:   partition,
+				cursor:      topicPartition.cursor,
+				offset:      offset,
+				leaderEpoch: rPartition.LeaderEpoch,
+				request:     loadPart,
 			})
 		}
 	}
 
-	if len(load) > 0 {
-		(&offsetsLoad{list: load}).loadingToWaiting(c)
-	}
-	if len(toSets) == 0 {
+	results <- loaded.addAll(load.errToLoaded(kerr.UnknownTopicOrPartition))
+}
+
+func (cl *Client) loadEpochsForBrokerLoad(ctx context.Context, broker *broker, load offsetLoadMap, results chan<- loadedOffsets) {
+	loaded := loadedOffsets{loadType: loadTypeEpoch}
+
+	kresp, err := broker.waitResp(ctx, load.buildEpochReq())
+	if err != nil {
+		results <- loaded.addAll(load.errToLoaded(err))
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	// If the version is < 2, we are speaking to an old broker. We should
+	// not have an old version, but we could have spoken to a new broker
+	// first then an old broker in the middle of a broker roll. For now, we
+	// will just loop retrying until the broker is upgraded.
 
-	for _, toSet := range toSets {
-		// Always try removing the load; only set the cursor to use the
-		// load if the load's seq is not stale.
-		if _, exists := c.offsetsLoading.list.removeLoad(toSet.topic, toSet.partition, toSet.load.seq); exists && toSet.load.seq == c.seq {
-			toSet.topicPartition.cursor.setOffset(toSet.load.currentEpoch, true, toSet.offset, toSet.leaderEpoch, c.seq)
-			c.usingPartitions = append(c.usingPartitions, toSet.topicPartition)
+	resp := kresp.(*kmsg.OffsetForLeaderEpochResponse)
+	for _, rTopic := range resp.Topics {
+		topic := rTopic.Topic
+		loadParts, ok := load[topic]
+		if !ok {
+			continue // should not happen: kafka replied with something we did not ask for
+		}
+
+		for _, rPartition := range rTopic.Partitions {
+			partition := rPartition.Partition
+			loadPart, ok := loadParts[partition]
+			if !ok {
+				continue // should not happen: kafka replied with something we did not ask for
+			}
+
+			if err := kerr.ErrorForCode(rPartition.ErrorCode); err != nil {
+				loaded.add(loadedOffset{
+					topic:     topic,
+					partition: partition,
+					err:       err,
+					request:   loadPart,
+				})
+				continue // partition err: handled in results
+			}
+
+			topicPartitions := cl.loadTopics()[topic].load()
+			topicPartition, ok := topicPartitions.all[partition]
+			if !ok {
+				continue // should not happen: we have not seen this partition from a metadata response
+			}
+
+			delete(loadParts, partition)
+			if len(loadParts) == 0 {
+				delete(load, topic)
+			}
+
+			offset := loadPart.at
+			var err error
+			if rPartition.EndOffset < offset {
+				offset = rPartition.EndOffset
+				err = &ErrDataLoss{topic, partition, offset, rPartition.EndOffset}
+			}
+
+			loaded.add(loadedOffset{
+				topic:       topic,
+				partition:   partition,
+				cursor:      topicPartition.cursor,
+				offset:      offset,
+				leaderEpoch: rPartition.LeaderEpoch,
+				err:         err,
+				request:     loadPart,
+			})
 		}
 	}
+
+	results <- loaded.addAll(load.errToLoaded(kerr.UnknownTopicOrPartition))
 }
 
 func (o offsetLoadMap) buildListReq(isolationLevel int8) *kmsg.ListOffsetsRequest {
@@ -899,17 +1077,17 @@ func (o offsetLoadMap) buildListReq(isolationLevel int8) *kmsg.ListOffsetsReques
 		parts := make([]kmsg.ListOffsetsRequestTopicPartition, 0, len(partitions))
 		for partition, offset := range partitions {
 			// If this partition is using an exact offset request,
-			// then Assign was called with the partition not
-			// existing. We just use -1 to ensure the partition
-			// is loaded.
-			timestamp := offset.request
+			// then we are listing for a partition that was not yet
+			// loaded by the client (due to metadata). We use -1
+			// just to ensure the partition is loaded.
+			timestamp := offset.at
 			if timestamp >= 0 {
 				timestamp = -1
 			}
 			parts = append(parts, kmsg.ListOffsetsRequestTopicPartition{
 				Partition:          partition,
 				CurrentLeaderEpoch: offset.currentEpoch, // KIP-320
-				Timestamp:          offset.request,
+				Timestamp:          offset.at,
 			})
 		}
 		req.Topics = append(req.Topics, kmsg.ListOffsetsRequestTopic{
@@ -920,113 +1098,6 @@ func (o offsetLoadMap) buildListReq(isolationLevel int8) *kmsg.ListOffsetsReques
 	return req
 }
 
-func (c *consumer) tryBrokerOffsetLoadEpoch(broker *broker, load offsetLoadMap) {
-	kresp, err := broker.waitResp(c.cl.ctx, load.buildEpochReq())
-	if err != nil {
-		(&offsetsLoad{epoch: load}).loadingToWaiting(c)
-		return
-	}
-	resp := kresp.(*kmsg.OffsetForLeaderEpochResponse)
-	// If the response version is < 2, then we cannot do truncation
-	// detection. We fallback to just listing offsets and hoping for
-	// the best. Of course, we should not be in this function if we
-	// never had a current leader to begin with, but it is possible
-	// we talked to one new broker and now are talking to a different
-	// older one in the same cluster.
-	if resp.Version < 2 {
-		c.mu.Lock()
-		loading := offsetsLoad{list: c.offsetsLoading.epoch}
-		c.offsetsLoading.epoch = nil
-		c.mu.Unlock()
-		loading.loadingToWaiting(c)
-		return
-	}
-
-	type toSet struct {
-		topic          string
-		partition      int32
-		topicPartition *topicPartition
-		offset         int64
-		leaderEpoch    int32
-		load           offsetLoad
-	}
-	var toSets []toSet
-
-	for _, rTopic := range resp.Topics {
-		topic := rTopic.Topic
-		waitingParts, ok := load[topic]
-		if !ok {
-			continue
-		}
-
-		for _, rPartition := range rTopic.Partitions {
-			partition := rPartition.Partition
-			waitingPart, ok := waitingParts[partition]
-			if !ok {
-				continue
-			}
-
-			err := kerr.ErrorForCode(rPartition.ErrorCode)
-			if err != nil {
-				if !kerr.IsRetriable(err) {
-					c.addFakeReadyForDraining(topic, partition, err, waitingPart.seq)
-					delete(waitingParts, partition)
-				}
-				continue
-			}
-
-			topicPartitions := c.cl.loadTopics()[topic].load()
-			topicPartition, ok := topicPartitions.all[partition]
-			if !ok {
-				continue // we have not yet loaded the partition
-			}
-
-			delete(waitingParts, partition)
-			if len(waitingParts) == 0 {
-				delete(load, topic)
-			}
-
-			if waitingPart.request < 0 {
-				panic("we should not be here with unknown offsets")
-			}
-			offset := waitingPart.request
-			if rPartition.EndOffset < offset {
-				offset = rPartition.EndOffset
-				err = &ErrDataLoss{topic, partition, offset, rPartition.EndOffset}
-				c.addFakeReadyForDraining(topic, partition, err, waitingPart.seq)
-			}
-
-			toSets = append(toSets, toSet{
-				topic,
-				partition,
-				topicPartition,
-				offset,
-				rPartition.LeaderEpoch,
-				waitingPart,
-			})
-		}
-	}
-
-	if len(load) > 0 {
-		(&offsetsLoad{epoch: load}).loadingToWaiting(c)
-	}
-	if len(toSets) == 0 {
-		return
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for _, toSet := range toSets {
-		// Always try removing the load; only set the cursor to use the
-		// load if the load's seq is not stale.
-		if _, exists := c.offsetsLoading.epoch.removeLoad(toSet.topic, toSet.partition, toSet.load.seq); exists && toSet.load.seq == c.seq {
-			toSet.topicPartition.cursor.setOffset(toSet.load.currentEpoch, true, toSet.offset, toSet.leaderEpoch, c.seq)
-			c.usingPartitions = append(c.usingPartitions, toSet.topicPartition)
-		}
-	}
-}
-
 func (o offsetLoadMap) buildEpochReq() *kmsg.OffsetForLeaderEpochRequest {
 	req := &kmsg.OffsetForLeaderEpochRequest{
 		ReplicaID: -1,
@@ -1035,9 +1106,6 @@ func (o offsetLoadMap) buildEpochReq() *kmsg.OffsetForLeaderEpochRequest {
 	for topic, partitions := range o {
 		parts := make([]kmsg.OffsetForLeaderEpochRequestTopicPartition, 0, len(partitions))
 		for partition, offset := range partitions {
-			if offset.epoch < 0 {
-				panic("we should not be here with negative epochs")
-			}
 			parts = append(parts, kmsg.OffsetForLeaderEpochRequestTopicPartition{
 				Partition:          partition,
 				CurrentLeaderEpoch: offset.currentEpoch,

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -152,18 +152,6 @@ func isRetriableBrokerErr(err error) bool {
 	return false
 }
 
-type errUnknownBrokerForPartition struct {
-	topic     string
-	partition int32
-	broker    int32
-}
-
-func (e *errUnknownBrokerForPartition) Error() string {
-	return fmt.Sprintf("Kafka replied that topic %s partition %d has broker leader %d,"+
-		" but did not reply with that broker in the broker list",
-		e.topic, e.partition, e.broker)
-}
-
 type errUnknownController struct {
 	id int32
 }

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -180,7 +180,7 @@ func TestRecBatchAppendTo(t *testing.T) {
 	// ***As a produce request***
 	txid := "tx"
 	kmsgReq := kmsg.ProduceRequest{
-		Version:       99,
+		Version:       8, // TODO bump to 99
 		TransactionID: &txid,
 		Acks:          -1,
 		TimeoutMillis: 1000,
@@ -193,7 +193,7 @@ func TestRecBatchAppendTo(t *testing.T) {
 		}},
 	}
 	ourReq := produceRequest{
-		version:       99,
+		version:       8,
 		txnID:         &txid,
 		acks:          -1,
 		timeout:       1000,


### PR DESCRIPTION
This is a very large commit that aims to make a lot of things simpler to
reason about in the consumer code, and then includes a few other
bugfixes bundled in that I noticed along the way.

Before this, the consumer used a bunch of sequence numbers to track
changes across assignments / etc. These sequence numbers were then used
to knife out stale partitions / ignore in-progress work that was
completing for stale partitions, while still accepting the non-stale
results.

This sequence number tracking and partition knifing was actually really
complicated and difficult to reason about, and I was never fully
confident in it. I knew there was some bug somewhere, and getting it to
work in the first place had me tracking down some really complicated
bugs to begin with.

This mostly rewrites the source and consumer code to ideally simplify
things. The state of partitions is no longer tracked through sequence
numbers that can be bumped whenever; instead, we use consumer sessions
that are stopped and started in full, and modifications happen while
stopped. This also attempts to simplify state changes from basically
happening anywhere to happening in fewer functions, and then adds a lot
of long winded documentation for why the state changes are safe.

Some simplifications still remain, but this is passing integration tests
right now. I'd like to clarify usedCursors, and to switch the useState
in a cursor to only have two states rather than three.

I'll shortly be following this with some consumer group API changes as
well, and will be simplifying the guts of a consumer group. Some changes
were already made to make things clearer, and to have fewer blocking
functions.

I noticed that fetch sessions had some lock inversion; that's fixed, and
the mutex aspects of a source / cursor have been drastically simplified.
The session also looked to have some flaws on unhappy path errors;
ideally those have been fixed, but they're hard to test.

I noticed that sinks and sources never updated their broker pointer,
which would be problematic if a broker changed but kept the same node
ID. There may have been some stuff in the metadata that fixed this up,
but regardless it was not the cleanest flow. The broker pointer was
definitely never updated. This commit changes that by putting sinks and
sources as a dedicated nodeID => sink/source field in the client itself,
and the sink/source looks up the broker pointer to use whenever issuing
a request. This allows brokers to change at any moment. This also moves
the sequenced async request from the broker to the sink itself, since
the sink is the only one that needed that, and putting it on the sink
allows brokers to change between requests.

This also removes the potential for a recBuf's sink or a cursor's source
to ever be nil. Instead, we default to the first seed broker. This is an
OK compromise because it allows us to start sending (and receiving
errors) immediately, while we expect to always have the relevant leader
broker loaded. This simplifies using a sink or a source, and also allows
things to begin notifying of load errors.