### PR TITLE
Varlong

### DIFF
--- a/generate/definitions/misc
+++ b/generate/definitions/misc
@@ -95,7 +95,7 @@ Record => not top level
   Attributes: int8
   // TimestampDelta is the millisecond delta of this record's timestamp
   // from the record's RecordBatch's FirstTimestamp.
-  TimestampDelta: varint
+  TimestampDelta: varlong
   // OffsetDelta is the delta of this record's offset from the record's
   // RecordBatch's FirstOffset.
   //

--- a/generate/gen.go
+++ b/generate/gen.go
@@ -15,6 +15,7 @@ func (Int64) TypeName() string                 { return "int64" }
 func (Float64) TypeName() string               { return "float64" }
 func (Uint32) TypeName() string                { return "uint32" }
 func (Varint) TypeName() string                { return "int32" }
+func (Varlong) TypeName() string               { return "int64" }
 func (Uuid) TypeName() string                  { return "[16]byte" }
 func (String) TypeName() string                { return "string" }
 func (NullableString) TypeName() string        { return "*string" }
@@ -69,6 +70,7 @@ func (Int64) WriteAppend(l *LineWriter)        { primAppend("Int64", l) }
 func (Float64) WriteAppend(l *LineWriter)      { primAppend("Float64", l) }
 func (Uint32) WriteAppend(l *LineWriter)       { primAppend("Uint32", l) }
 func (Varint) WriteAppend(l *LineWriter)       { primAppend("Varint", l) }
+func (Varlong) WriteAppend(l *LineWriter)      { primAppend("Varlong", l) }
 func (Uuid) WriteAppend(l *LineWriter)         { primAppend("Uuid", l) }
 func (VarintString) WriteAppend(l *LineWriter) { primAppend("VarintString", l) }
 func (VarintBytes) WriteAppend(l *LineWriter)  { primAppend("VarintBytes", l) }
@@ -254,6 +256,9 @@ func (s Struct) WriteAppend(l *LineWriter) {
 		case Varint:
 			l.Write("dst = kbin.AppendUvarint(dst, kbin.VarintLen(v))")
 			f.Type.WriteAppend(l)
+		case Varlong:
+			l.Write("dst = kbin.AppendUvarint(dst, kbin.VarlongLen(v))")
+			f.Type.WriteAppend(l)
 		case Uuid:
 			l.Write("dst = kbin.AppendUvarint(dst, 16)")
 			f.Type.WriteAppend(l)
@@ -366,6 +371,7 @@ func (Int64) WriteDecode(l *LineWriter)        { primDecode("Int64", l) }
 func (Float64) WriteDecode(l *LineWriter)      { primDecode("Float64", l) }
 func (Uint32) WriteDecode(l *LineWriter)       { primDecode("Uint32", l) }
 func (Varint) WriteDecode(l *LineWriter)       { primDecode("Varint", l) }
+func (Varlong) WriteDecode(l *LineWriter)      { primDecode("Varlong", l) }
 func (Uuid) WriteDecode(l *LineWriter)         { primDecode("Uuid", l) }
 func (VarintString) WriteDecode(l *LineWriter) { primUnsafeDecode("VarintString", l) }
 func (VarintBytes) WriteDecode(l *LineWriter)  { primDecode("VarintBytes", l) }

--- a/generate/main.go
+++ b/generate/main.go
@@ -67,6 +67,10 @@ type (
 		HasDefault bool
 		Default    int32
 	}
+	Varlong struct {
+		HasDefault bool
+		Default    int64
+	}
 	Uuid         struct{}
 	VarintString struct{}
 	VarintBytes  struct{}
@@ -301,6 +305,18 @@ func (i Varint) SetDefault(s string) Type {
 }
 func (i Varint) GetDefault() (interface{}, bool) { return i.Default, i.HasDefault }
 func (Varint) GetTypeDefault() interface{}       { return 0 }
+
+func (i Varlong) SetDefault(s string) Type {
+	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		die("invalid varlong default: %v", err)
+	}
+	i.Default = v
+	i.HasDefault = true
+	return i
+}
+func (i Varlong) GetDefault() (interface{}, bool) { return i.Default, i.HasDefault }
+func (Varlong) GetTypeDefault() interface{}       { return 0 }
 
 func (s NullableString) SetDefault(v string) Type {
 	if v != "null" {

--- a/generate/parse.go
+++ b/generate/parse.go
@@ -27,6 +27,7 @@ var types = map[string]Type{
 	"float64":         Float64{},
 	"uint32":          Uint32{},
 	"varint":          Varint{},
+	"varlong":         Varlong{},
 	"uuid":            Uuid{},
 	"string":          String{},
 	"nullable-string": NullableString{},

--- a/pkg/kbin/primitives.go
+++ b/pkg/kbin/primitives.go
@@ -75,7 +75,7 @@ func AppendUint32(dst []byte, u uint32) []byte {
 
 // uvarintLens could only be length 65, but using 256 allows bounds check
 // elimination on lookup.
-const uvarintLens = "\x01\x01\x01\x01\x01\x01\x01\x01\x02\x02\x02\x02\x02\x02\x02\x03\x03\x03\x03\x03\x03\x03\x04\x04\x04\x04\x04\x04\x04\x05\x05\x05\x05\x05\x05\x05\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x08\x08\x08\x08\x08\x08\x08\x09\x09\x09\x09\x09\x09\x09\x10\x10\x10\x10\x10\x10\x10\x11\x11\x11\x11\x11\x11\x11\x12\x12\x12\x12\x12\x12\x12\x13\x13\x13\x13\x13\x13\x13\x14\x14\x14\x14\x14\x14\x14\x15\x15\x15\x15\x15\x15\x15\x16\x16\x16\x16\x16\x16\x16\x17\x17\x17\x17\x17\x17\x17\x18\x18\x18\x18\x18\x18\x18\x19\x19\x19\x19\x19\x19\x19\x20\x20\x20\x20\x20\x20\x20\x21\x21\x21\x21\x21\x21\x21\x22\x22\x22\x22\x22\x22\x22\x23\x23\x23\x23\x23\x23\x23\x24\x24\x24\x24\x24\x24\x24\x25\x25\x25\x25\x25\x25\x25\x26\x26\x26\x26\x26\x26\x26\x27\x27\x27\x27\x27\x27\x27\x28\x28\x28\x28\x28\x28\x28\x29\x29\x29\x29\x29\x29\x29\x30\x30\x30\x30\x30\x30\x30\x31\x31\x31\x31\x31\x31\x31\x32\x32\x32\x32\x32\x32\x32\x33\x33\x33\x33\x33\x33\x33\x34\x34\x34\x34\x34\x34\x34\x35\x35\x35\x35\x35\x35\x35\x36\x36\x36\x36\x36\x36\x36\x37\x37\x37"
+const uvarintLens = "\x01\x01\x01\x01\x01\x01\x01\x01\x02\x02\x02\x02\x02\x02\x02\x03\x03\x03\x03\x03\x03\x03\x04\x04\x04\x04\x04\x04\x04\x05\x05\x05\x05\x05\x05\x05\x06\x06\x06\x06\x06\x06\x06\x07\x07\x07\x07\x07\x07\x07\x08\x08\x08\x08\x08\x08\x08\x09\x09\x09\x09\x09\x09\x09\x0a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
 // VarintLen returns how long i would be if it were varint encoded.
 func VarintLen(i int32) int {
@@ -86,6 +86,10 @@ func VarintLen(i int32) int {
 // UvarintLen returns how long u would be if it were uvarint encoded.
 func UvarintLen(u uint32) int {
 	return int(uvarintLens[byte(bits.Len32(u))])
+}
+
+func uvarlongLen(u uint64) int {
+	return int(uvarintLens[byte(bits.Len64(u))])
 }
 
 // Varint is a loop unrolled 32 bit varint decoder. The return semantics
@@ -135,12 +139,102 @@ func Uvarint(in []byte) (uint32, int) {
 		goto fail
 	}
 
-	x |= uint32(in[4]&0x7f) << 28
+	x |= uint32(in[4]) << 28
 	if in[4] <= 0x0f {
 		return x, 5
 	}
 
 	overflow = -5
+
+fail:
+	return 0, overflow
+}
+
+// Varlong is a loop unrolled 64 bit varint decoder. The return semantics
+// are the same as binary.Varint, with the added benefit that overflows
+// in 10 byte encodings are handled rather than left to the user.
+func Varlong(in []byte) (int64, int) {
+	x, n := uvarlong(in)
+	return int64((x >> 1) ^ -(x & 1)), n
+}
+
+func uvarlong(in []byte) (uint64, int) {
+	var x uint64
+	var overflow int
+
+	if len(in) < 1 {
+		goto fail
+	}
+
+	x = uint64(in[0] & 0x7f)
+	if in[0]&0x80 == 0 {
+		return x, 1
+	} else if len(in) < 2 {
+		goto fail
+	}
+
+	x |= uint64(in[1]&0x7f) << 7
+	if in[1]&0x80 == 0 {
+		return x, 2
+	} else if len(in) < 3 {
+		goto fail
+	}
+
+	x |= uint64(in[2]&0x7f) << 14
+	if in[2]&0x80 == 0 {
+		return x, 3
+	} else if len(in) < 4 {
+		goto fail
+	}
+
+	x |= uint64(in[3]&0x7f) << 21
+	if in[3]&0x80 == 0 {
+		return x, 4
+	} else if len(in) < 5 {
+		goto fail
+	}
+
+	x |= uint64(in[4]&0x7f) << 28
+	if in[4]&0x80 == 0 {
+		return x, 5
+	} else if len(in) < 6 {
+		goto fail
+	}
+
+	x |= uint64(in[5]&0x7f) << 35
+	if in[5]&0x80 == 0 {
+		return x, 6
+	} else if len(in) < 7 {
+		goto fail
+	}
+
+	x |= uint64(in[6]&0x7f) << 42
+	if in[6]&0x80 == 0 {
+		return x, 7
+	} else if len(in) < 8 {
+		goto fail
+	}
+
+	x |= uint64(in[7]&0x7f) << 49
+	if in[7]&0x80 == 0 {
+		return x, 8
+	} else if len(in) < 9 {
+		goto fail
+	}
+
+	x |= uint64(in[8]&0x7f) << 56
+	if in[8]&0x80 == 0 {
+		return x, 9
+	} else if len(in) < 10 {
+		goto fail
+	}
+
+	x |= uint64(in[9]) << 63
+	if in[9] <= 0x01 {
+		return x, 10
+	}
+
+	overflow = -10
 
 fail:
 	return 0, overflow
@@ -154,6 +248,91 @@ func AppendVarint(dst []byte, i int32) []byte {
 // AppendUvarint appends a uvarint encoded u to dst.
 func AppendUvarint(dst []byte, u uint32) []byte {
 	switch UvarintLen(u) {
+	case 5:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte((u>>21)&0x7f|0x80),
+			byte(u>>28))
+	case 4:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte(u>>21))
+	case 3:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte(u>>14))
+	case 2:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte(u>>7))
+	case 1:
+		return append(dst, byte(u))
+	}
+	return dst
+}
+
+// AppendVarlong appends a varint encoded i to dst.
+func AppendVarlong(dst []byte, i int64) []byte {
+	return appendUvarlong(dst, uint64(i)<<1^uint64(i>>63))
+}
+
+func appendUvarlong(dst []byte, u uint64) []byte {
+	switch uvarlongLen(u) {
+	case 10:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte((u>>21)&0x7f|0x80),
+			byte((u>>28)&0x7f|0x80),
+			byte((u>>35)&0x7f|0x80),
+			byte((u>>42)&0x7f|0x80),
+			byte((u>>49)&0x7f|0x80),
+			byte((u>>56)&0x7f|0x80),
+			byte(u>>63))
+	case 9:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte((u>>21)&0x7f|0x80),
+			byte((u>>28)&0x7f|0x80),
+			byte((u>>35)&0x7f|0x80),
+			byte((u>>42)&0x7f|0x80),
+			byte((u>>49)&0x7f|0x80),
+			byte(u>>56))
+	case 8:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte((u>>21)&0x7f|0x80),
+			byte((u>>28)&0x7f|0x80),
+			byte((u>>35)&0x7f|0x80),
+			byte((u>>42)&0x7f|0x80),
+			byte(u>>49))
+	case 7:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte((u>>21)&0x7f|0x80),
+			byte((u>>28)&0x7f|0x80),
+			byte((u>>35)&0x7f|0x80),
+			byte(u>>42))
+	case 6:
+		return append(dst,
+			byte(u&0x7f|0x80),
+			byte((u>>7)&0x7f|0x80),
+			byte((u>>14)&0x7f|0x80),
+			byte((u>>21)&0x7f|0x80),
+			byte((u>>28)&0x7f|0x80),
+			byte(u>>35))
 	case 5:
 		return append(dst,
 			byte(u&0x7f|0x80),
@@ -419,6 +598,18 @@ func (b *Reader) Uint32() uint32 {
 // Varint returns a varint int32 from the reader.
 func (b *Reader) Varint() int32 {
 	val, n := Varint(b.Src)
+	if n <= 0 {
+		b.bad = true
+		b.Src = nil
+		return 0
+	}
+	b.Src = b.Src[n:]
+	return val
+}
+
+// Varlong returns a varlong int64 from the reader.
+func (b *Reader) Varlong() int64 {
+	val, n := Varlong(b.Src)
 	if n <= 0 {
 		b.bad = true
 		b.Src = nil

--- a/pkg/kbin/primitives_test.go
+++ b/pkg/kbin/primitives_test.go
@@ -31,6 +31,30 @@ func TestUvarint(t *testing.T) {
 	}
 }
 
+func TestVarlong(t *testing.T) {
+	if err := quick.Check(func(x int64) bool {
+		var expPut [10]byte
+		n := binary.PutVarint(expPut[:], x)
+
+		gotPut := AppendVarlong(nil, x)
+		if !bytes.Equal(expPut[:n], gotPut) {
+			fmt.Println(expPut[:n], gotPut)
+			return false
+		}
+
+		expRead, expN := binary.Varint(expPut[:n])
+		gotRead, gotN := Varlong(gotPut)
+
+		if expN != gotN || expRead != gotRead {
+			return false
+		}
+
+		return true
+	}, nil); err != nil {
+		t.Error(err)
+	}
+}
+
 func BenchmarkUvarint(b *testing.B) {
 	for _, u := range []uint32{
 		0,         // len 1

--- a/pkg/kmsg/api.go
+++ b/pkg/kmsg/api.go
@@ -33,16 +33,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg/internal/kbin"
 )
 
-// GroupMemberMetadata is a type alias for ConsumerMemberMetadata. This is the
-// old deprecated name. The old name is kept around as part of API guarantees
-// in the kgo package.
-type GroupMemberMetadata = ConsumerMemberMetadata
-
-// GroupMemberAssignment is a type alias for ConsumerMemberAssignment. This is
-// the old deprecated name. The old name is kept around as part of API
-// guarantees in the kgo package.
-type GroupMemberAssignment = ConsumerMemberAssignment
-
 //go:generate cp ../kbin/primitives.go internal/kbin/
 
 // Requestor issues requests. Notably, the kgo.Client and kgo.Broker implements

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -368,7 +368,7 @@ type Record struct {
 
 	// TimestampDelta is the millisecond delta of this record's timestamp
 	// from the record's RecordBatch's FirstTimestamp.
-	TimestampDelta int32
+	TimestampDelta int64
 
 	// OffsetDelta is the delta of this record's offset from the record's
 	// RecordBatch's FirstOffset.
@@ -402,7 +402,7 @@ func (v *Record) AppendTo(dst []byte) []byte {
 	}
 	{
 		v := v.TimestampDelta
-		dst = kbin.AppendVarint(dst, v)
+		dst = kbin.AppendVarlong(dst, v)
 	}
 	{
 		v := v.OffsetDelta
@@ -455,7 +455,7 @@ func (v *Record) readFrom(src []byte, unsafe bool) error {
 		s.Attributes = v
 	}
 	{
-		v := b.Varint()
+		v := b.Varlong()
 		s.TimestampDelta = v
 	}
 	{
@@ -1691,7 +1691,7 @@ func NewConsumerMemberMetadataOwnedPartition() ConsumerMemberMetadataOwnedPartit
 // ConsumerMemberMetadata is the metadata that is usually sent with a join group
 // request with the "consumer" protocol (normal, non-connect consumers).
 type ConsumerMemberMetadata struct {
-	// Version is 0, 1, or 2.
+	// Version is either version 0 or version 1.
 	Version int16
 
 	// Topics is the list of topics in the group that this member is interested
@@ -1880,7 +1880,7 @@ func NewConsumerMemberAssignmentTopic() ConsumerMemberAssignmentTopic {
 // sync group request with the "consumer" protocol (normal, non-connect
 // consumers).
 type ConsumerMemberAssignment struct {
-	// Verson is 0, 1, or 2.
+	// Verson is currently version 0.
 	Version int16
 
 	// Topics contains topics in the assignment.


### PR DESCRIPTION
When this repo was originally developed, the Kafka documentation erroneously specified that Record.TimestampDelta was a varint, not a varlong.

Fixing this requires releasing a new major version of kmsg to switch the field from an int32 to an int64.