### PR TITLE
Support delegation of offset management before consumer group topic consumption begins

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1319,20 +1319,19 @@ func RequireStableFetchOffsets() GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.requireStable = true }}
 }
 
-// AdjustOffsetsBeforeAssign sets the function to be called when a group is joined
+// AdjustFetchOffsetsFn sets the function to be called when a group is joined
 // after offsets are fetched for those partitions so that a user can adjust them
 // before consumption begins.
 //
-// This function combined with OnPartitionsRevoked should not exceed the
-// rebalance interval. It is possible for the group, immediately after
-// finishing a balance, to re-enter a new balancing session.
+// This function combined should not exceed the rebalance interval. It is possible
+// for the group, immediately after finishing a balance, to re-enter a new balancing
+// session. This function is passed a context that is canceled if the current group
+// session finishes (i.e., after revoking).
 //
-// The AdjustOffsetsBeforeAssign function is passed the client's context, which is
-// only canceled if the client is closed.
-//
-// This function is not called concurrent with any other On callback, and this
-// function is given a new map that the user is free to modify.
-func AdjustOffsetsBeforeAssign(adjustOffsetsBeforeAssign func(context.Context, map[string]map[int32]Offset) (map[string]map[int32]Offset, error)) GroupOpt {
+// If you are resetting the position of the offset, you may want to clear any existing
+// "epoch" with WithEpoch(-1). If the epoch is non-negative, the client performs
+// data loss detection, which may result in errors and unexpected consuming offsets.
+func AdjustFetchOffsetsFn(adjustOffsetsBeforeAssign func(context.Context, map[string]map[int32]Offset) (map[string]map[int32]Offset, error)) GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.adjustOffsetsBeforeAssign = adjustOffsetsBeforeAssign }}
 }
 

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/twmb/franz-go/pkg/kmsg"
 	"math"
 	"math/rand"
 	"net"
@@ -14,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
 )

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1323,14 +1323,14 @@ func RequireStableFetchOffsets() GroupOpt {
 // after offsets are fetched for those partitions so that a user can adjust them
 // before consumption begins.
 //
-// This function combined should not exceed the rebalance interval. It is possible
+// This function should not exceed the rebalance interval. It is possible
 // for the group, immediately after finishing a balance, to re-enter a new balancing
 // session. This function is passed a context that is canceled if the current group
 // session finishes (i.e., after revoking).
 //
 // If you are resetting the position of the offset, you may want to clear any existing
 // "epoch" with WithEpoch(-1). If the epoch is non-negative, the client performs
-// data loss detection, which may result in errors and unexpected consuming offsets.
+// data loss detection, which may result in errors and unexpected behavior.
 func AdjustFetchOffsetsFn(adjustOffsetsBeforeAssign func(context.Context, map[string]map[int32]Offset) (map[string]map[int32]Offset, error)) GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.adjustOffsetsBeforeAssign = adjustOffsetsBeforeAssign }}
 }

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type groupConsumer struct {

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type groupConsumer struct {
@@ -1244,6 +1243,11 @@ start:
 		if !groupTopics.hasTopic(fetchedTopic) {
 			delete(offsets, fetchedTopic)
 			g.cfg.logger.Log(LogLevelWarn, "member was assigned topic that we did not ask for in ConsumeTopics! skipping assigning this topic!", "group", g.cfg.group, "topic", fetchedTopic)
+		}
+	}
+	if g.cfg.adjustOffsetsBeforeAssign != nil {
+		if offsets, err = g.cfg.adjustOffsetsBeforeAssign(ctx, offsets); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
One of the features preventing full adoption of `franz-go` in my application was the ability for consumer groups to swizzle offsets upon assignment of topics & partitions before consumption on those topics begins. In `confluent-kafka-go` this is illustrated via [this example](https://gist.github.com/edenhill/9dfc019b980a5eb3365c84524a1f12b0).

This PR offers a means via callback function (set with a GroupOpt) to intercept those assignments and change them before cursors are created.