### PR TITLE
General updates

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -86,10 +86,11 @@ type Client struct {
 	coordinatorsMu sync.Mutex
 	coordinators   map[coordinatorKey]int32
 
-	updateMetadataCh    chan struct{}
-	updateMetadataNowCh chan struct{} // like above, but with high priority
-	metawait            metawait
-	metadone            chan struct{}
+	updateMetadataCh     chan struct{}
+	updateMetadataNowCh  chan struct{} // like above, but with high priority
+	blockingMetadataFnCh chan func()
+	metawait             metawait
+	metadone             chan struct{}
 }
 
 func (cl *Client) idempotent() bool { return !cl.cfg.disableIdempotency }
@@ -167,9 +168,10 @@ func NewClient(opts ...Opt) (*Client, error) {
 
 		coordinators: make(map[coordinatorKey]int32),
 
-		updateMetadataCh:    make(chan struct{}, 1),
-		updateMetadataNowCh: make(chan struct{}, 1),
-		metadone:            make(chan struct{}),
+		updateMetadataCh:     make(chan struct{}, 1),
+		updateMetadataNowCh:  make(chan struct{}, 1),
+		blockingMetadataFnCh: make(chan func()),
+		metadone:             make(chan struct{}),
 	}
 	cl.producer.init()
 	cl.consumer.init(cl)

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -135,7 +135,10 @@ out:
 				New: func() interface{} {
 					zstdEnc, err := zstd.NewWriter(nil,
 						zstd.WithEncoderLevel(level),
-						zstd.WithEncoderConcurrency(1))
+						zstd.WithWindowSize(64<<10),
+						zstd.WithEncoderConcurrency(1),
+						zstd.WithZeroFrames(true),
+					)
 					if err != nil {
 						zstdEnc, _ = zstd.NewWriter(nil,
 							zstd.WithEncoderConcurrency(1))
@@ -230,7 +233,10 @@ func newDecompressor() *decompressor {
 		},
 		unzstdPool: sync.Pool{
 			New: func() interface{} {
-				zstdDec, _ := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+				zstdDec, _ := zstd.NewReader(nil,
+					zstd.WithDecoderLowmem(true),
+					zstd.WithDecoderConcurrency(1),
+				)
 				r := &zstdDecoder{zstdDec}
 				runtime.SetFinalizer(r, func(r *zstdDecoder) {
 					r.inner.Close()

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -462,7 +462,7 @@ func RetryBackoff(backoff func(int) time.Duration) Opt {
 
 // RequestRetries sets the number of tries that retriable requests are allowed,
 // overriding the unlimited default. This option does not apply to produce
-// requests.
+// requests; to limit produce request retries, see ProduceRetries.
 func RequestRetries(n int) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.retries = int64(n) }}
 }
@@ -682,9 +682,9 @@ func ProduceRequestTimeout(limit time.Duration) ProducerOpt {
 // the unlimited default.
 //
 // If idempotency is enabled (as it is by default), this option is only
-// enforced if it is safe to do so without messing up sequence numbers. It is
-// safe to enforce if a record was never issued in a request to Kafka, or if it
-// was requested and received a response.
+// enforced if it is safe to do so without creating invalid sequence numbers.
+// It is safe to enforce if a record was never issued in a request to Kafka, or
+// if it was requested and received a response.
 //
 // This option is different from RequestRetries to allow finer grained control
 // of when to fail when producing records.
@@ -745,9 +745,9 @@ func ManualFlushing() ProducerOpt {
 // batch before timing out, overriding the ulimited default.
 //
 // If idempotency is enabled (as it is by default), this option is only
-// enforced if it is safe to do so without messing up sequence numbers.  It is
-// safe to enforce if a record was never issued in a request to Kafka, or if it
-// was requested and received a response.
+// enforced if it is safe to do so without creating invalid sequence numbers.
+// It is safe to enforce if a record was never issued in a request to Kafka, or
+// if it was requested and received a response.
 //
 // The timeout for all records in a batch inherit the timeout of the first
 // record in that batch. That is, once the first record's timeout expires, all

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -187,6 +187,27 @@ func (c *consumer) unsetAndWait() (wasDead bool) {
 //
 // This returns a function to wait for a group to be left, if in one.
 func (c *consumer) unset() (wasDead bool, wait func()) {
+	// Unsetting means all old cursors are useless. Before we return, we
+	// delete all old cursors. This is especially important in the context
+	// of a new assignment, which will create new cursors that may
+	// duplicate our old.
+	//
+	// Note that this is happening outside of the context of a valid
+	// consumer session, so we do not need to worry about much else.
+	//
+	// Since we are blocking metadata, sinksAndSources cannot be modified
+	// concurrently and we do not need a lock.
+	cl := c.cl
+	defer cl.blockingMetadataFn(func() {
+		for _, sns := range cl.sinksAndSources {
+			s := sns.source
+			s.cursorsMu.Lock()
+			s.cursors = nil
+			s.cursorsStart = 0
+			s.cursorsMu.Unlock()
+		}
+	})
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1013,7 +1013,7 @@ func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool) 
 	if immediate {
 		s.c.cl.triggerUpdateMetadataNow()
 	} else {
-		wait = s.c.cl.triggerUpdateMetadata()
+		wait = s.c.cl.triggerUpdateMetadata(false) // avoid trigger if within refresh interval
 	}
 
 	s.listOrEpochMu.Lock() // collapse any listOrEpochs that occur during meta update into one

--- a/pkg/kgo/consumer_direct.go
+++ b/pkg/kgo/consumer_direct.go
@@ -88,7 +88,7 @@ func (cl *Client) AssignPartitions(opts ...DirectConsumeOpt) {
 	}
 
 	defer c.storeDirect(d)
-	defer cl.triggerUpdateMetadata()
+	defer cl.triggerUpdateMetadata(true) // we definitely want to trigger a metadata update
 
 	if d.regexTopics {
 		return

--- a/pkg/kgo/consumer_direct.go
+++ b/pkg/kgo/consumer_direct.go
@@ -45,6 +45,8 @@ func ConsumeTopicsRegex() DirectConsumeOpt {
 }
 
 type directConsumer struct {
+	tps *topicsPartitions // data for topics that the user assigned
+
 	topics     map[string]Offset
 	partitions map[string]map[int32]Offset
 
@@ -71,6 +73,7 @@ func (cl *Client) AssignPartitions(opts ...DirectConsumeOpt) {
 	}
 
 	d := &directConsumer{
+		tps:        newTopicsPartitions(),
 		topics:     make(map[string]Offset),
 		partitions: make(map[string]map[int32]Offset),
 		reTopics:   make(map[string]Offset),
@@ -84,8 +87,7 @@ func (cl *Client) AssignPartitions(opts ...DirectConsumeOpt) {
 		return
 	}
 
-	c.storeDirect(d)
-
+	defer c.storeDirect(d)
 	defer cl.triggerUpdateMetadata()
 
 	if d.regexTopics {
@@ -99,14 +101,13 @@ func (cl *Client) AssignPartitions(opts ...DirectConsumeOpt) {
 	for topic := range d.partitions {
 		topics = append(topics, topic)
 	}
-	cl.storeTopics(topics)
+	d.tps.storeTopics(topics)
 }
 
 // findNewAssignments returns new partitions to consume at given offsets
 // based off the current topics.
-func (d *directConsumer) findNewAssignments(
-	topics map[string]*topicPartitions,
-) map[string]map[int32]Offset {
+func (d *directConsumer) findNewAssignments() map[string]map[int32]Offset {
+	topics := d.tps.load()
 	// First, we build everything we could theoretically want to consume.
 	toUse := make(map[string]map[int32]Offset, 10)
 	for topic, topicPartitions := range topics {

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -406,7 +406,7 @@ func (cl *Client) AssignGroup(group string, opts ...GroupOpt) {
 	}
 
 	defer c.storeGroup(g)
-	defer cl.triggerUpdateMetadata()
+	defer cl.triggerUpdateMetadata(true) // we definitely want to trigger a metadata update
 
 	for _, balancer := range g.balancers {
 		g.cooperative = g.cooperative && balancer.isCooperative()

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -517,6 +517,8 @@ func (g *groupConsumer) leave() (wait func()) {
 				"group", g.id,
 				"memberID", g.memberID, // lock not needed now since nothing can change it (manageDone)
 			)
+			// If we error when leaving, there is not much
+			// we can do. We may as well just return.
 			(&kmsg.LeaveGroupRequest{
 				Group:    g.id,
 				MemberID: g.memberID,

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -38,6 +38,8 @@ var (
 	// stopped due to a concurrent metadata response.
 	errChosenBrokerDead = errors.New("the internal broker struct chosen to issue this requesthas died--either the broker id is migrating or no longer exists")
 
+	errProducerIDLoadFail = errors.New("unable to initialize a producer ID due to request retry limits")
+
 	// A temporary error returned when Kafka replies with a different
 	// correlation ID than we were expecting for the request the client
 	// issued.

--- a/pkg/kgo/internal/sticky/graph.go
+++ b/pkg/kgo/internal/sticky/graph.go
@@ -55,7 +55,7 @@ func (b *balancer) newGraph(
 	return g
 }
 
-func (g *graph) changeOwnership(edge uint32, newDst uint16) {
+func (g *graph) changeOwnership(edge int32, newDst uint16) {
 	g.cxns[edge] = newDst
 }
 
@@ -96,7 +96,7 @@ func (g *graph) findSteal(from uint16) ([]stealSegment, bool) {
 
 		for _, topicNum := range g.out[current.node] {
 			info := g.b.topicInfos[topicNum]
-			firstPartNum, lastPartNum := info.partNum, info.partNum+uint32(info.partitions)
+			firstPartNum, lastPartNum := info.partNum, info.partNum+info.partitions
 			for edge := firstPartNum; edge < lastPartNum; edge++ {
 				neighborNode := g.cxns[edge]
 				neighbor, isNew := g.getScore(neighborNode)
@@ -131,16 +131,16 @@ func (g *graph) findSteal(from uint16) ([]stealSegment, bool) {
 type stealSegment struct {
 	src  uint16 // member num
 	dst  uint16 // member num
-	part uint32 // partNum
+	part int32  // partNum
 }
 
 type pathScore struct {
 	done    bool
 	node    uint16 // member num
 	parent  *pathScore
-	srcEdge uint32 // partNum
-	level   int32  // partitions owned on this segment
-	gscore  int32  // how many steals it would take to get here
+	srcEdge int32 // partNum
+	level   int32 // partitions owned on this segment
+	gscore  int32 // how many steals it would take to get here
 	fscore  int32
 }
 

--- a/pkg/kgo/internal/sticky/graph.go
+++ b/pkg/kgo/internal/sticky/graph.go
@@ -95,9 +95,6 @@ func (g *graph) findSteal(from uint16) ([]stealSegment, bool) {
 		current.done = true
 
 		for _, topicNum := range g.out[current.node] {
-			// Even if we create a partition here for a topic that
-			// no longer exists, it does not matter because we will
-			// not loop at all below.
 			info := g.b.topicInfos[topicNum]
 			firstPartNum, lastPartNum := info.partNum, info.partNum+uint32(info.partitions)
 			for edge := firstPartNum; edge < lastPartNum; edge++ {
@@ -108,6 +105,9 @@ func (g *graph) findSteal(from uint16) ([]stealSegment, bool) {
 				}
 
 				gscore := current.gscore + 1
+				// If our neghbor gscore is less or equal, then we can
+				// reach the neighbor through a previous route we have
+				// tried and should not try again.
 				if gscore < neighbor.gscore {
 					neighbor.parent = current
 					neighbor.srcEdge = edge
@@ -116,8 +116,10 @@ func (g *graph) findSteal(from uint16) ([]stealSegment, bool) {
 					if isNew {
 						heap.Push(rem, neighbor)
 					}
-					// We never need to fix the heap position; it is
-					// not possible for us to find a lower score.
+					// We never need to fix the heap position.
+					// Our level and fscore is static, and once
+					// we set gscore, it is the minumum it will be
+					// and we never revisit this neighbor.
 				}
 			}
 		}
@@ -138,30 +140,27 @@ type pathScore struct {
 	parent  *pathScore
 	srcEdge uint32 // partNum
 	level   int32  // partitions owned on this segment
-	gscore  int32
+	gscore  int32  // how many steals it would take to get here
 	fscore  int32
 }
 
 type pathScores []pathScore
 
 const infinityScore = 1<<31 - 1
-const noScore = 1<<31 - 1
+const noScore = -1
 
 // For A*, if we never overestimate (with h), then the path we find is
 // optimal. A true estimation of our distance to any node is the node's
-// level minus ours. However, we do not actually know what we want to
-// steal; we do not know what we are searching for.
-//
-// If we have a neighbor 10 levels up, it makes more sense to steal
-// from that neighbor than one 5 levels up.
+// level minus ours.
 //
 // At worst, our target must be +2 levels from us. So, our estimation
-// any node can be our level, +2, minus theirs. This allows neighbor
-// nodes that _are_ 10 levels higher to flood out any bad path and to
-// jump to the top of the priority queue. If there is no high level
-// to steal from, our estimator works normally.
+// any node can be our level, +2, minus theirs.
 func h(first, target *pathScore) int32 {
-	return first.level + 2 - target.level
+	r := first.level + 2 - target.level
+	if r < 0 {
+		return 0
+	}
+	return r
 }
 
 func (g *graph) getScore(node uint16) (*pathScore, bool) {
@@ -184,14 +183,14 @@ func (p *pathHeap) Len() int { return len(*p) }
 func (p *pathHeap) Swap(i, j int) {
 	h := *p
 	h[i], h[j] = h[j], h[i]
-
 }
 
 func (p *pathHeap) Less(i, j int) bool {
 	l, r := (*p)[i], (*p)[j]
-	return l.fscore < r.fscore ||
-		l.fscore == r.fscore &&
-			l.node < r.node
+	return l.level > r.level || l.level == r.level &&
+		(l.fscore < r.fscore || l.fscore == r.fscore &&
+			(l.gscore < r.gscore || l.gscore == r.gscore &&
+				l.node < r.node))
 }
 
 func (p *pathHeap) Push(x interface{}) { *p = append(*p, x.(*pathScore)) }

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -293,6 +293,7 @@ func (cl *Client) fetchTopicMetadata(reqTopics []string) (map[string]*topicParti
 					maxRecordBatchBytes: cl.maxRecordBatchBytesForTopic(topicMeta.Topic),
 
 					recBufsIdx: -1,
+					failing:    partMeta.ErrorCode != 0,
 				},
 
 				cursor: &cursor{

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -184,7 +184,7 @@ func (cl *Client) updateMetadata() (needsRetry bool, err error) {
 	defer cl.consumer.doOnMetadataUpdate()
 
 	var (
-		tpsProducerLoad = cl.loadTopics()
+		tpsProducerLoad = cl.producer.topics.load()
 		tpsConsumer     *topicsPartitions
 		all             bool
 		reqTopics       []string

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -446,7 +446,7 @@ func (cl *Client) partitionsForTopicProduce(pr promisedRec) (*topicPartitions, *
 		return parts, v
 	}
 	cl.addUnknownTopicRecord(pr)
-	cl.triggerUpdateMetadata()
+	cl.triggerUpdateMetadata(false)
 
 	return nil, nil // our record is buffered waiting for metadata update; nothing to return
 }

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -14,6 +14,15 @@ import (
 )
 
 type producer struct {
+	topicsMu sync.Mutex // locked to prevent concurrent updates; reads are always atomic
+	topics   *topicsPartitions
+
+	// unknownTopics buffers all records for topics that are not loaded.
+	// The map is to a pointer to a slice for reasons documented in
+	// waitUnknownTopic.
+	unknownTopicsMu sync.Mutex
+	unknownTopics   map[string]*unknownTopicProduces
+
 	bufferedRecords int64
 
 	id           atomic.Value
@@ -46,6 +55,8 @@ type unknownTopicProduces struct {
 }
 
 func (p *producer) init() {
+	p.topics = newTopicsPartitions()
+	p.unknownTopics = make(map[string]*unknownTopicProduces)
 	p.waitBuffer = make(chan struct{}, 100)
 	p.idVersion = -1
 	p.id.Store(&producerID{
@@ -111,11 +122,13 @@ func (cl *Client) Produce(
 	r *Record,
 	promise func(*Record, error),
 ) error {
-	if cl.cfg.txnID != nil && atomic.LoadUint32(&cl.producer.producingTxn) != 1 {
+	p := &cl.producer
+
+	if cl.cfg.txnID != nil && atomic.LoadUint32(&p.producingTxn) != 1 {
 		return errNotInTransaction
 	}
 
-	if atomic.AddInt64(&cl.producer.bufferedRecords, 1) > cl.cfg.maxBufferedRecords {
+	if atomic.AddInt64(&p.bufferedRecords, 1) > cl.cfg.maxBufferedRecords {
 		// If the client ctx cancels or the produce ctx cancels, we
 		// need to un-count our buffering of this record. As well, to
 		// be safe, we need to drain a slot from the waitBuffer chan,
@@ -124,7 +137,7 @@ func (cl *Client) Produce(
 		// (i.e., pretending we finished this record) and drain the
 		// waitBuffer as normal.
 		drainBuffered := func() {
-			go func() { <-cl.producer.waitBuffer }()
+			go func() { <-p.waitBuffer }()
 			cl.finishRecordPromise(promisedRec{noPromise, nil}, nil)
 		}
 		if cl.cfg.manualFlushing {
@@ -132,7 +145,7 @@ func (cl *Client) Produce(
 			return ErrMaxBuffered
 		}
 		select {
-		case <-cl.producer.waitBuffer:
+		case <-p.waitBuffer:
 		case <-cl.ctx.Done():
 			drainBuffered()
 			return cl.ctx.Err()
@@ -150,18 +163,20 @@ func (cl *Client) Produce(
 }
 
 func (cl *Client) finishRecordPromise(pr promisedRec, err error) {
+	p := &cl.producer
+
 	// We call the promise before finishing the record; this allows users
 	// of Flush to know that all buffered records are completely done
 	// before Flush returns.
 	pr.promise(pr.Record, err)
 
-	buffered := atomic.AddInt64(&cl.producer.bufferedRecords, -1)
+	buffered := atomic.AddInt64(&p.bufferedRecords, -1)
 	if buffered >= cl.cfg.maxBufferedRecords {
-		go func() { cl.producer.waitBuffer <- struct{}{} }()
-	} else if buffered == 0 && atomic.LoadInt32(&cl.producer.flushing) > 0 {
-		cl.producer.notifyMu.Lock()
-		cl.producer.notifyMu.Unlock()
-		cl.producer.notifyCond.Broadcast()
+		go func() { p.waitBuffer <- struct{}{} }()
+	} else if buffered == 0 && atomic.LoadInt32(&p.flushing) > 0 {
+		p.notifyMu.Lock()
+		p.notifyMu.Unlock()
+		p.notifyCond.Broadcast()
 	}
 }
 
@@ -232,12 +247,14 @@ var errReloadProducerID = errors.New("producer id needs reloading")
 // producing only (no transactions, which are more special). After the first
 // load, this clears all buffered unknown topics.
 func (cl *Client) producerID() (int64, int16, error) {
-	id := cl.producer.id.Load().(*producerID)
-	if id.err == errReloadProducerID {
-		cl.producer.idMu.Lock()
-		defer cl.producer.idMu.Unlock()
+	p := &cl.producer
 
-		if id = cl.producer.id.Load().(*producerID); id.err == errReloadProducerID {
+	id := p.id.Load().(*producerID)
+	if id.err == errReloadProducerID {
+		p.idMu.Lock()
+		defer p.idMu.Unlock()
+
+		if id = p.id.Load().(*producerID); id.err == errReloadProducerID {
 
 			if cl.cfg.disableIdempotency {
 				cl.cfg.logger.Log(LogLevelInfo, "skipping producer id initialization because the client was configured to disable idempotent writes")
@@ -246,7 +263,7 @@ func (cl *Client) producerID() (int64, int16, error) {
 					epoch: -1,
 					err:   nil,
 				}
-				cl.producer.id.Store(id)
+				p.id.Store(id)
 
 				// For the idempotent producer, as specified in KIP-360,
 				// if we had an ID, we can bump the epoch locally.
@@ -259,13 +276,13 @@ func (cl *Client) producerID() (int64, int16, error) {
 					epoch: id.epoch + 1,
 					err:   nil,
 				}
-				cl.producer.id.Store(id)
+				p.id.Store(id)
 
 			} else {
 				newID, keep := cl.doInitProducerID(id.id, id.epoch)
 				if keep {
 					id = newID
-					cl.producer.id.Store(id)
+					p.id.Store(id)
 				} else {
 					// If we are not keeping the producer ID,
 					// we will return our old ID but with a
@@ -294,7 +311,7 @@ func (cl *Client) producerID() (int64, int16, error) {
 // 2.5.0+, it is safe to call this if the producer ID can be reset (KIP-360),
 // in EndTransaction.
 func (cl *Client) resetAllProducerSequences() {
-	for _, tp := range cl.loadTopics() {
+	for _, tp := range cl.producer.topics.load() {
 		for _, p := range tp.load().partitions {
 			p.records.mu.Lock()
 			p.records.needSeqReset = true
@@ -304,10 +321,12 @@ func (cl *Client) resetAllProducerSequences() {
 }
 
 func (cl *Client) failProducerID(id int64, epoch int16, err error) {
-	cl.producer.idMu.Lock()
-	defer cl.producer.idMu.Unlock()
+	p := &cl.producer
 
-	current := cl.producer.id.Load().(*producerID)
+	p.idMu.Lock()
+	defer p.idMu.Unlock()
+
+	current := p.id.Load().(*producerID)
 	if current.id != id || current.epoch != epoch {
 		cl.cfg.logger.Log(LogLevelInfo, "ignoring a fail producer id request due to current id being different",
 			"current_id", current.id,
@@ -327,7 +346,7 @@ func (cl *Client) failProducerID(id int64, epoch int16, err error) {
 	//
 	// If this is UnknownProducerID with a txnID, then EndTransaction will
 	// recover us.
-	cl.producer.id.Store(&producerID{
+	p.id.Store(&producerID{
 		id:    id,
 		epoch: epoch,
 		err:   err,
@@ -390,88 +409,67 @@ func (cl *Client) doInitProducerID(lastID int64, lastEpoch int16) (*producerID, 
 // If the topic is not loaded yet, this buffers the record and returns
 // nil, nil.
 func (cl *Client) partitionsForTopicProduce(pr promisedRec) (*topicPartitions, *topicPartitionsData) {
+	p := &cl.producer
 	topic := pr.Topic
 
-	// If the topic exists and there are partitions, then we can simply
-	// return the parts.
-	topics := cl.loadTopics()
+	topics := p.topics.load()
 	parts, exists := topics[topic]
 	if exists {
-		v := parts.load()
-		if len(v.partitions) > 0 {
+		if v := parts.load(); len(v.partitions) > 0 {
 			return parts, v
 		}
 	}
 
-	if !exists {
-		// If the topic does not exist, we check again under the topics
-		// mu.
-		cl.topicsMu.Lock()
-		topics = cl.loadTopics()
-		if _, exists = topics[topic]; !exists {
-			// The topic definitely does not exist; we create it.
-			//
-			// Before we store the new topics and release the topic
-			// mu, we lock unknownTopicsMu. We cannot allow a
-			// concurrent metadata update to see our new topic and
-			// store partitions for it before we are waiting from
-			// the addUnknownTopicRecord func. Otherwise, we would
-			// fall into the wait and never be re-notified.
-			parts = newTopicPartitions()
-			newTopics := cl.cloneTopics()
-			newTopics[topic] = parts
-
-			cl.unknownTopicsMu.Lock() // lock before store and topicsMu release
-			cl.topics.Store(newTopics)
-			cl.topicsMu.Unlock()
-
+	if !exists { // topic did not exist: check again under mu and potentially create it
+		p.topicsMu.Lock()
+		if exists = p.topics.load().hasTopic(topic); !exists { // update exists for below
+			// Before we store the new topic, we lock unknown
+			// topics to prevent a concurrent metadata update
+			// seeing our new topic before we are waiting from the
+			// addUnknownTopicRecord fn. Otherwise, we would wait
+			// and never be re-notified.
+			p.unknownTopicsMu.Lock()
+			p.topics.storeTopics([]string{topic})
+			p.topicsMu.Unlock()
 			cl.addUnknownTopicRecord(pr)
-			cl.unknownTopicsMu.Unlock()
-
+			p.unknownTopicsMu.Unlock()
 		} else {
-			// Topic existed: fall into the logic below.
-			cl.topicsMu.Unlock()
+			p.topicsMu.Unlock() // topic existed: fall into logic below
 		}
 	}
 
 	if exists {
-		// If the topic does exist, either partitions were loaded,
-		// meaning we can just return the load since we are guaranteed
-		// sequential now (if producing to this topic in a single
-		// goroutine), or they were not loaded and we must add our
-		// record in order under unknownTopicsMu.
-		//
-		// See comment in storePartitionsUpdate to the ordering
-		// of our lock then load, or the comment above.
-		cl.unknownTopicsMu.Lock()
-		topics = cl.loadTopics()
-		parts = topics[topic]
-		v := parts.load()
-		if len(v.partitions) > 0 {
-			cl.unknownTopicsMu.Unlock()
-			return parts, v
+		// The topic existed, but maybe has not loaded partitions yet.
+		// We have to lock unknown topics first to ensure ordering
+		// just in case a load has not happened.
+		p.unknownTopicsMu.Lock()
+		defer p.unknownTopicsMu.Unlock()
+
+		topics = p.topics.load()
+		parts, exists = topics[topic]
+		if exists {
+			if v := parts.load(); len(v.partitions) > 0 {
+				return parts, v
+			}
 		}
 		cl.addUnknownTopicRecord(pr)
-		cl.unknownTopicsMu.Unlock()
 	}
 
 	cl.triggerUpdateMetadataNow()
 
-	// Our record is buffered waiting for a metadata update to discover
-	// the topic. We return nil here.
-	return nil, nil
+	return nil, nil // our record is buffered waiting for metadata update; nothing to return
 }
 
 // addUnknownTopicRecord adds a record to a topic whose partitions are
 // currently unknown. This is always called with the unknownTopicsMu held.
 func (cl *Client) addUnknownTopicRecord(pr promisedRec) {
-	unknown := cl.unknownTopics[pr.Topic]
+	unknown := cl.producer.unknownTopics[pr.Topic]
 	if unknown == nil {
 		unknown = &unknownTopicProduces{
 			buffered: make([]promisedRec, 0, 100),
 			wait:     make(chan error, 5),
 		}
-		cl.unknownTopics[pr.Topic] = unknown
+		cl.producer.unknownTopics[pr.Topic] = unknown
 	}
 	unknown.buffered = append(unknown.buffered, pr)
 	if len(unknown.buffered) == 1 {
@@ -523,14 +521,15 @@ func (cl *Client) waitUnknownTopic(
 	// cleared the unknownTopics, and then a new produce went and set a
 	// completely new pointer-to-slice in unknownTopics. We do not want to
 	// fail everything in that new slice.
-	cl.unknownTopicsMu.Lock()
-	nowUnknown := cl.unknownTopics[topic]
+	p := &cl.producer
+	p.unknownTopicsMu.Lock()
+	nowUnknown := p.unknownTopics[topic]
 	if nowUnknown != unknown {
-		cl.unknownTopicsMu.Unlock()
+		p.unknownTopicsMu.Unlock()
 		return
 	}
-	delete(cl.unknownTopics, topic)
-	cl.unknownTopicsMu.Unlock()
+	delete(p.unknownTopics, topic)
+	p.unknownTopicsMu.Unlock()
 
 	for _, pr := range unknown.buffered {
 		cl.finishRecordPromise(pr, err)
@@ -542,10 +541,12 @@ func (cl *Client) waitUnknownTopic(
 //
 // If the context finishes (Done), this returns the context's error.
 func (cl *Client) Flush(ctx context.Context) error {
+	p := &cl.producer
+
 	// Signal to finishRecord that we want to be notified once buffered hits 0.
 	// Also forbid any new producing to start a linger.
-	atomic.AddInt32(&cl.producer.flushing, 1)
-	defer atomic.AddInt32(&cl.producer.flushing, -1)
+	atomic.AddInt32(&p.flushing, 1)
+	defer atomic.AddInt32(&p.flushing, -1)
 
 	cl.cfg.logger.Log(LogLevelInfo, "flushing")
 	defer cl.cfg.logger.Log(LogLevelDebug, "flushed")
@@ -555,7 +556,7 @@ func (cl *Client) Flush(ctx context.Context) error {
 	// must wake anything that could be lingering up, after which all sinks
 	// will loop draining.
 	if cl.cfg.linger > 0 || cl.cfg.manualFlushing {
-		for _, parts := range cl.loadTopics() {
+		for _, parts := range p.topics.load() {
 			for _, part := range parts.load().partitions {
 				part.records.unlingerAndManuallyDrain()
 			}
@@ -565,12 +566,12 @@ func (cl *Client) Flush(ctx context.Context) error {
 	quit := false
 	done := make(chan struct{})
 	go func() {
-		cl.producer.notifyMu.Lock()
-		defer cl.producer.notifyMu.Unlock()
+		p.notifyMu.Lock()
+		defer p.notifyMu.Unlock()
 		defer close(done)
 
-		for !quit && atomic.LoadInt64(&cl.producer.bufferedRecords) > 0 {
-			cl.producer.notifyCond.Wait()
+		for !quit && atomic.LoadInt64(&p.bufferedRecords) > 0 {
+			p.notifyCond.Wait()
 		}
 	}()
 
@@ -578,10 +579,10 @@ func (cl *Client) Flush(ctx context.Context) error {
 	case <-done:
 		return nil
 	case <-ctx.Done():
-		cl.producer.notifyMu.Lock()
+		p.notifyMu.Lock()
 		quit = true
-		cl.producer.notifyMu.Unlock()
-		cl.producer.notifyCond.Broadcast()
+		p.notifyMu.Unlock()
+		p.notifyCond.Broadcast()
 		return ctx.Err()
 	}
 }
@@ -598,14 +599,16 @@ func (cl *Client) Flush(ctx context.Context) error {
 // receiving a response that has a retriable error code. That is, if our
 // request keeps dying.
 func (cl *Client) bumpRepeatedLoadErr(err error) {
-	for _, partitions := range cl.loadTopics() {
+	p := &cl.producer
+
+	for _, partitions := range p.topics.load() {
 		for _, partition := range partitions.load().partitions {
 			partition.records.bumpRepeatedLoadErr(err)
 		}
 	}
-	cl.unknownTopicsMu.Lock()
-	defer cl.unknownTopicsMu.Unlock()
-	for _, unknown := range cl.unknownTopics {
+	p.unknownTopicsMu.Lock()
+	defer p.unknownTopicsMu.Unlock()
+	for _, unknown := range p.unknownTopics {
 		select {
 		case unknown.wait <- err:
 		default:
@@ -615,7 +618,9 @@ func (cl *Client) bumpRepeatedLoadErr(err error) {
 
 // Clears all buffered records in the client with the given error.
 func (cl *Client) failBufferedRecords(err error) {
-	for _, partitions := range cl.loadTopics() {
+	p := &cl.producer
+
+	for _, partitions := range p.topics.load() {
 		for _, partition := range partitions.load().partitions {
 			recBuf := partition.records
 			recBuf.mu.Lock()
@@ -623,10 +628,10 @@ func (cl *Client) failBufferedRecords(err error) {
 			recBuf.mu.Unlock()
 		}
 	}
-	cl.unknownTopicsMu.Lock()
-	defer cl.unknownTopicsMu.Unlock()
-	for topic, unknown := range cl.unknownTopics {
-		delete(cl.unknownTopics, topic)
+	p.unknownTopicsMu.Lock()
+	defer p.unknownTopicsMu.Unlock()
+	for topic, unknown := range p.unknownTopics {
+		delete(p.unknownTopics, topic)
 		close(unknown.wait)
 		for _, pr := range unknown.buffered {
 			cl.finishRecordPromise(pr, err)

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -34,8 +34,7 @@ type producer struct {
 	flushing int32 // >0 if flushing, can Flush many times concurrently
 
 	aborting uint32 // 1 means yes
-	drains   int32  // number of sinks draining
-	issues   int32  // number of in flight produce requests
+	workers  int32  // number of sinks draining / number of in flight produce requests
 
 	idMu       sync.Mutex
 	idVersion  int16
@@ -67,11 +66,8 @@ func (p *producer) init() {
 	p.notifyCond = sync.NewCond(&p.notifyMu)
 }
 
-func (p *producer) incDrains() { atomic.AddInt32(&p.drains, 1) }
-func (p *producer) incIssues() { atomic.AddInt32(&p.issues, 1) }
-
-func (p *producer) decDrains() { p.decAbortNotify(&p.drains) }
-func (p *producer) decIssues() { p.decAbortNotify(&p.issues) }
+func (p *producer) incWorkers() { atomic.AddInt32(&p.workers, 1) }
+func (p *producer) decWorkers() { p.decAbortNotify(&p.workers) }
 
 func (p *producer) decAbortNotify(v *int32) {
 	if atomic.AddInt32(v, -1) != 0 || atomic.LoadUint32(&p.aborting) == 0 {

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -191,7 +191,7 @@ func (s *sink) maybeBackoff() {
 	}
 	defer s.clearBackoff()
 
-	s.cl.triggerUpdateMetadata() // as good a time as any
+	s.cl.triggerUpdateMetadata(false) // as good a time as any
 
 	tries := int(atomic.AddUint32(&s.consecutiveFailures, 1))
 	after := time.NewTimer(s.cl.cfg.retryBackoff(tries))
@@ -854,7 +854,7 @@ func (s *sink) handleRetryBatches(retry seqRecBatches) {
 		needsMetaUpdate = true
 	})
 	if needsMetaUpdate {
-		s.cl.triggerUpdateMetadata()
+		s.cl.triggerUpdateMetadata(false)
 	}
 }
 

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1327,6 +1327,7 @@ func (r *produceRequest) tryAddBatch(produceVersion int32, recBuf *recBuf, batch
 	}
 
 	if recBuf.needSeqReset && recBuf.batches[0] == batch {
+		recBuf.needSeqReset = false
 		recBuf.seq = 0
 		recBuf.batch0Seq = 0
 	}

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -548,7 +548,7 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 		alreadySentToDoneFetch = true
 		s.session.reset()
 
-		s.cl.triggerUpdateMetadata()
+		s.cl.triggerUpdateMetadata() // as good a time as any
 		s.consecutiveFailures++
 		after := time.NewTimer(s.cl.cfg.retryBackoff(s.consecutiveFailures))
 		defer after.Stop()
@@ -652,11 +652,9 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 		s.session.reset()
 	}
 
-	if updateMeta {
+	if updateMeta && !reloadOffsets.loadWithSessionNow(consumerSession) {
 		s.cl.triggerUpdateMetadataNow()
 	}
-
-	reloadOffsets.loadWithSessionNow(consumerSession)
 
 	if len(fetch.Topics) > 0 {
 		buffered = true

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -548,7 +548,7 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 		alreadySentToDoneFetch = true
 		s.session.reset()
 
-		s.cl.triggerUpdateMetadata() // as good a time as any
+		s.cl.triggerUpdateMetadata(false) // as good a time as any
 		s.consecutiveFailures++
 		after := time.NewTimer(s.cl.cfg.retryBackoff(s.consecutiveFailures))
 		defer after.Stop()

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -429,7 +429,7 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 
 	// After the flush, no records are being produced to, and we can set
 	// addedToTxn to false outside of any mutex.
-	for _, parts := range cl.loadTopics() {
+	for _, parts := range cl.producer.topics.load() {
 		for _, part := range parts.load().partitions {
 			if part.records.addedToTxn {
 				part.records.addedToTxn = false


### PR DESCRIPTION
See each individual commit; this contains a series of updates that touch metadata & the consumer & mostly the producer, and by the end we are now able to cancel produce records without breaking sequence numbers.

Also throws in a few sticky perf increases for fun.