### PR TITLE
Fix sr.URLs handling of https

### DIFF
--- a/pkg/sr/config.go
+++ b/pkg/sr/config.go
@@ -34,9 +34,11 @@ func UserAgent(ua string) Opt {
 func URLs(urls ...string) Opt {
 	return opt{func(cl *Client) {
 		for i, u := range urls {
-			if !strings.HasPrefix(u, "http://") {
-				urls[i] = "http://" + u
+			if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+				continue
 			}
+
+			urls[i] = "http://" + u
 		}
 		cl.urls = urls
 	}}


### PR DESCRIPTION
Currently sr.URLs will prepend http:// onto urls with https:// addresses making it unusable with https based schema registries.