### PR TITLE
Revert "kmsg: commit new ConsumerMemberMetadata for KIP-792"

### DIFF
--- a/generate/definitions/23_offset_for_leader_epoch
+++ b/generate/definitions/23_offset_for_leader_epoch
@@ -53,7 +53,7 @@ OffsetForLeaderEpochResponse =>
       // UNKNOWN_LEADER_EPOCH if returned if the client is using a current leader epoch
       // that the actual leader does not know of. This could occur when the client
       // has newer metadata than the broker when the broker just became the leader for
-      // a replica.
+      //  a replica.
       ErrorCode: int16
       // Partition is the partition this response is for.
       Partition: int32

--- a/generate/definitions/misc
+++ b/generate/definitions/misc
@@ -364,7 +364,7 @@ StickyMemberMetadata => not top level, no encoding
 // ConsumerMemberMetadata is the metadata that is usually sent with a join group
 // request with the "consumer" protocol (normal, non-connect consumers).
 ConsumerMemberMetadata => not top level, with version field
-  // Version is 0, 1, or 2.
+  // Version is either version 0 or version 1.
   Version: int16
   // Topics is the list of topics in the group that this member is interested
   // in consuming.
@@ -377,13 +377,12 @@ ConsumerMemberMetadata => not top level, with version field
   OwnedPartitions: [=>] // v1+
     Topic: string
     Partitions: [int32]
-  Generation: int32(-1) // v2+
 
 // ConsumerMemberAssignment is the assignment data that is usually sent with a
 // sync group request with the "consumer" protocol (normal, non-connect
 // consumers).
 ConsumerMemberAssignment => not top level, with version field
-  // Verson is 0, 1, or 2.
+  // Verson is currently version 0.
   Version: int16
   // Topics contains topics in the assignment.
   Topics: [=>]

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -1705,9 +1705,6 @@ type ConsumerMemberMetadata struct {
 	// OwnedPartitions, introduced for KIP-429, are the partitions that this
 	// member currently owns.
 	OwnedPartitions []ConsumerMemberMetadataOwnedPartition // v1+
-
-	// This field has a default of -1.
-	Generation int32 // v2+
 }
 
 func (v *ConsumerMemberMetadata) AppendTo(dst []byte) []byte {
@@ -1747,10 +1744,6 @@ func (v *ConsumerMemberMetadata) AppendTo(dst []byte) []byte {
 				}
 			}
 		}
-	}
-	if version >= 2 {
-		v := v.Generation
-		dst = kbin.AppendInt32(dst, v)
 	}
 	return dst
 }
@@ -1846,17 +1839,12 @@ func (v *ConsumerMemberMetadata) readFrom(src []byte, unsafe bool) error {
 		v = a
 		s.OwnedPartitions = v
 	}
-	if version >= 2 {
-		v := b.Int32()
-		s.Generation = v
-	}
 	return b.Complete()
 }
 
 // Default sets any default fields. Calling this allows for future compatibility
 // if new fields are added to ConsumerMemberMetadata.
 func (v *ConsumerMemberMetadata) Default() {
-	v.Generation = -1
 }
 
 // NewConsumerMemberMetadata returns a default ConsumerMemberMetadata
@@ -2022,8 +2010,9 @@ func NewConsumerMemberAssignment() ConsumerMemberAssignment {
 // "connect" protocol. v1 introduced incremental cooperative rebalancing (akin
 // to cooperative-sticky) per KIP-415.
 //
-//	v0 defined in connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/ConnectProtocol.java
-//	v1+ defined in connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeConnectProtocol.java
+//     v0 defined in connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/ConnectProtocol.java
+//     v1+ defined in connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeConnectProtocol.java
+//
 type ConnectMemberMetadata struct {
 	Version int16
 
@@ -16021,7 +16010,8 @@ type ApiVersionsRequest struct {
 	//
 	// If using v3, this field is required and must match the following pattern:
 	//
-	//	[a-zA-Z0-9](?:[a-zA-Z0-9\\-.]*[a-zA-Z0-9])?
+	//     [a-zA-Z0-9](?:[a-zA-Z0-9\\-.]*[a-zA-Z0-9])?
+	//
 	ClientSoftwareName string // v3+
 
 	// ClientSoftwareVersion is the version of the software name in the prior
@@ -19349,7 +19339,7 @@ type OffsetForLeaderEpochResponseTopicPartition struct {
 	// UNKNOWN_LEADER_EPOCH if returned if the client is using a current leader epoch
 	// that the actual leader does not know of. This could occur when the client
 	// has newer metadata than the broker when the broker just became the leader for
-	// a replica.
+	//  a replica.
 	ErrorCode int16
 
 	// Partition is the partition this response is for.
@@ -43596,6 +43586,7 @@ func (k Key) Int16() int16 { return int16(k) }
 // * 4 (BROKER)
 //
 // * 8 (BROKER_LOGGER)
+//
 type ConfigResourceType int8
 
 func (v ConfigResourceType) String() string {
@@ -43678,6 +43669,7 @@ func (e *ConfigResourceType) UnmarshalText(text []byte) error {
 //
 // * 6 (DYNAMIC_BROKER_LOGGER_CONFIG)
 // Broker logger; see KIP-412.
+//
 type ConfigSource int8
 
 func (v ConfigSource) String() string {
@@ -43777,6 +43769,7 @@ func (e *ConfigSource) UnmarshalText(text []byte) error {
 // * 8 (CLASS)
 //
 // * 9 (PASSWORD)
+//
 type ConfigType int8
 
 func (v ConfigType) String() string {
@@ -43884,6 +43877,7 @@ func (e *ConfigType) UnmarshalText(text []byte) error {
 // * 2 (APPEND)
 //
 // * 3 (SUBTRACT)
+//
 type IncrementalAlterConfigOp int8
 
 func (v IncrementalAlterConfigOp) String() string {
@@ -43966,6 +43960,7 @@ func (e *IncrementalAlterConfigOp) UnmarshalText(text []byte) error {
 // * 6 (DELEGATION_TOKEN)
 //
 // * 7 (USER)
+//
 type ACLResourceType int8
 
 func (v ACLResourceType) String() string {
@@ -44067,6 +44062,7 @@ func (e *ACLResourceType) UnmarshalText(text []byte) error {
 //
 // * 4 (PREFIXED)
 // The name must have our requested name as a prefix (that is, "foo" will match on "foobar").
+//
 type ACLResourcePatternType int8
 
 func (v ACLResourcePatternType) String() string {
@@ -44145,6 +44141,7 @@ func (e *ACLResourcePatternType) UnmarshalText(text []byte) error {
 //
 // * 3 (ALLOW)
 // Any allow permission.
+//
 type ACLPermissionType int8
 
 func (v ACLPermissionType) String() string {
@@ -44238,6 +44235,7 @@ func (e *ACLPermissionType) UnmarshalText(text []byte) error {
 // * 13 (CREATE_TOKENS)
 //
 // * 14 (DESCRIBE_TOKENS)
+//
 type ACLOperation int8
 
 func (v ACLOperation) String() string {
@@ -44383,6 +44381,7 @@ func (e *ACLOperation) UnmarshalText(text []byte) error {
 // * 6 (Dead)
 //
 // * 7 (PrepareEpochFence)
+//
 type TransactionState int8
 
 func (v TransactionState) String() string {
@@ -44484,6 +44483,7 @@ func (e *TransactionState) UnmarshalText(text []byte) error {
 //
 // * 2 (ANY)
 // Matches all named quotas and default quotas for the given EntityType.
+//
 type QuotasMatchType int8
 
 func (v QuotasMatchType) String() string {
@@ -44552,6 +44552,7 @@ func (e *QuotasMatchType) UnmarshalText(text []byte) error {
 // * 2 (QUORUM_REASSIGNMENT)
 //
 // * 3 (LEADER_CHANGE)
+//
 type ControlRecordKeyType int8
 
 func (v ControlRecordKeyType) String() string {


### PR DESCRIPTION
This reverts commit a7c820032cc2255e2fa8414903cec6bfc2773535.

Kafka has changed the protocol within the release a few tiems; we'll wait until Kafka releases before we stabilize of our own protocol changes.