### PR TITLE
kgo/kadm: add support for WriteTxnMarkers

### DIFF
--- a/pkg/kadm/configs.go
+++ b/pkg/kadm/configs.go
@@ -143,7 +143,7 @@ func (cl *Client) describeConfigs(
 				}
 				rc.Configs = append(rc.Configs, rcv)
 			}
-			configs = append(configs, rc)
+			configs = append(configs, rc) // we are not storing in a map, no existence-check possible
 		}
 		return nil
 	})
@@ -315,7 +315,7 @@ func (cl *Client) alterConfigs(
 	return rs, shardErrEach(req, shards, func(kr kmsg.Response) error {
 		resp := kr.(*kmsg.IncrementalAlterConfigsResponse)
 		for _, r := range resp.Resources {
-			rs = append(rs, AlterConfigsResponse{
+			rs = append(rs, AlterConfigsResponse{ // we are not storing in a map, no existence check possible
 				Name: r.ResourceName,
 				Err:  kerr.ErrorForCode(r.ErrorCode),
 			})

--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -223,7 +223,7 @@ func (cl *Client) ListGroups(ctx context.Context, filterStates ...string) (Liste
 			return err
 		}
 		for _, g := range resp.Groups {
-			list[g.Group] = ListedGroup{
+			list[g.Group] = ListedGroup{ // group only lives on one broker, no need to exist-check
 				Coordinator:  b.NodeID,
 				Group:        g.Group,
 				ProtocolType: g.ProtocolType,
@@ -327,7 +327,7 @@ func (cl *Client) DescribeGroups(ctx context.Context, groups ...string) (Describ
 				}
 				return g.Members[i].MemberID < g.Members[j].MemberID
 			})
-			described[g.Group] = g
+			described[g.Group] = g // group only lives on one broker, no need to exist-check
 		}
 		return nil
 	})
@@ -405,7 +405,7 @@ func (cl *Client) DeleteGroups(ctx context.Context, groups ...string) (DeleteGro
 	return rs, shardErrEach(req, shards, func(kr kmsg.Response) error {
 		resp := kr.(*kmsg.DeleteGroupsResponse)
 		for _, g := range resp.Groups {
-			rs[g.Group] = DeleteGroupResponse{
+			rs[g.Group] = DeleteGroupResponse{ // group is always on one broker, no need to exist-check
 				Group: g.Group,
 				Err:   kerr.ErrorForCode(g.ErrorCode),
 			}
@@ -990,7 +990,7 @@ func (cl *Client) FetchManyOffsets(ctx context.Context, groups ...string) FetchO
 				Fetched: rs,
 				Err:     kerr.ErrorForCode(g.ErrorCode),
 			}
-			fetched[g.Group] = fg
+			fetched[g.Group] = fg // group coordinator owns all of a group, no need to check existence
 			for _, t := range g.Topics {
 				rt := make(map[int32]OffsetResponse)
 				rs[t.Topic] = rt

--- a/pkg/kadm/logdirs.go
+++ b/pkg/kadm/logdirs.go
@@ -171,7 +171,7 @@ func (cl *Client) AlterAllReplicaLogDirs(ctx context.Context, alter AlterReplica
 	resps := make(AlterAllReplicaLogDirsResponses)
 	return resps, shardErrEachBroker(req, shards, func(b BrokerDetail, kr kmsg.Response) error {
 		resp := kr.(*kmsg.AlterReplicaLogDirsResponse)
-		resps[b.NodeID] = newAlterLogDirsResp(b.NodeID, alter, resp)
+		resps[b.NodeID] = newAlterLogDirsResp(b.NodeID, alter, resp) // one node ID, no need to unique-check
 		return nil
 	})
 }
@@ -566,7 +566,7 @@ func (cl *Client) DescribeAllLogDirs(ctx context.Context, s TopicsSet) (Describe
 		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
 			return err
 		}
-		resps[b.NodeID] = newDescribeLogDirsResp(b.NodeID, resp)
+		resps[b.NodeID] = newDescribeLogDirsResp(b.NodeID, resp) // one node ID, no need to unique-check
 		return nil
 	})
 }

--- a/pkg/kadm/txn.go
+++ b/pkg/kadm/txn.go
@@ -374,7 +374,7 @@ func (ds DescribedTransactions) TransactionalIDs() []string {
 // DescribeTransactions describes either all transactional IDs specified, or
 // all transactional IDs in the cluster if none are specified.
 //
-// This may return *ShardErrors.
+// This may return *ShardErrors or *AuthError.
 //
 // If no transactional IDs are specified and this method first lists
 // transactional IDs, and listing IDs returns a *ShardErrors, this function
@@ -487,7 +487,7 @@ func (ls ListedTransactions) TransactionalIDs() []string {
 // to. Producer IDs can be specified to filter for transactions from the given
 // producer.
 //
-// This may return *ShardErrors.
+// This may return *ShardErrors or *AuthError.
 func (cl *Client) ListTransactions(ctx context.Context, producerIDs []int64, filterStates []string) (ListedTransactions, error) {
 	req := kmsg.NewPtrListTransactionsRequest()
 	req.ProducerIDFilters = producerIDs

--- a/pkg/kadm/txn.go
+++ b/pkg/kadm/txn.go
@@ -232,6 +232,14 @@ func (cl *Client) DescribeProducers(ctx context.Context, s TopicsSet) (Described
 			return nil, err
 		}
 		s = m.Topics.TopicsSet()
+	} else if e := s.EmptyTopics(); len(e) > 0 {
+		m, err := cl.Metadata(ctx, e...)
+		if err != nil {
+			return nil, err
+		}
+		for t, ps := range m.Topics.TopicsSet() {
+			s[t] = ps
+		}
 	}
 
 	req := kmsg.NewPtrDescribeProducersRequest()

--- a/pkg/kadm/txn.go
+++ b/pkg/kadm/txn.go
@@ -23,6 +23,49 @@ type DescribedProducer struct {
 	CurrentTxnStartOffset int64  // CurrentTxnStartOffset is the first offset in the transaction.
 }
 
+// Less returns whether the left described producer is less than the right,
+// in order of:
+//
+//   - Topic
+//   - Partition
+//   - ProducerID
+//   - ProducerEpoch
+//   - LastTimestamp
+//   - LastSequence
+func (l *DescribedProducer) Less(r *DescribedProducer) bool {
+	if l.Topic < r.Topic {
+		return true
+	}
+	if l.Topic > r.Topic {
+		return false
+	}
+	if l.Partition < r.Partition {
+		return true
+	}
+	if l.Partition > r.Partition {
+		return false
+	}
+	if l.ProducerID < r.ProducerID {
+		return true
+	}
+	if l.ProducerID > r.ProducerID {
+		return false
+	}
+	if l.ProducerEpoch < r.ProducerEpoch {
+		return true
+	}
+	if l.ProducerEpoch > r.ProducerEpoch {
+		return false
+	}
+	if l.LastTimestamp < r.LastTimestamp {
+		return true
+	}
+	if l.LastTimestamp > r.LastTimestamp {
+		return false
+	}
+	return l.LastSequence < r.LastSequence
+}
+
 // DescribedProducers maps producer IDs to the full described producer.
 type DescribedProducers map[int64]DescribedProducer
 


### PR DESCRIPTION
This will be released in a patch release for franz-go, and a minor release for kadm. The patch is because this always should have been supported and it's a minor internal niche behavior change. The minor is because in kadm, this is new API surface (but also in kadm, this includes a bugfix for DeleteRecords and two other really new APIs).