### PR TITLE
Add examples for transactional producer and consumer

### DIFF
--- a/examples/transactions/main.go
+++ b/examples/transactions/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "context"
+
+func main() {
+	kafkaBrokers := "localhost:9092"
+	topic := "test"
+
+	ctx := context.Background()
+	go startConsuming(ctx, kafkaBrokers, topic)
+	startProducing(ctx, kafkaBrokers, topic)
+}

--- a/examples/transactions/transactional_consumer.go
+++ b/examples/transactions/transactional_consumer.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func startConsuming(ctx context.Context, kafkaBrokers string, topic string) {
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(strings.Split(kafkaBrokers, ",")...),
+		// Only read messages that have been written as part of committed transactions.
+		kgo.FetchIsolationLevel(kgo.ReadCommitted()),
+	)
+	if err != nil {
+		fmt.Printf("error initializing Kafka consumer: %v\n", err)
+		return
+	}
+
+	client.AssignGroupTransactSession(
+		"my-consumer-group",
+		kgo.GroupTopics(topic),
+	)
+
+consumerLoop:
+	for {
+		fetches := client.PollFetches(ctx)
+		iter := fetches.RecordIter()
+
+		for _, fetchErr := range fetches.Errors() {
+			fmt.Printf(
+				"error consuming from topic: topic=%s, partition=%d, err=%v",
+				fetchErr.Topic, fetchErr.Partition, fetchErr.Err,
+			)
+			break consumerLoop
+		}
+
+		for !iter.Done() {
+			record := iter.Next()
+			fmt.Printf("consumed record with message: %v", string(record.Value))
+		}
+	}
+
+	fmt.Println("consumer exited")
+}

--- a/examples/transactions/transactional_consumer.go
+++ b/examples/transactions/transactional_consumer.go
@@ -20,8 +20,7 @@ func startConsuming(ctx context.Context, kafkaBrokers string, topic string) {
 	}
 
 	client.AssignGroup("my-consumer-group", kgo.GroupTopics(topic))
-	// Leave the consumer group when the consumer exits.
-	defer client.AssignGroup("")
+	defer client.Close()
 
 consumerLoop:
 	for {

--- a/examples/transactions/transactional_consumer.go
+++ b/examples/transactions/transactional_consumer.go
@@ -19,10 +19,9 @@ func startConsuming(ctx context.Context, kafkaBrokers string, topic string) {
 		return
 	}
 
-	client.AssignGroupTransactSession(
-		"my-consumer-group",
-		kgo.GroupTopics(topic),
-	)
+	client.AssignGroup("my-consumer-group", kgo.GroupTopics(topic))
+	// Leave the consumer group when the consumer exits.
+	defer client.AssignGroup("")
 
 consumerLoop:
 	for {

--- a/examples/transactions/transactional_producer.go
+++ b/examples/transactions/transactional_producer.go
@@ -67,6 +67,9 @@ func startProducing(ctx context.Context, kafkaBrokers string, topic string) {
 func produceRecords(ctx context.Context, client *kgo.Client, topic string, batch int) error {
 	errChan := make(chan error)
 
+	// Records are produced sequentially in order to demonstrate that a consumer
+	// using the ReadCommitted isolation level will not consume any records until
+	// the transaction is committed.
 	for i := 0; i < 10; i++ {
 		message := fmt.Sprintf("batch %d record %d\n", batch, i)
 		r := &kgo.Record{

--- a/examples/transactions/transactional_producer.go
+++ b/examples/transactions/transactional_producer.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func startProducing(ctx context.Context, kafkaBrokers string, topic string) {
+	producerId := strconv.FormatInt(int64(os.Getpid()), 10)
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(strings.Split(kafkaBrokers, ",")...),
+		kgo.TransactionalID(producerId),
+	)
+	if err != nil {
+		fmt.Printf("error initializing Kafka producer client: %v", err)
+		return
+	}
+
+	defer client.Close()
+
+	batch := 0
+	for {
+		if err := client.BeginTransaction(); err != nil {
+			fmt.Printf("error beginning transaction: %v\n", err)
+			break
+		}
+
+		// Write some messages in the transaction.
+		if err := produceRecords(ctx, client, topic, batch); err != nil {
+			fmt.Printf("error producing message: %v\n", err)
+			rollback(ctx, client)
+			continue
+		}
+
+		// Flush all of the buffered messages.
+		if err := client.Flush(ctx); err != nil {
+			if err != context.Canceled {
+				fmt.Printf("error flushing messages: %v\n", err)
+			}
+
+			rollback(ctx, client)
+			continue
+		}
+
+		// Attempt to commit the transaction and explicitly abort if it fails.
+		if err := client.EndTransaction(ctx, kgo.TryCommit); err != nil {
+			fmt.Printf("error committing transaction: %v\n", err)
+
+			if rollbackErr := client.AbortBufferedRecords(ctx); err != nil {
+				fmt.Printf("error rolling back transaction after commit failure: %v\n", rollbackErr)
+			}
+		}
+
+		batch += 1
+		time.Sleep(10 * time.Second)
+	}
+
+	fmt.Println("producer exited")
+}
+
+func produceRecords(ctx context.Context, client *kgo.Client, topic string, batch int) error {
+	errChan := make(chan error)
+
+	for i := 0; i < 10; i++ {
+		message := fmt.Sprintf("batch %d record %d\n", batch, i)
+		r := &kgo.Record{
+			Value: []byte(message),
+			Topic: topic,
+		}
+
+		err := client.Produce(ctx, r, func(r *kgo.Record, e error) {
+			fmt.Printf("produced message: %s", message)
+			errChan <- e
+		})
+		if err != nil {
+			return err
+		}
+
+		select {
+		case err := <-errChan:
+			if err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+func rollback(ctx context.Context, client *kgo.Client) {
+	if err := client.EndTransaction(ctx, kgo.TryAbort); err != nil {
+		fmt.Printf("error rolling back transaction: %v\n", err)
+	}
+	fmt.Println("transaction rolled back")
+}

--- a/examples/transactions/transactional_producer.go
+++ b/examples/transactions/transactional_producer.go
@@ -85,13 +85,8 @@ func produceRecords(ctx context.Context, client *kgo.Client, topic string, batch
 			return err
 		}
 
-		select {
-		case err := <-errChan:
-			if err != nil {
-				return err
-			}
-		case <-ctx.Done():
-			return ctx.Err()
+		if err := <-errChan; err != nil {
+			return err
 		}
 	}
 

--- a/examples/transactions/transactional_producer.go
+++ b/examples/transactions/transactional_producer.go
@@ -98,6 +98,7 @@ func produceRecords(ctx context.Context, client *kgo.Client, topic string, batch
 func rollback(ctx context.Context, client *kgo.Client) {
 	if err := client.EndTransaction(ctx, kgo.TryAbort); err != nil {
 		fmt.Printf("error rolling back transaction: %v\n", err)
+		return
 	}
 	fmt.Println("transaction rolled back")
 }


### PR DESCRIPTION
Hi @twmb! I'm implementing a new producer with this library since it seems to have great support for producing messages in transactions and I need exactly-once semantics. I ended up crafting a couple of examples to test things out and figured I might put them out there for the sake of consolidating some of the transaction documentation.

I know the other examples don't use a main package but I found it convenient to be able to run the example as-is so I left it in there. More than happy to make changes to that or any other part of this.

As a side note, if I'm doing anything wrong here I'd really appreciate any feedback or guidance here.

Example output (repeats every 10s):
```
produced message: batch 0 record 0
produced message: batch 0 record 1
produced message: batch 0 record 2
produced message: batch 0 record 3
produced message: batch 0 record 4
produced message: batch 0 record 5
produced message: batch 0 record 6
produced message: batch 0 record 7
produced message: batch 0 record 8
produced message: batch 0 record 9
consumed record with message: batch 0 record 0
consumed record with message: batch 0 record 1
consumed record with message: batch 0 record 2
consumed record with message: batch 0 record 3
consumed record with message: batch 0 record 4
consumed record with message: batch 0 record 5
consumed record with message: batch 0 record 6
consumed record with message: batch 0 record 7
consumed record with message: batch 0 record 8
consumed record with message: batch 0 record 9
```