### PR TITLE
Improve formatting and fix a typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,11 @@ franz-go supplementary docs
 This directory contains documents for various aspects of the client itself.
 Please refer to the directory tree below for what the pages mean!
 
-[docs](./docs) — you are here
-├── [admin requests](./docs/admin-requests.md) for an overview of how to issue admin requests
-├── [architecture](./docs/architecture.md) for descrbing the packages in franz-go and some internals
-├── [consuming](./docs/consuming.md) for a description of consuming in a group (and a short section on the simple consumer)
-├── [producing](./docs/producing.md) for a description of producing and producing guarantees
-└── [performance](./docs/performance.md) for some notes about performance
+<pre>
+<a href="./">docs</a> — you are here
+├── <a href="./admin-requests.md">admin requests</a> - an overview of how to issue admin requests
+├── <a href="./architecture.md">architecture</a> - a description of the packages in franz-go and some internals
+├── <a href="./consuming.md">consuming</a> - a description of consuming in a group (and a short section on the simple consumer)
+├── <a href="./producing.md">producing</a> - a description of producing and producing guarantees
+└── <a href="./performance.md">performance</a> - some notes about performance
+</pre>


### PR DESCRIPTION
A small improvement to the formatting of the docs README.md.
I believe this is the desired layout based on the original markdown.