### PR TITLE
Fix integration test action

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -14,7 +14,7 @@ jobs:
   golangci:
     if: github.repository == 'twmb/franz-go'
     runs-on: ubuntu-latest
-    name: 'golangci-lint on amd64'
+    name: "golangci-lint on amd64"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -28,7 +28,7 @@ jobs:
     if: github.repository == 'twmb/franz-go'
     needs: golangci
     runs-on: ubuntu-latest
-    name: 'vet on arm'
+    name: "vet on arm"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,31 +57,34 @@ jobs:
             echo "staticcheck ./..."
             staticcheck -checks 'all,-ST1003,-SA1012,-ST1016,-SA1019,-SA2001' ./... # actually contains atomicalign check
 
-# TODO: fix
-#  integration-test:
-#    if: github.repository == 'twmb/franz-go'
-#    needs: golangci
-#    runs-on: ubuntu-latest
-#    name: 'integration test kafka'
-#    container: golang:1.19.2
-#    services:
-#      zk:
-#        image: bitnami/zookeeper:latest
-#        ports:
-#          - 2181:2181
-#        env:
-#          ALLOW_ANONYMOUS_LOGIN: yes
-#      kafka:
-#        image: bitnami/kafka:latest
-#        ports:
-#          - 9092:9092
-#        env:
-#          ALLOW_PLAINTEXT_LISTENER: yes
-#          KAFKA_CFG_ZOOKEEPER_CONNECT: zk:2181
-#    steps:
-#      - uses: actions/checkout@v3
-#      - run: go test ./...
-#        env:
-#          KGO_TEST_RF: 1
-#          KGO_SEEDS: kafka:9092
-#          KGO_TEST_RECORDS: 50000
+  integration-test:
+    if: github.repository == 'twmb/franz-go'
+    needs: golangci
+    runs-on: ubuntu-latest
+    name: "integration test kafka"
+    container: golang:1.19.2
+    services:
+      kafka:
+        image: bitnami/kafka:latest
+        ports:
+          - 9092:9092
+        env:
+          KAFKA_ENABLE_KRAFT: yes
+          KAFKA_CFG_PROCESS_ROLES: controller,broker
+          KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+          # Set this to "PLAINTEXT://127.0.0.1:9092" if you want to run this container on localhost via Docker
+          KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+          KAFKA_CFG_BROKER_ID: 1
+          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_KRAFT_CLUSTER_ID: XkpGZQ27R3eTl3OdTm2LYA # 16 byte base64-encoded UUID
+          # BITNAMI_DEBUG: true # Enable this to get more info on startup failures
+    steps:
+      - uses: actions/checkout@v3
+      - run: go test ./...
+        env:
+          KGO_TEST_RF: 1
+          KGO_SEEDS: kafka:9092
+          KGO_TEST_RECORDS: 50000

--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -37,6 +37,7 @@ func TestGroupETL(t *testing.T) {
 
 	go func() {
 		cl, _ := NewClient(
+			getSeedBrokers(),
 			WithLogger(BasicLogger(os.Stderr, testLogLevel, nil)),
 			MaxBufferedRecords(10000),
 		)
@@ -116,6 +117,7 @@ func (c *testConsumer) etl(etlsBeforeQuit int) {
 	netls := 0 // for if etlsBeforeQuit is non-negative
 
 	opts := []Opt{
+		getSeedBrokers(),
 		WithLogger(testLogger()),
 		ConsumerGroup(c.group),
 		ConsumeTopics(c.consumeFrom),

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -25,12 +25,8 @@ var (
 )
 
 func init() {
-	seeds := os.Getenv("KGO_SEEDS")
-	if seeds == "" {
-		seeds = "127.0.0.1:9092"
-	}
 	var err error
-	adm, err = NewClient(SeedBrokers(strings.Split(seeds, ",")...))
+	adm, err = NewClient(getSeedBrokers())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create admin client: %v", err))
 	}
@@ -41,6 +37,14 @@ func init() {
 	if n, _ := strconv.Atoi(os.Getenv("KGO_TEST_RECORDS")); n > 0 {
 		testRecordLimit = n
 	}
+}
+
+func getSeedBrokers() Opt {
+	seeds := os.Getenv("KGO_SEEDS")
+	if seeds == "" {
+		seeds = "127.0.0.1:9092"
+	}
+	return SeedBrokers(strings.Split(seeds, ",")...)
 }
 
 var loggerNum int64

--- a/pkg/kgo/txn_test.go
+++ b/pkg/kgo/txn_test.go
@@ -28,6 +28,7 @@ func TestTxnEtl(t *testing.T) {
 
 	go func() {
 		cl, err := NewClient(
+			getSeedBrokers(),
 			WithLogger(BasicLogger(os.Stderr, testLogLevel, nil)),
 			TransactionalID("p"+randsha()),
 			TransactionTimeout(2*time.Minute),
@@ -135,6 +136,7 @@ func (c *testConsumer) goTransact(txnsBeforeQuit int) {
 func (c *testConsumer) transact(txnsBeforeQuit int) {
 	defer c.wg.Done()
 	txnSess, _ := NewGroupTransactSession(
+		getSeedBrokers(),
 		TransactionalID(randsha()),
 		TransactionTimeout(2*time.Minute),
 		WithLogger(testLogger()),


### PR DESCRIPTION
Hey @twmb, following up on #218, I think this should do the trick using the `bitnami/kafka` container in Zookeeperless mode. I had to adjust the tests a bit so the `KGO_SEEDS` env var is read by each test which needs to connect to Kafka.

I also tried to use Redpanda, but there are some issues with it. Could you please let me know how you got the tests to pass against it? It may just be that I'm not configuring it correctly (maybe it doesn't like the fact that I'm running it as a single node?), but my Kafka knowledge is too limited to troubleshoot it. Here's what I tried:

```shell
> docker run --rm -p9092:9092 docker.vectorized.io/vectorized/redpanda:latest start --default-log-level=debug --smp 1 --reserve-memory 0M --overprovisioned --set redpanda.enable_transactions=true --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr 127.0.0.1:9092
> # Wait for container to start
> KGO_TEST_RF=1 KGO_TEST_RECORDS=50000 go test -v -count 1 ./...
```

I pulled the current `latest` tag of the Redpanda container (`sha256:84c8cd98ed7a50e4f378af55600c92c4fb097afab4ec164c3ded9b0e884754c4`).

I guess this log entry might be relevant: [ERROR] fatal InitProducerID error, failing all buffered records; broker: 1, err: INVALID_PRODUCER_EPOCH: Producer attempted an operation with an old epoch.

Here are the full logs:

[redpanda.log](https://github.com/twmb/franz-go/files/9793352/redpanda.log)
[test.log](https://github.com/twmb/franz-go/files/9793354/test.log)
