### PR TITLE
kgo.Client: avoid panic in OffsetFetchRequest when coordinator is not loaded

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,3 +27,55 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+
+  integration-test-kafka:
+    if: github.repository == 'twmb/franz-go'
+    needs: golangci
+    runs-on: ubuntu-latest
+    name: "integration test kafka"
+    container: golang:1.19.2
+    services:
+      kafka:
+        image: bitnami/kafka:latest
+        ports:
+          - 9092:9092
+        env:
+          KAFKA_ENABLE_KRAFT: yes
+          KAFKA_CFG_PROCESS_ROLES: controller,broker
+          KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+          # Set this to "PLAINTEXT://127.0.0.1:9092" if you want to run this container on localhost via Docker
+          KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+          KAFKA_CFG_BROKER_ID: 1
+          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_KRAFT_CLUSTER_ID: XkpGZQ27R3eTl3OdTm2LYA # 16 byte base64-encoded UUID
+    steps:
+      - uses: actions/checkout@v3
+      - run: go test ./...
+        env:
+          KGO_TEST_RF: 1
+          KGO_SEEDS: kafka:9092
+          KGO_TEST_UNSAFE: true
+          KGO_TEST_STABLE_FETCH: true
+
+  integration-test-redpanda:
+    if: github.repository == 'twmb/franz-go'
+    needs: golangci
+    runs-on: ubuntu-latest
+    name: "integration test redpanda"
+    container: golang:1.19.2
+    services:
+      redpanda:
+        image: vectorized/redpanda-nightly:latest
+        ports:
+          - 9092:9092
+        env:
+          REDPANDA_ADVERTISE_KAFKA_ADDRESS: redpanda:9092
+    steps:
+      - uses: actions/checkout@v3
+      - run: go test ./...
+        env:
+          KGO_TEST_RF: 1
+          KGO_SEEDS: redpanda:9092

--- a/pkg/kgo/client_test.go
+++ b/pkg/kgo/client_test.go
@@ -1,7 +1,10 @@
 package kgo
 
 import (
+	"context"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
@@ -103,4 +106,20 @@ func TestParseBrokerAddrErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnknownGroupOffsetFetchPinned(t *testing.T) {
+	req := kmsg.NewOffsetFetchRequest()
+	req.Group = "unknown-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	cl, _ := NewClient(
+		getSeedBrokers(),
+	)
+	defer cl.Close()
+	defer func() {
+		if err := recover(); err != nil {
+			t.Errorf("fetch panicked: %v", err)
+		}
+	}()
+	req.RequestWith(context.Background(), cl)
 }


### PR DESCRIPTION
Internally, OffsetFetchRequest is sharded, but only on old brokers. We
first try not sharding. To have this one-or-the-other behavior, we wrap
the request with an internal pinned type before issuing it. Before we
return the response shards to the user, we remove any pin wrapping.

The offset fetch sharder accidentally did not return a pinned req in
cases that were known to be failures (i.e. were actually not going to be
issued). This wasn't caught in testing because the only time this really
happens is when:

* the FindCoordinator request outright fails
* the broker's coordinator is not yet loaded

The latter case happens for a brief window when using groups for the
first time in a new cluster.

Rather than always return a pinned req, we instead check if the request
actually is pinned. This is more bullet proof for the future and
actually eliminates the need for the current helper "is this pinned"
function.

This also adds a tiny integration test that theoretically should trigger
the issue occasionally -- if this test runs first in a test suite, then
it will panic. I've also tested this locally before and after this
change on a new cluster both times.

Lastly, this removes accidentally requesting an empty group in
FindCoordinators if the request was batched.

Closes #317 