### PR TITLE
chore: upgrade go to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go
 
-go 1.15
+go 1.16
 
 require (
 	github.com/klauspost/compress v1.15.9

--- a/pkg/sasl/kerberos/go.mod
+++ b/pkg/sasl/kerberos/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/pkg/sasl/kerberos
 
-go 1.15
+go 1.16
 
 require (
 	github.com/jcmturner/gokrb5/v8 v8.4.3

--- a/pkg/sr/go.mod
+++ b/pkg/sr/go.mod
@@ -1,3 +1,3 @@
 module github.com/twmb/franz-go/pkg/sr
 
-go 1.15
+go 1.16


### PR DESCRIPTION
Some packages are using go 1.16 and another usine 1.15.
This PR will update all `go 1.15` to `go 1.16`.
