### PR TITLE
bench: fix double goroutine invoke for printRate()

### DIFF
--- a/examples/bench/compare/confluent-kafka-go/main.go
+++ b/examples/bench/compare/confluent-kafka-go/main.go
@@ -26,13 +26,11 @@ var (
 )
 
 func printRate() {
-	go func() {
-		for range time.Tick(time.Second) {
-			recs := atomic.SwapInt64(&rateRecs, 0)
-			bytes := atomic.SwapInt64(&rateBytes, 0)
-			fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
-		}
-	}()
+	for range time.Tick(time.Second) {
+		recs := atomic.SwapInt64(&rateRecs, 0)
+		bytes := atomic.SwapInt64(&rateBytes, 0)
+		fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
+	}
 }
 
 func die(msg string, args ...interface{}) {
@@ -99,7 +97,6 @@ func main() {
 
 		if err := c.Subscribe(*topic, nil); err != nil {
 			die("unable to subscribe to topic: %v", err)
-
 		}
 		for {
 			ev := c.Poll(100)

--- a/examples/bench/compare/sarama/main.go
+++ b/examples/bench/compare/sarama/main.go
@@ -34,13 +34,11 @@ var (
 )
 
 func printRate() {
-	go func() {
-		for range time.Tick(time.Second) {
-			recs := atomic.SwapInt64(&rateRecs, 0)
-			bytes := atomic.SwapInt64(&rateBytes, 0)
-			fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
-		}
-	}()
+	for range time.Tick(time.Second) {
+		recs := atomic.SwapInt64(&rateRecs, 0)
+		bytes := atomic.SwapInt64(&rateBytes, 0)
+		fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
+	}
 }
 
 func die(msg string, args ...interface{}) {

--- a/examples/bench/compare/segment/main.go
+++ b/examples/bench/compare/segment/main.go
@@ -39,13 +39,11 @@ var (
 )
 
 func printRate() {
-	go func() {
-		for range time.Tick(time.Second) {
-			recs := atomic.SwapInt64(&rateRecs, 0)
-			bytes := atomic.SwapInt64(&rateBytes, 0)
-			fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
-		}
-	}()
+	for range time.Tick(time.Second) {
+		recs := atomic.SwapInt64(&rateRecs, 0)
+		bytes := atomic.SwapInt64(&rateBytes, 0)
+		fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
+	}
 }
 
 func die(msg string, args ...interface{}) {

--- a/examples/bench/main.go
+++ b/examples/bench/main.go
@@ -49,13 +49,11 @@ var (
 )
 
 func printRate() {
-	go func() {
-		for range time.Tick(time.Second) {
-			recs := atomic.SwapInt64(&rateRecs, 0)
-			bytes := atomic.SwapInt64(&rateBytes, 0)
-			fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
-		}
-	}()
+	for range time.Tick(time.Second) {
+		recs := atomic.SwapInt64(&rateRecs, 0)
+		bytes := atomic.SwapInt64(&rateBytes, 0)
+		fmt.Printf("%0.2f MiB/s; %0.2fk records/s\n", float64(bytes)/(1024*1024), float64(recs)/1000)
+	}
 }
 
 func die(msg string, args ...interface{}) {


### PR DESCRIPTION
`printRate()` is already called with `go printRate()` so remove another `go func() {}()` inside `printRate()` methods.