### PR TITLE
Use a named enum for compression codecs

### DIFF
--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -97,8 +97,8 @@ func TestCompressDecompress(t *testing.T) {
 
 func BenchmarkCompress(b *testing.B) {
 	in := bytes.Repeat([]byte("abcdefghijklmno pqrs tuvwxy   z"), 100)
-	for _, codec := range []int8{1, 2, 3, 4} {
-		c, _ := newCompressor(CompressionCodec{codec: codec}) // snappy
+	for _, codec := range []codecType{codecGzip, codecSnappy, codecLZ4, codecZstd} {
+		c, _ := newCompressor(CompressionCodec{codec: codec})
 		b.Run(fmt.Sprint(codec), func(b *testing.B) {
 			var afterSize int
 			for i := 0; i < b.N; i++ {

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -399,13 +399,13 @@ func BenchmarkAppendBatch(b *testing.B) {
 	buf := make([]byte, 10<<10) // broker's reuse input buffers, so we do so here as well
 	for _, pair := range []struct {
 		name  string
-		codec int8
+		codec codecType
 	}{
-		{"no compression", 0},
-		{"gzip", 1},
-		{"snappy", 2},
-		{"lz4", 3},
-		{"zstd", 4},
+		{"no compression", codecNone},
+		{"gzip", codecGzip},
+		{"snappy", codecSnappy},
+		{"lz4", codecLZ4},
+		{"zstd", codecZstd},
 	} {
 		b.Run(pair.name, func(b *testing.B) {
 			compressor, _ := newCompressor(CompressionCodec{codec: pair.codec})

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -2158,7 +2158,7 @@ func (b seqRecBatch) appendToAsMessageSet(dst []byte, version uint8, compressor 
 			dst = appendMessageTo(
 				dst[:nullableBytesLenAt+4],
 				version,
-				codec,
+				int8(codec),
 				int64(len(b.records)-1),
 				b.firstTimestamp,
 				inner,


### PR DESCRIPTION
Rather than using int literals everywhere.

If we want to be a little more cautious, we could use explicit values for each `codecType` constant rather than just the values implied by `iota` - e.g. `codecGzip = 1`, etc.