### PR TITLE
Fix createTopics admin method

### DIFF
--- a/pkg/kadm/topics.go
+++ b/pkg/kadm/topics.go
@@ -75,7 +75,7 @@ func (cl *Client) createTopics(ctx context.Context, dry bool, p int32, rf int16,
 	}
 
 	req := kmsg.NewCreateTopicsRequest()
-	req.ValidateOnly = true
+	req.ValidateOnly = dry
 	for _, t := range topics {
 		rt := kmsg.NewCreateTopicsRequestTopic()
 		rt.Topic = t


### PR DESCRIPTION
Admin client method `createTopics` always sets `req.ValidateOnly` as `true` which causes Topics never created.

This PR fixes the issue by using already existing `dry` parameter.

