### PR TITLE
Fix kadm Sorted: TopicsSet -> TopicsList function

### DIFF
--- a/pkg/kadm/kadm.go
+++ b/pkg/kadm/kadm.go
@@ -452,6 +452,7 @@ func (s TopicsSet) Sorted() TopicsList {
 			tps.Partitions = append(tps.Partitions, p)
 		}
 		tps.Partitions = int32s(tps.Partitions)
+		l = append(l, tps)
 	}
 	sort.Slice(l, func(i, j int) bool { return l[i].Topic < l[j].Topic })
 	return l


### PR DESCRIPTION
Just a quick fix to one of the kadm convenience representations

Tested with:

```go
	dg, err := adm.DescribeGroups(context.Background(), group)
	ts := dg.AssignedPartitions()

	tl := ts.Sorted()

	fmt.Println(tl[0].Topic)
	fmt.Println(len(ts[tl[0].Topic]), len(tl[0].Partitions))
```

to see if partitions in the output TopicsList match those in the input TopicsSet

As a side note, I used librdkafka previously and recall seeing a 'top-par' type often. In kadm it is equivalent to the Partition Type and it can be a handy abstraction (not always). I wondered if some other kadm structs could embed Partition. Perhaps Offset, ListedOffset, DescribedLogDirPartition or DeleteRecordsResponse? I am happy to submit a suggestion, if it could be useful.