### PR TITLE
kgo/config: change default maxPartBytes to 1MB

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -427,7 +427,7 @@ func defaultCfg() cfg {
 		maxWait:        5000,
 		minBytes:       1,
 		maxBytes:       50 << 20,
-		maxPartBytes:   10 << 20,
+		maxPartBytes:   1 << 20,
 		resetOffset:    NewOffset().AtStart(),
 		isolationLevel: 0,
 


### PR DESCRIPTION
This is the same as the Apache Kafka default.  There
are two motivations:
- 10MB is a rather large default: results in a client
  requesting up to a gig of data for a 100 partition
  topic, which hits server side limits and gets clamped.
- Simplify support by having default client request
  sizes not depend on which of the popular clients
  the user is on.