### PR TITLE
config: add producer option to configure transactions backoff duration

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -782,6 +782,19 @@ func WithHooks(hooks ...Hook) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.hooks = append(cfg.hooks, hooks...) }}
 }
 
+// ConcurrentTransactionBackoff sets the backoff interval to use during
+// transactional requests in case we encounter CONCURRENT_TRANSACTIONS error,
+// overriding the default 20ms.
+//
+// Sometimes, when a client begins a transaction quickly enough after finishing
+// a previous one, Kafka will return a CONCURRENT_TRANSACTIONS error. Clients
+// are expected to backoff slightly and retry the operation. Lower backoffs may
+// increase load on the brokers, while higher backoffs may increase transaction
+// latency in clients.
+func ConcurrentTransactionBackoff(backoff time.Duration) Opt {
+	return clientOpt{func(cfg *cfg) { cfg.txnBackoff = backoff }}
+}
+
 ////////////////////////////
 // PRODUCER CONFIGURATION //
 ////////////////////////////
@@ -1037,12 +1050,6 @@ func TransactionalID(id string) ProducerOpt {
 // transaction, not when a transaction begins.
 func TransactionTimeout(timeout time.Duration) ProducerOpt {
 	return producerOpt{func(cfg *cfg) { cfg.txnTimeout = timeout }}
-}
-
-// ConcurrentTransactionBackoff sets the backoff interval to use during
-// transactional requests in case we encounter CONCURRENT_TRANSACTIONS error.
-func ConcurrentTransactionBackoff(backoff time.Duration) ProducerOpt {
-	return producerOpt{func(cfg *cfg) { cfg.txnBackoff = backoff }}
 }
 
 ////////////////////////////

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -115,6 +115,7 @@ type cfg struct {
 	linger              time.Duration
 	recordTimeout       time.Duration
 	manualFlushing      bool
+	txnBackoff          time.Duration
 
 	partitioner Partitioner
 
@@ -460,6 +461,7 @@ func defaultCfg() cfg {
 		produceTimeout:      10 * time.Second,
 		recordRetries:       math.MaxInt64,             // effectively unbounded
 		partitioner:         StickyKeyPartitioner(nil), // default to how Kafka partitions
+		txnBackoff:          20 * time.Millisecond,
 
 		//////////////
 		// consumer //
@@ -1035,6 +1037,12 @@ func TransactionalID(id string) ProducerOpt {
 // transaction, not when a transaction begins.
 func TransactionTimeout(timeout time.Duration) ProducerOpt {
 	return producerOpt{func(cfg *cfg) { cfg.txnTimeout = timeout }}
+}
+
+// ConcurrentTransactionBackoff sets the backoff interval to use during
+// transactional requests in case we encounter CONCURRENT_TRANSACTIONS error.
+func ConcurrentTransactionBackoff(backoff time.Duration) ProducerOpt {
+	return producerOpt{func(cfg *cfg) { cfg.txnBackoff = backoff }}
 }
 
 ////////////////////////////


### PR DESCRIPTION
And lower the default from 100ms to 20ms in line with Java Kafka client