### PR TITLE
pkg/kgo: bugfix ConsumePreferringLagFn

### DIFF
--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -124,7 +124,7 @@ func (c *testConsumer) etl(etlsBeforeQuit int) {
 		ConsumeTopics(c.consumeFrom),
 		Balancers(c.balancer),
 		MaxBufferedRecords(10000),
-		ConsumePreferringLagFn(PreferLagAt(10)),
+		ConsumePreferringLagFn(PreferLagAt(1)),
 
 		// Even with autocommitting, autocommitting does not commit
 		// *the latest* when being revoked. We always want to commit

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -536,9 +536,9 @@ func (s *sink) handleReqClientErr(req *produceRequest, err error) {
 		isRetriableBrokerErr(err):
 		updateMeta := !isRetriableBrokerErr(err)
 		if updateMeta {
-			s.cl.cfg.logger.Log(LogLevelInfo, "produce request failed triggering metadata update", "broker", logID(s.nodeID), "err", err)
+			s.cl.cfg.logger.Log(LogLevelInfo, "produce request failed, triggering metadata update", "broker", logID(s.nodeID), "err", err)
 		}
-		s.handleRetryBatches(req.batches, req.backoffSeq, updateMeta, false, "failed produce request triggering metadata update")
+		s.handleRetryBatches(req.batches, req.backoffSeq, updateMeta, false, "failed produce request triggered metadata update")
 
 	case errors.Is(err, ErrClientClosed):
 		s.cl.failBufferedRecords(ErrClientClosed)


### PR DESCRIPTION
adjustPreferringLag adds back topics and partitions that the user did not specify. For partitions specifically, we reuse a partition map for all topics rather than create potentially dozens of partition maps.

Previously, the code did not clear out the partition map entirely before moving onto the next topic. If a second topic had fewer partitions than a first topic, then we would add back fake partitions into our fetch, and when we went to build a fetch request, we would panic because the consumer offset pointer to use for the fake partition didn't exist.

We now properly clear the map entirely between topics.

Additionally, this fixes a bit of the previous behavior w.r.t. ordering: we documented that any unchanged ordering was preserved -- i.e. if you only wanted one partition at the front, the prior ordering for the remaining partitions was unchanged. The implementation did not honor this -- we iterated over maps to add back topics & partitions the user did not specify, and map iteration is unordered. We now iterate over the original input and compare if the input still exists in the map, and if so, add back. This makes adjusting slower, but _hopefully_ the impact is not noticeably worse.

The integration tests are improved slightly, but I've been unable to trigger this in the integration tests -- instead, I recreated this locally.

* One broker
* Create two topics, one with one partition, the other with 2
* Produce 5mil messages to each topic
* Group consume to the end so there is no lag
* Seek before the end for the one-topic partition, seek one partition of the two-partition topic to the beginning, the other at the end
* Redo the consumer

The above will panic on the last step without this commit, and will not panic with this commit.

Closes #310.