### PR TITLE
kadm: bump to go1.19, add First{,E} and Any{,E} helpers

### DIFF
--- a/pkg/kadm/acls.go
+++ b/pkg/kadm/acls.go
@@ -979,7 +979,7 @@ func (cl *Client) DescribeACLs(ctx context.Context, b *ACLBuilder) (DescribeACLs
 	return rs, nil
 }
 
-var any = []string{"any"}
+var sliceAny = []string{"any"}
 
 func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.DescribeACLsRequest, error) {
 	if err := b.ValidateFilter(); err != nil {
@@ -1026,7 +1026,7 @@ func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.De
 		{kmsg.ACLResourceTypeDelegationToken, b.tokens, b.anyToken},
 	} {
 		if typeNames.any {
-			typeNames.names = any
+			typeNames.names = sliceAny
 		}
 		for _, name := range typeNames.names {
 			for _, op := range b.ops {
@@ -1060,10 +1060,10 @@ func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.De
 					},
 				} {
 					if perm.anyPrincipal {
-						perm.principals = any
+						perm.principals = sliceAny
 					}
 					if perm.anyHost {
-						perm.hosts = any
+						perm.hosts = sliceAny
 					}
 					for _, principal := range perm.principals {
 						for _, host := range perm.hosts {

--- a/pkg/kadm/go.mod
+++ b/pkg/kadm/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/pkg/kadm
 
-go 1.17
+go 1.19
 
 require (
 	github.com/twmb/franz-go v1.10.1

--- a/pkg/kadm/kadm_test.go
+++ b/pkg/kadm/kadm_test.go
@@ -1,0 +1,88 @@
+package kadm
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func input[V any](v V) V { return v }
+
+func inputErr[V any](v V, err error) (V, error) { return v, err }
+
+func TestFirst(t *testing.T) {
+	for _, test := range []struct {
+		in     []int
+		inErr  error
+		exp    int
+		expErr bool
+	}{
+		{[]int{3, 4, 5}, nil, 3, false},
+		{[]int{4}, nil, 4, false},
+		{[]int{4}, errors.New("foo"), 4, true},
+		{nil, errors.New("foo"), 0, true},
+	} {
+		got, err := FirstOrErr(inputErr(test.in, test.inErr))
+		gotErr := err != nil
+		if gotErr != test.expErr {
+			t.Errorf("got err? %v, exp err? %v", gotErr, test.expErr)
+		}
+		if !gotErr && !test.expErr {
+			if !reflect.DeepEqual(got, test.exp) {
+				t.Errorf("got %v != exp %v", got, test.exp)
+			}
+		}
+
+		got, exists := First(input(test.in))
+		if len(test.in) == 0 {
+			if exists {
+				t.Error("got exists, expected no")
+			}
+			continue
+		}
+		if !exists {
+			t.Error("got not exists, expected yes")
+		}
+		if !reflect.DeepEqual(got, test.exp) {
+			t.Errorf("got %v != exp %v", got, test.exp)
+		}
+	}
+}
+
+func TestAny(t *testing.T) {
+	for _, test := range []struct {
+		in     map[int]string
+		inErr  error
+		exp    string
+		expErr bool
+	}{
+		{map[int]string{3: "foo"}, nil, "foo", false},
+		{map[int]string{3: "foo"}, errors.New("foo"), "foo", true},
+		{nil, errors.New("foo"), "", true},
+	} {
+		got, err := AnyOrErr(inputErr(test.in, test.inErr))
+		gotErr := err != nil
+		if gotErr != test.expErr {
+			t.Errorf("got err? %v, exp err? %v", gotErr, test.expErr)
+		}
+		if !gotErr && !test.expErr {
+			if !reflect.DeepEqual(got, test.exp) {
+				t.Errorf("got %v != exp %v", got, test.exp)
+			}
+		}
+
+		got, exists := Any(input(test.in))
+		if len(test.in) == 0 {
+			if exists {
+				t.Error("got exists, expected no")
+			}
+			continue
+		}
+		if !exists {
+			t.Error("got not exists, expected yes")
+		}
+		if !reflect.DeepEqual(got, test.exp) {
+			t.Errorf("got %v != exp %v", got, test.exp)
+		}
+	}
+}


### PR DESCRIPTION
This will make it _much_ easier to get the one response a user is interested in.

Requires go1.19