### PR TITLE
Fix isNetClosedErr

### DIFF
--- a/pkg/kgo/go115.go
+++ b/pkg/kgo/go115.go
@@ -1,5 +1,5 @@
-//go:build go1.15
-// +build go1.15
+//go:build !go1.16
+// +build !go1.16
 
 package kgo
 

--- a/pkg/kgo/go116.go
+++ b/pkg/kgo/go116.go
@@ -1,5 +1,5 @@
-//go:build go1.16 && !go1.15
-// +build go1.16,!go1.15
+//go:build go1.16
+// +build go1.16
 
 package kgo
 


### PR DESCRIPTION
I believe that d5e80b38ca2be44853b776286c6f3c1c4704c403 reversed its build constraints. It looks like the intent is to use `error.Is` from Go 1.16 onward, and to use `strings.Contains` in Go 1.15.

However, per https://pkg.go.dev/cmd/go#hdr-Build_constraints , the go1.15 tag is set for all Go versions from Go 1.15 *onward*. That means that go115.go will be used in Go 1.16 and onward, and go116.go will only be used in Go 1.15.

This commit reverses that, so that go115.go (string.Contains) is used in Go 1.15 and go116.go (error.Is) is used in Go 1.16 onward.