### PR TITLE
config: edit comment for FetchMaxWait (about Java setting)

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1034,7 +1034,7 @@ func TransactionTimeout(timeout time.Duration) ProducerOpt {
 // fetch response to hit the minimum number of required bytes before returning,
 // overriding the default 5s.
 //
-// This corresponds to the Java replica.fetch.wait.max.ms setting.
+// This corresponds to the Java fetch.max.wait.ms setting.
 func FetchMaxWait(wait time.Duration) ConsumerOpt {
 	return consumerOpt{func(cfg *cfg) { cfg.maxWait = int32(wait.Milliseconds()) }}
 }


### PR DESCRIPTION
I have found a slight inconsistency.

[fetch.max.wait.ms](https://kafka.apache.org/documentation/#consumerconfigs_fetch.max.wait.ms)