### PR TITLE
remove KIP-866 temporarily

### DIFF
--- a/generate/definitions/04_leader_and_isr
+++ b/generate/definitions/04_leader_and_isr
@@ -31,11 +31,8 @@ LeaderAndISRResponseTopicPartition => not top level, no encoding, flexible v4+
 // Kafka 1.0 introduced version 1. Kafka 2.2 introduced version 2, proposed
 // in KIP-380, which changed the layout of the struct to be more memory
 // efficient. Kafka 2.4.0 introduced version 3 with KIP-455.
-// Kafka 3.4 introduced version 7 with KIP-866.
-LeaderAndISRRequest => key 4, max version 7, flexible v4+
+LeaderAndISRRequest => key 4, max version 6, flexible v4+
   ControllerID: int32
-  // The KRaft controller id, used during migration. See KIP-866.
-  KRaftControllerID: int32(-1) // v7+
   ControllerEpoch: int32
   BrokerEpoch: int64(-1) // v2+
   Type: int8 // v5+

--- a/generate/definitions/05_stop_replica
+++ b/generate/definitions/05_stop_replica
@@ -8,12 +8,9 @@
 //
 // Kafka 2.6 introduced version 3, proposed in KIP-570, reorganizes partitions
 // to be stored and adds the leader epoch and delete partition fields per partition.
-// Kafka 3.4 introduced version 4 with KIP-866.
-StopReplicaRequest => key 5, max version 4, flexible v2+
+StopReplicaRequest => key 5, max version 3, flexible v2+
   ControllerID: int32
   ControllerEpoch: int32
-  // The KRaft controller id, used during migration. See KIP-866.
-  KRaftControllerID: int32(-1) // v4+
   BrokerEpoch: int64(-1) // v1+
   DeletePartitions: bool // v0-v2
   Topics: [=>]

--- a/generate/definitions/06_update_metadata
+++ b/generate/definitions/06_update_metadata
@@ -19,11 +19,8 @@ UpdateMetadataRequestTopicPartition => not top level, no encoding, flexible v6+
 //
 // Kafka 2.2 introduced version 5, proposed in KIP-380, which changed the
 // layout of the struct to be more memory efficient.
-// Kafka 3.4 introduced version 8 with KIP-866.
-UpdateMetadataRequest => key 6, max version 8, flexible v6+
+UpdateMetadataRequest => key 6, max version 7, flexible v6+
   ControllerID: int32
-  // The KRaft controller id, used during migration. See KIP-866.
-  KRaftControllerID: int32 // v8+
   ControllerEpoch: int32
   BrokerEpoch: int64(-1) // v5+
   PartitionStates: [UpdateMetadataRequestTopicPartition] // v0-v4

--- a/generate/definitions/62_broker_registration
+++ b/generate/definitions/62_broker_registration
@@ -1,6 +1,6 @@
 // For KIP-500 / KIP-631, BrokerRegistrationRequest is an internal
 // broker-to-broker only request.
-BrokerRegistrationRequest => key 62, max version 1, flexible v0+
+BrokerRegistrationRequest => key 62, max version 0, flexible v0+
   // The broker ID.
   BrokerID: int32
   // The cluster ID of the broker process.
@@ -27,9 +27,6 @@ BrokerRegistrationRequest => key 62, max version 1, flexible v0+
     MaxSupportedVersion: int16
   // The rack that this broker is in, if any.
   Rack: nullable-string
-  // Set by a ZK broker if the required configurations for ZK migration are
-  // present.
-  IsMigratingZkBroker: bool // v1+
 
 // BrokerRegistrationResponse is a response to a BrokerRegistrationRequest.
 BrokerRegistrationResponse =>

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -7039,17 +7039,11 @@ func NewLeaderAndISRRequestLiveLeader() LeaderAndISRRequestLiveLeader {
 // Kafka 1.0 introduced version 1. Kafka 2.2 introduced version 2, proposed
 // in KIP-380, which changed the layout of the struct to be more memory
 // efficient. Kafka 2.4.0 introduced version 3 with KIP-455.
-// Kafka 3.4 introduced version 7 with KIP-866.
 type LeaderAndISRRequest struct {
 	// Version is the version of this message used with a Kafka broker.
 	Version int16
 
 	ControllerID int32
-
-	// The KRaft controller id, used during migration. See KIP-866.
-	//
-	// This field has a default of -1.
-	KRaftControllerID int32 // v7+
 
 	ControllerEpoch int32
 
@@ -7069,7 +7063,7 @@ type LeaderAndISRRequest struct {
 }
 
 func (*LeaderAndISRRequest) Key() int16                 { return 4 }
-func (*LeaderAndISRRequest) MaxVersion() int16          { return 7 }
+func (*LeaderAndISRRequest) MaxVersion() int16          { return 6 }
 func (v *LeaderAndISRRequest) SetVersion(version int16) { v.Version = version }
 func (v *LeaderAndISRRequest) GetVersion() int16        { return v.Version }
 func (v *LeaderAndISRRequest) IsFlexible() bool         { return v.Version >= 4 }
@@ -7093,10 +7087,6 @@ func (v *LeaderAndISRRequest) AppendTo(dst []byte) []byte {
 	_ = isFlexible
 	{
 		v := v.ControllerID
-		dst = kbin.AppendInt32(dst, v)
-	}
-	if version >= 7 {
-		v := v.KRaftControllerID
 		dst = kbin.AppendInt32(dst, v)
 	}
 	{
@@ -7393,10 +7383,6 @@ func (v *LeaderAndISRRequest) readFrom(src []byte, unsafe bool) error {
 	{
 		v := b.Int32()
 		s.ControllerID = v
-	}
-	if version >= 7 {
-		v := b.Int32()
-		s.KRaftControllerID = v
 	}
 	{
 		v := b.Int32()
@@ -7855,7 +7841,6 @@ func NewPtrLeaderAndISRRequest() *LeaderAndISRRequest {
 // Default sets any default fields. Calling this allows for future compatibility
 // if new fields are added to LeaderAndISRRequest.
 func (v *LeaderAndISRRequest) Default() {
-	v.KRaftControllerID = -1
 	v.BrokerEpoch = -1
 }
 
@@ -7905,7 +7890,7 @@ type LeaderAndISRResponse struct {
 }
 
 func (*LeaderAndISRResponse) Key() int16                 { return 4 }
-func (*LeaderAndISRResponse) MaxVersion() int16          { return 7 }
+func (*LeaderAndISRResponse) MaxVersion() int16          { return 6 }
 func (v *LeaderAndISRResponse) SetVersion(version int16) { v.Version = version }
 func (v *LeaderAndISRResponse) GetVersion() int16        { return v.Version }
 func (v *LeaderAndISRResponse) IsFlexible() bool         { return v.Version >= 4 }
@@ -8252,7 +8237,6 @@ func NewStopReplicaRequestTopic() StopReplicaRequestTopic {
 //
 // Kafka 2.6 introduced version 3, proposed in KIP-570, reorganizes partitions
 // to be stored and adds the leader epoch and delete partition fields per partition.
-// Kafka 3.4 introduced version 4 with KIP-866.
 type StopReplicaRequest struct {
 	// Version is the version of this message used with a Kafka broker.
 	Version int16
@@ -8260,11 +8244,6 @@ type StopReplicaRequest struct {
 	ControllerID int32
 
 	ControllerEpoch int32
-
-	// The KRaft controller id, used during migration. See KIP-866.
-	//
-	// This field has a default of -1.
-	KRaftControllerID int32 // v4+
 
 	// This field has a default of -1.
 	BrokerEpoch int64 // v1+
@@ -8278,7 +8257,7 @@ type StopReplicaRequest struct {
 }
 
 func (*StopReplicaRequest) Key() int16                 { return 5 }
-func (*StopReplicaRequest) MaxVersion() int16          { return 4 }
+func (*StopReplicaRequest) MaxVersion() int16          { return 3 }
 func (v *StopReplicaRequest) SetVersion(version int16) { v.Version = version }
 func (v *StopReplicaRequest) GetVersion() int16        { return v.Version }
 func (v *StopReplicaRequest) IsFlexible() bool         { return v.Version >= 2 }
@@ -8304,10 +8283,6 @@ func (v *StopReplicaRequest) AppendTo(dst []byte) []byte {
 	}
 	{
 		v := v.ControllerEpoch
-		dst = kbin.AppendInt32(dst, v)
-	}
-	if version >= 4 {
-		v := v.KRaftControllerID
 		dst = kbin.AppendInt32(dst, v)
 	}
 	if version >= 1 {
@@ -8414,10 +8389,6 @@ func (v *StopReplicaRequest) readFrom(src []byte, unsafe bool) error {
 	{
 		v := b.Int32()
 		s.ControllerEpoch = v
-	}
-	if version >= 4 {
-		v := b.Int32()
-		s.KRaftControllerID = v
 	}
 	if version >= 1 {
 		v := b.Int64()
@@ -8554,7 +8525,6 @@ func NewPtrStopReplicaRequest() *StopReplicaRequest {
 // Default sets any default fields. Calling this allows for future compatibility
 // if new fields are added to StopReplicaRequest.
 func (v *StopReplicaRequest) Default() {
-	v.KRaftControllerID = -1
 	v.BrokerEpoch = -1
 }
 
@@ -8605,7 +8575,7 @@ type StopReplicaResponse struct {
 }
 
 func (*StopReplicaResponse) Key() int16                 { return 5 }
-func (*StopReplicaResponse) MaxVersion() int16          { return 4 }
+func (*StopReplicaResponse) MaxVersion() int16          { return 3 }
 func (v *StopReplicaResponse) SetVersion(version int16) { v.Version = version }
 func (v *StopReplicaResponse) GetVersion() int16        { return v.Version }
 func (v *StopReplicaResponse) IsFlexible() bool         { return v.Version >= 2 }
@@ -8881,15 +8851,11 @@ func NewUpdateMetadataRequestLiveBroker() UpdateMetadataRequestLiveBroker {
 //
 // Kafka 2.2 introduced version 5, proposed in KIP-380, which changed the
 // layout of the struct to be more memory efficient.
-// Kafka 3.4 introduced version 8 with KIP-866.
 type UpdateMetadataRequest struct {
 	// Version is the version of this message used with a Kafka broker.
 	Version int16
 
 	ControllerID int32
-
-	// The KRaft controller id, used during migration. See KIP-866.
-	KRaftControllerID int32 // v8+
 
 	ControllerEpoch int32
 
@@ -8907,7 +8873,7 @@ type UpdateMetadataRequest struct {
 }
 
 func (*UpdateMetadataRequest) Key() int16                 { return 6 }
-func (*UpdateMetadataRequest) MaxVersion() int16          { return 8 }
+func (*UpdateMetadataRequest) MaxVersion() int16          { return 7 }
 func (v *UpdateMetadataRequest) SetVersion(version int16) { v.Version = version }
 func (v *UpdateMetadataRequest) GetVersion() int16        { return v.Version }
 func (v *UpdateMetadataRequest) IsFlexible() bool         { return v.Version >= 6 }
@@ -8931,10 +8897,6 @@ func (v *UpdateMetadataRequest) AppendTo(dst []byte) []byte {
 	_ = isFlexible
 	{
 		v := v.ControllerID
-		dst = kbin.AppendInt32(dst, v)
-	}
-	if version >= 8 {
-		v := v.KRaftControllerID
 		dst = kbin.AppendInt32(dst, v)
 	}
 	{
@@ -9234,10 +9196,6 @@ func (v *UpdateMetadataRequest) readFrom(src []byte, unsafe bool) error {
 	{
 		v := b.Int32()
 		s.ControllerID = v
-	}
-	if version >= 8 {
-		v := b.Int32()
-		s.KRaftControllerID = v
 	}
 	{
 		v := b.Int32()
@@ -9739,7 +9697,7 @@ type UpdateMetadataResponse struct {
 }
 
 func (*UpdateMetadataResponse) Key() int16                 { return 6 }
-func (*UpdateMetadataResponse) MaxVersion() int16          { return 8 }
+func (*UpdateMetadataResponse) MaxVersion() int16          { return 7 }
 func (v *UpdateMetadataResponse) SetVersion(version int16) { v.Version = version }
 func (v *UpdateMetadataResponse) GetVersion() int16        { return v.Version }
 func (v *UpdateMetadataResponse) IsFlexible() bool         { return v.Version >= 6 }
@@ -40939,16 +40897,12 @@ type BrokerRegistrationRequest struct {
 	// The rack that this broker is in, if any.
 	Rack *string
 
-	// Set by a ZK broker if the required configurations for ZK migration are
-	// present.
-	IsMigratingZkBroker bool // v1+
-
 	// UnknownTags are tags Kafka sent that we do not know the purpose of.
 	UnknownTags Tags
 }
 
 func (*BrokerRegistrationRequest) Key() int16                 { return 62 }
-func (*BrokerRegistrationRequest) MaxVersion() int16          { return 1 }
+func (*BrokerRegistrationRequest) MaxVersion() int16          { return 0 }
 func (v *BrokerRegistrationRequest) SetVersion(version int16) { v.Version = version }
 func (v *BrokerRegistrationRequest) GetVersion() int16        { return v.Version }
 func (v *BrokerRegistrationRequest) IsFlexible() bool         { return v.Version >= 0 }
@@ -41063,10 +41017,6 @@ func (v *BrokerRegistrationRequest) AppendTo(dst []byte) []byte {
 		} else {
 			dst = kbin.AppendNullableString(dst, v)
 		}
-	}
-	if version >= 1 {
-		v := v.IsMigratingZkBroker
-		dst = kbin.AppendBool(dst, v)
 	}
 	if isFlexible {
 		dst = kbin.AppendUvarint(dst, 0+uint32(v.UnknownTags.Len()))
@@ -41254,10 +41204,6 @@ func (v *BrokerRegistrationRequest) readFrom(src []byte, unsafe bool) error {
 		}
 		s.Rack = v
 	}
-	if version >= 1 {
-		v := b.Bool()
-		s.IsMigratingZkBroker = v
-	}
 	if isFlexible {
 		s.UnknownTags = internalReadTags(&b)
 	}
@@ -41307,7 +41253,7 @@ type BrokerRegistrationResponse struct {
 }
 
 func (*BrokerRegistrationResponse) Key() int16                 { return 62 }
-func (*BrokerRegistrationResponse) MaxVersion() int16          { return 1 }
+func (*BrokerRegistrationResponse) MaxVersion() int16          { return 0 }
 func (v *BrokerRegistrationResponse) SetVersion(version int16) { v.Version = version }
 func (v *BrokerRegistrationResponse) GetVersion() int16        { return v.Version }
 func (v *BrokerRegistrationResponse) IsFlexible() bool         { return v.Version >= 0 }


### PR DESCRIPTION
The protocols are changing a lot, so we will just remove these APIs until 3.4 is stabilized. They are broker to broker only, so they aren't that important anyway.