### PR TITLE
Use correct error in debug log for request failure

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -740,7 +740,7 @@ start:
 						"tries", tries,
 						"backoff", backoff,
 						"request_error", err,
-						"response_error", err,
+						"response_error", retryErr,
 					)
 					if r.cl.waitTries(ctx, backoff) {
 						next, nextErr = r.br()


### PR DESCRIPTION
It was using plain `err` twice and never logging the `retryErr`.