### PR TITLE
Add Context to Record

### DIFF
--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -365,7 +365,7 @@ func (cl *Client) produce(
 	if ctx == nil {
 		ctx = context.Background()
 	} else {
-		r.Ctx = ctx
+		r.ctx = ctx
 	}
 	if promise == nil {
 		promise = noPromise

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -365,7 +365,7 @@ func (cl *Client) produce(
 	if ctx == nil {
 		ctx = context.Background()
 	} else {
-		r.ctx = ctx
+		r.Context = ctx
 	}
 	if promise == nil {
 		promise = noPromise

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -364,6 +364,8 @@ func (cl *Client) produce(
 ) {
 	if ctx == nil {
 		ctx = context.Background()
+	} else {
+		r.Ctx = ctx
 	}
 	if promise == nil {
 		promise = noPromise

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -68,7 +68,7 @@ func (a RecordAttrs) IsControl() bool {
 
 // Record is a record to write to Kafka.
 type Record struct {
-	// Context is an optional field that can be used to pass contextual information
+	// ctx is an optional field that can be used to pass contextual information
 	// to a record.
 	//
 	// This is useful when you want to propagate span data from tracing libraries.
@@ -146,12 +146,16 @@ type Record struct {
 	Offset int64
 }
 
-// SetContext sets the Context on the Record.
-// It can be used to enrich records.
-func (r *Record) SetContext(ctx context.Context) {
+// WithContext enriches the Record with a Context.
+func (r *Record) WithContext(ctx context.Context) *Record {
+	if ctx == nil {
+		panic("nil context")
+	}
 	r.ctx = ctx
+	return r
 }
 
+// Context returns the Records context.
 func (r *Record) Context() context.Context {
 	if r.ctx != nil {
 		return r.ctx

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -151,8 +151,10 @@ func (r *Record) WithContext(ctx context.Context) *Record {
 	if ctx == nil {
 		panic("nil context")
 	}
-	r.ctx = ctx
-	return r
+	r2 := new(Record)
+	*r2 = *r
+	r2.ctx = ctx
+	return r2
 }
 
 // Context returns the Records context.

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -1,6 +1,7 @@
 package kgo
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"time"
@@ -67,6 +68,12 @@ func (a RecordAttrs) IsControl() bool {
 
 // Record is a record to write to Kafka.
 type Record struct {
+	// Ctx is an optional field that can be used to pass contextual information
+	// to a record.
+	//
+	// This is useful when you want to propagate span data from tracing libraries.
+	Ctx context.Context
+
 	// Key is an optional field that can be used for partition assignment.
 	//
 	// This is generally used with a hash partitioner to cause all records

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -68,11 +68,11 @@ func (a RecordAttrs) IsControl() bool {
 
 // Record is a record to write to Kafka.
 type Record struct {
-	// Ctx is an optional field that can be used to pass contextual information
+	// Context is an optional field that can be used to pass contextual information
 	// to a record.
 	//
 	// This is useful when you want to propagate span data from tracing libraries.
-	Ctx context.Context
+	ctx context.Context
 
 	// Key is an optional field that can be used for partition assignment.
 	//
@@ -144,6 +144,19 @@ type Record struct {
 	// the offset used in the produce request and does not mirror the
 	// offset actually stored within Kafka.
 	Offset int64
+}
+
+// SetContext sets the Context on the Record.
+// It can be used to enrich records.
+func (r *Record) SetContext(ctx context.Context) {
+	r.ctx = ctx
+}
+
+func (r *Record) Context() context.Context {
+	if r.ctx != nil {
+		return r.ctx
+	}
+	return context.Background()
 }
 
 // When buffering records, we calculate the length and tsDelta ahead of time

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -68,11 +68,12 @@ func (a RecordAttrs) IsControl() bool {
 
 // Record is a record to write to Kafka.
 type Record struct {
-	// ctx is an optional field that can be used to pass contextual information
-	// to a record.
+	// Context is an optional field that is used for enriching records.
 	//
-	// This is useful when you want to propagate span data from tracing libraries.
-	ctx context.Context
+	// This is set in the produce call. It can be used to propagate record
+	// enrichment across producer hooks. It can also be set in a consumer hook
+	// to propagate record enrichment to consumer clients.
+	Context context.Context
 
 	// Key is an optional field that can be used for partition assignment.
 	//
@@ -144,25 +145,6 @@ type Record struct {
 	// the offset used in the produce request and does not mirror the
 	// offset actually stored within Kafka.
 	Offset int64
-}
-
-// WithContext enriches the Record with a Context.
-func (r *Record) WithContext(ctx context.Context) *Record {
-	if ctx == nil {
-		panic("nil context")
-	}
-	r2 := new(Record)
-	*r2 = *r
-	r2.ctx = ctx
-	return r2
-}
-
-// Context returns the Records context.
-func (r *Record) Context() context.Context {
-	if r.ctx != nil {
-		return r.ctx
-	}
-	return context.Background()
 }
 
 // When buffering records, we calculate the length and tsDelta ahead of time


### PR DESCRIPTION
In this pull request, we add a `Context` to the `Record` type. Adding the context provides the ability to enrich the record with data. Our use-case is observing requests/events as they propagate through Kafka and the rest our distributed environment, aka the "distributed tracing" pattern[1].

The following snippet demonstrates how an upstream process propagates its context to franz-go. In this example, we would like to start tracing HTTP requests when using an HTTP server. The HTTP request context includes tracing data. This context is passed to the Kafka producer. We made an update to produce that checks for context and enriches the Kafka record. From there, a hook can reference the context and continue tracing the request.

```
func fooHandler(w http.ResponseWriter, req *http.Request, cl *kgo.Client) {
  ctx := req.Context() // Context here has tracing data
  span := trace.SpanFromContext(ctx)
  span.SetName("fooHandler")
  defer span.End()

  record := &kgo.Record{Topic: "my-topic", Value: []byte("foo")}
  var wg sync.WaitGroup
  wg.Add(1)

  cl.Produce(ctx, record, func(_ *kgo.Record, err error) {
   defer wg.Done()
   if err != nil {
     fmt.Printf("record had a produce error: %v\n", err)
     span := trace.SpanFromContext(ctx)
     span.SetStatus(codes.Error, err.Error())
     span.RecordError(err)
     ... 
   }
  })

  wg.Wait()

 ...
}
```

Other libraries use the pattern of adding a context to entities such as HTTP[2]. Having the context on the record allows for instrumenting code via existing hooks. We demonstrate a POC of instrumentation in PR#200[3].


Links:
[1] https://microservices.io/patterns/observability/distributed-tracing.html
[2] https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/net/http/request.go;l=355-363
[3] https://github.com/twmb/franz-go/pull/200

CC: @tobiasbrodersen @brunsgaard

@twmb, what are your thoughts on this proposal? 