### PR TITLE
Use atomic.Bool in Go 1.19+

### DIFF
--- a/pkg/kgo/atomic_maybe_work.go
+++ b/pkg/kgo/atomic_maybe_work.go
@@ -2,27 +2,6 @@ package kgo
 
 import "sync/atomic"
 
-// a helper type for some places
-type atomicBool uint32
-
-func (b *atomicBool) set(v bool) {
-	if v {
-		atomic.StoreUint32((*uint32)(b), 1)
-	} else {
-		atomic.StoreUint32((*uint32)(b), 0)
-	}
-}
-
-func (b *atomicBool) get() bool { return atomic.LoadUint32((*uint32)(b)) == 1 }
-
-func (b *atomicBool) swap(v bool) bool {
-	var swap uint32
-	if v {
-		swap = 1
-	}
-	return atomic.SwapUint32((*uint32)(b), swap) == 1
-}
-
 const (
 	stateUnstarted = iota
 	stateWorking

--- a/pkg/kgo/go118.go
+++ b/pkg/kgo/go118.go
@@ -1,0 +1,26 @@
+//go:build !go1.19
+// +build !go1.19
+
+package kgo
+
+import "sync/atomic"
+
+type atomicBool uint32
+
+func (b *atomicBool) Store(v bool) {
+	if v {
+		atomic.StoreUint32((*uint32)(b), 1)
+	} else {
+		atomic.StoreUint32((*uint32)(b), 0)
+	}
+}
+
+func (b *atomicBool) Load() bool { return atomic.LoadUint32((*uint32)(b)) == 1 }
+
+func (b *atomicBool) Swap(v bool) bool {
+	var swap uint32
+	if v {
+		swap = 1
+	}
+	return atomic.SwapUint32((*uint32)(b), swap) == 1
+}

--- a/pkg/kgo/go119.go
+++ b/pkg/kgo/go119.go
@@ -1,0 +1,10 @@
+//go:build go1.19
+// +build go1.19
+
+package kgo
+
+import "sync/atomic"
+
+type atomicBool struct {
+	atomic.Bool
+}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -158,7 +158,7 @@ func (t *txnReqBuilder) add(rb *recBuf) {
 	if t.txnID == nil {
 		return
 	}
-	if rb.addedToTxn.swap(true) {
+	if rb.addedToTxn.Swap(true) {
 		return
 	}
 	if t.req == nil {
@@ -443,7 +443,7 @@ func (s *sink) doTxnReq(
 // inflight, and that it was not added to the txn and that we need to reset the
 // drain index.
 func (b *recBatch) removeFromTxn() {
-	b.owner.addedToTxn.set(false)
+	b.owner.addedToTxn.Store(false)
 	b.owner.resetBatchDrainIdx()
 	b.decInflight()
 }

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -596,7 +596,7 @@ func (cl *Client) EndAndBeginTransaction(
 	var readd map[string][]int32
 	for topic, parts := range cl.producer.topics.load() {
 		for i, part := range parts.load().partitions {
-			if part.records.addedToTxn.swap(false) {
+			if part.records.addedToTxn.Swap(false) {
 				if how == EndBeginTxnUnsafe {
 					if readd == nil {
 						readd = make(map[string][]int32)
@@ -705,7 +705,7 @@ func (cl *Client) EndAndBeginTransaction(
 
 		for topic, parts := range cl.producer.topics.load() {
 			for i, part := range parts.load().partitions {
-				if part.records.addedToTxn.get() {
+				if part.records.addedToTxn.Load() {
 					readd[topic] = append(readd[topic], int32(i))
 				}
 			}
@@ -836,7 +836,7 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 	// addedToTxn to false outside of any mutex.
 	for _, parts := range cl.producer.topics.load() {
 		for _, part := range parts.load().partitions {
-			anyAdded = part.records.addedToTxn.swap(false) || anyAdded
+			anyAdded = part.records.addedToTxn.Swap(false) || anyAdded
 		}
 	}
 


### PR DESCRIPTION
Instead of using our own atomicBool type, let's use the standard atomic.Bool type in versions of Go that contain it.