### PR TITLE
examples: fixed typo

### DIFF
--- a/examples/goroutine_per_partition_consuming/autocommit_marks/main.go
+++ b/examples/goroutine_per_partition_consuming/autocommit_marks/main.go
@@ -124,7 +124,7 @@ func main() {
 		kgo.ConsumerGroup(*group),
 		kgo.ConsumeTopics(*topic),
 		kgo.OnPartitionsAssigned(s.assigned),
-		kgo.OnPartitionsRevoked(s.lost),
+		kgo.OnPartitionsRevoked(s.revoked),
 		kgo.OnPartitionsLost(s.lost),
 		kgo.AutoCommitMarks(),
 		kgo.BlockRebalanceOnPoll(),


### PR DESCRIPTION
I think I found a typo in the example.