### PR TITLE
kadm: bump franz-go to 1.10.1

### DIFF
--- a/pkg/kadm/go.mod
+++ b/pkg/kadm/go.mod
@@ -3,7 +3,7 @@ module github.com/twmb/franz-go/pkg/kadm
 go 1.17
 
 require (
-	github.com/twmb/franz-go v1.10.0
+	github.com/twmb/franz-go v1.10.1
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0
 	golang.org/x/crypto v0.3.0
 )

--- a/pkg/kadm/go.sum
+++ b/pkg/kadm/go.sum
@@ -4,8 +4,8 @@ github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrD
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
 github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/twmb/franz-go v1.10.0 h1:g/mW/kTsaF6jmQiFHcTn2kHoT/0f+N6KRtedefLk9xg=
-github.com/twmb/franz-go v1.10.0/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
+github.com/twmb/franz-go v1.10.1 h1:dtSg4V6YIoDIHCBVT+AWNsqcP/PG6S1Gg6RQ5h0tWPM=
+github.com/twmb/franz-go v1.10.1/go.mod h1:PMze0jNfNghhih2XHbkmTFykbMF5sJqmNJB31DOOzro=
 github.com/twmb/franz-go/pkg/kmsg v1.2.0 h1:jYWh2qFw5lDbNv5Gvu/sMKagzICxuA5L6m1W2Oe7XUo=
 github.com/twmb/franz-go/pkg/kmsg v1.2.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
required for WriteTxnMarkers sharding