### PR TITLE
Fix Redpanda tests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -100,6 +100,8 @@ jobs:
         image: vectorized/redpanda-nightly:latest
         ports:
           - 9092:9092
+        env:
+          REDPANDA_ADVERTISE_KAFKA_ADDRESS: redpanda:9092
     steps:
       - uses: actions/checkout@v3
       - run: go test ./...


### PR DESCRIPTION
Hey @twmb, thanks for [the nudge](https://github.com/twmb/franz-go/pull/223#issuecomment-1284886598) :) I think this might just suffice.

Technically, the Docker command should look smth like this, I think (or at least that's what I've been cargo-culting for a while): `docker run --rm -p9092:9092 docker.vectorized.io/vectorized/redpanda:latest start --default-log-level=debug --smp 1 --reserve-memory 0M --overprovisioned --set redpanda.enable_transactions=true --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr redpanda:9092`, but GitHub Actions [doesn't allow](https://stackoverflow.com/questions/60849745/how-can-i-run-a-command-in-github-action-service-containers) users to overwrite the Docker `CMD` yet, which is a very weird omission IMHO.