### PR TITLE
Revert "kmsg: commit new proto for KIP-881"

### DIFF
--- a/generate/definitions/misc
+++ b/generate/definitions/misc
@@ -364,7 +364,7 @@ StickyMemberMetadata => not top level, no encoding
 // ConsumerMemberMetadata is the metadata that is usually sent with a join group
 // request with the "consumer" protocol (normal, non-connect consumers).
 ConsumerMemberMetadata => not top level, with version field
-  // Version is 0, 1, 2, or 3.
+  // Version is 0, 1, or 2.
   Version: int16
   // Topics is the list of topics in the group that this member is interested
   // in consuming.
@@ -377,10 +377,7 @@ ConsumerMemberMetadata => not top level, with version field
   OwnedPartitions: [=>] // v1+
     Topic: string
     Partitions: [int32]
-  // Generation is the generation of the group.
   Generation: int32(-1) // v2+
-  // Rack, if non-nil, opts into rack-aware replica assignment.
-  Rack: nullable-string // v3+
 
 // ConsumerMemberAssignment is the assignment data that is usually sent with a
 // sync group request with the "consumer" protocol (normal, non-connect

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -1691,7 +1691,7 @@ func NewConsumerMemberMetadataOwnedPartition() ConsumerMemberMetadataOwnedPartit
 // ConsumerMemberMetadata is the metadata that is usually sent with a join group
 // request with the "consumer" protocol (normal, non-connect consumers).
 type ConsumerMemberMetadata struct {
-	// Version is 0, 1, 2, or 3.
+	// Version is 0, 1, or 2.
 	Version int16
 
 	// Topics is the list of topics in the group that this member is interested
@@ -1706,13 +1706,8 @@ type ConsumerMemberMetadata struct {
 	// member currently owns.
 	OwnedPartitions []ConsumerMemberMetadataOwnedPartition // v1+
 
-	// Generation is the generation of the group.
-	//
 	// This field has a default of -1.
 	Generation int32 // v2+
-
-	// Rack, if non-nil, opts into rack-aware replica assignment.
-	Rack *string // v3+
 }
 
 func (v *ConsumerMemberMetadata) AppendTo(dst []byte) []byte {
@@ -1756,10 +1751,6 @@ func (v *ConsumerMemberMetadata) AppendTo(dst []byte) []byte {
 	if version >= 2 {
 		v := v.Generation
 		dst = kbin.AppendInt32(dst, v)
-	}
-	if version >= 3 {
-		v := v.Rack
-		dst = kbin.AppendNullableString(dst, v)
 	}
 	return dst
 }
@@ -1858,15 +1849,6 @@ func (v *ConsumerMemberMetadata) readFrom(src []byte, unsafe bool) error {
 	if version >= 2 {
 		v := b.Int32()
 		s.Generation = v
-	}
-	if version >= 3 {
-		var v *string
-		if unsafe {
-			v = b.UnsafeNullableString()
-		} else {
-			v = b.NullableString()
-		}
-		s.Rack = v
 	}
 	return b.Complete()
 }


### PR DESCRIPTION
This reverts commit b8459811983b3489830b0c7734723311a86e9238.

Just in case this changes before it is actually used -- we can just add the protocol when it is actually used in balancers themselves.