### PR TITLE
v1.11.5: support 64 bit timestamp deltas in a backcompat manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
-v1.11.4
+v1.11.5
 ===
 
-This patch release is tied to a v2 major release in pkg/kmsg and fixes two
-bugs.
+v1.11.4 is retracted and because it actually requires a v2 release. When a
+breaking kmsg release must happen, v2 of franz-go will happen and I will make a
+change thorough enough such that major kmsg changes will not require a major
+franz-go change again.
 
 When this repo was initially written, the Kafka documentation for the wire
 serialization of a Kafka record was wrong and different from how things were
 actually implemented in the Java source. I used the documentation for my own
 implementation. The documentation was [later fixed](https://github.com/apache/kafka/commit/94ccd4d).
 
-What this means is that in this repo, `kmsg.Record.TimestampDelta` has changed
-from an int32 to an int64, necessitating a major version bump in the kmsg
-package.
+What this means is that in this repo, `kmsg.Record.TimestampDelta` should be
+changed from an int32 to int64. Rather than release a major version of kmsg, I
+have added a `TimestampDelta64` field.
 
 The old 32 bit timestamp delta meant that this package could only represent
 records that had up to 24 days of a delta within a batch. Apparently, this may
@@ -21,8 +23,8 @@ More minor: previously, `AddConsumeTopics` did not work on direct consumers nor
 on a client that consumed nothing to begin with. These shortcomings have been
 addressed.
 
+* [`12e3c11`](https://github.com/twmb/franz-go/commit/12e3c11) **bugfix** franz-go: support 64 bit timestamp deltas
 * [`f613fb8`](https://github.com/twmb/franz-go/commit/f613fb8) **bugfix** pkg/kgo: patch AddConsumeTopics
-* [`bb41aa3`](https://github.com/twmb/franz-go/commit/bb41aa3) **bugfix** pkg/kmsg: change Record.TimestampDelta to int64, a varlong
 
 v1.11.3
 ===

--- a/examples/requesting/request_metadata.go
+++ b/examples/requesting/request_metadata.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 )
 

--- a/examples/sasl/aws_msk_iam/main.go
+++ b/examples/sasl/aws_msk_iam/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl/aws"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/klauspost/compress v1.15.9
 	github.com/pierrec/lz4/v4 v4.1.15
-	github.com/twmb/franz-go/pkg/kmsg v1.2.0
+	github.com/twmb/franz-go/pkg/kmsg v1.3.0
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.15
 require (
 	github.com/klauspost/compress v1.15.9
 	github.com/pierrec/lz4/v4 v4.1.15
-	github.com/twmb/franz-go/pkg/kmsg/v2 v2.0.1
+	github.com/twmb/franz-go/pkg/kmsg v1.2.0
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
 )

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/twmb/franz-go/pkg/kmsg v1.2.0
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
 )
+
+retract v1.11.4 // This version is actually a breaking change and requires a major version change.

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQan
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/twmb/franz-go/pkg/kmsg/v2 v2.0.1 h1:DToARrl154rtwWJFIpGopaAK+t9MIz1239bNl/n2Gvc=
-github.com/twmb/franz-go/pkg/kmsg/v2 v2.0.1/go.mod h1:6OeA4WSQXVfDmkVW65VZJn0Xg7HT5ApIn+XB1fSpuWQ=
+github.com/twmb/franz-go/pkg/kmsg v1.2.0 h1:jYWh2qFw5lDbNv5Gvu/sMKagzICxuA5L6m1W2Oe7XUo=
+github.com/twmb/franz-go/pkg/kmsg v1.2.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQan
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/twmb/franz-go/pkg/kmsg v1.2.0 h1:jYWh2qFw5lDbNv5Gvu/sMKagzICxuA5L6m1W2Oe7XUo=
-github.com/twmb/franz-go/pkg/kmsg v1.2.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
+github.com/twmb/franz-go/pkg/kmsg v1.3.0 h1:ouBETB7nTqRxiO5E8/pySoFZtVEW2VWw55z3/bsUzTw=
+github.com/twmb/franz-go/pkg/kmsg v1.3.0/go.mod h1:SxG/xJKhgPu25SamAq0rrucfp7lbzCpEXOC+vH/ELrY=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 h1:GIAS/yBem/gq2MUqgNIzUHW7cJMmx3TGZOrnyYaNQ6c=
 golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/kbin/primitives.go
+++ b/pkg/kbin/primitives.go
@@ -88,6 +88,12 @@ func UvarintLen(u uint32) int {
 	return int(uvarintLens[byte(bits.Len32(u))])
 }
 
+// VarlongLen returns how long i would be if it were varlong encoded.
+func VarlongLen(i int64) int {
+	u := uint64(i)<<1 ^ uint64(i>>63)
+	return uvarlongLen(u)
+}
+
 func uvarlongLen(u uint64) int {
 	return int(uvarintLens[byte(bits.Len64(u))])
 }

--- a/pkg/kbin/primitives_test.go
+++ b/pkg/kbin/primitives_test.go
@@ -8,6 +8,35 @@ import (
 	"testing/quick"
 )
 
+func TestVarint(t *testing.T) {
+	if err := quick.Check(func(x int32) bool {
+		var expPut [10]byte
+		n := binary.PutVarint(expPut[:], int64(x))
+
+		gotPut := AppendVarint(nil, x)
+		if !bytes.Equal(expPut[:n], gotPut) {
+			return false
+		}
+		if len(gotPut) != n {
+			return false
+		}
+		if VarintLen(x) != n {
+			return false
+		}
+
+		expRead, expN := binary.Varint(expPut[:n])
+		gotRead, gotN := Varint(gotPut)
+
+		if expN != gotN || expRead != int64(gotRead) {
+			return false
+		}
+
+		return true
+	}, nil); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestUvarint(t *testing.T) {
 	if err := quick.Check(func(u uint32) bool {
 		var expPut [10]byte
@@ -38,7 +67,12 @@ func TestVarlong(t *testing.T) {
 
 		gotPut := AppendVarlong(nil, x)
 		if !bytes.Equal(expPut[:n], gotPut) {
-			fmt.Println(expPut[:n], gotPut)
+			return false
+		}
+		if len(gotPut) != n {
+			return false
+		}
+		if VarlongLen(x) != n {
 			return false
 		}
 

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
 )
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
 )
 

--- a/pkg/kgo/client_test.go
+++ b/pkg/kgo/client_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func TestMaxVersions(t *testing.T) {

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
 )

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // Offset is a message offset in a partition.

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type groupConsumer struct {

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo/internal/sticky"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // GroupBalancer balances topics and partitions among group members.

--- a/pkg/kgo/group_balancer_test.go
+++ b/pkg/kgo/group_balancer_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // This simple test hits every branch of cooperative-sticky's adjustCooperative

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 var (

--- a/pkg/kgo/internal/sticky/help_test.go
+++ b/pkg/kgo/internal/sticky/help_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type udBuilder struct {

--- a/pkg/kgo/internal/sticky/sticky.go
+++ b/pkg/kgo/internal/sticky/sticky.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"sort"
 
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // Sticky partitioning has two versions, the latter from KIP-341 preventing a

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -37,7 +37,8 @@ func TestPromisedRecAppendTo(t *testing.T) {
 				{Key: "header key 1", Value: []byte("header value 1")},
 				{Key: "header key 2", Value: []byte("header value 2")},
 			},
-			Offset: 1<<32 | 2,
+			LeaderEpoch: 1,
+			Offset:      2,
 		},
 	}
 
@@ -103,14 +104,16 @@ func TestRecBatchAppendTo(t *testing.T) {
 							{"header key 1", []byte("header value 1")},
 							{"header key 2", []byte("header value 2")},
 						},
-						Offset: 1<<32 | 2,
+						LeaderEpoch: 1,
+						Offset:      2,
 					},
 				},
 				{
 					Record: &Record{
-						Key:    []byte("key 2"),
-						Value:  []byte("value 2"),
-						Offset: 3<<32 | 4,
+						Key:         []byte("key 2"),
+						Value:       []byte("value 2"),
+						LeaderEpoch: 3,
+						Offset:      4,
 					},
 				},
 			},
@@ -274,16 +277,18 @@ func TestMessageSetAppendTo(t *testing.T) {
 			records: []promisedRec{
 				{
 					Record: &Record{
-						Key:    []byte("loooooong key 1"),
-						Value:  []byte("loooooong value 1"),
-						Offset: 1 << 32,
+						Key:         []byte("loooooong key 1"),
+						Value:       []byte("loooooong value 1"),
+						LeaderEpoch: 1,
+						Offset:      0,
 					},
 				},
 				{
 					Record: &Record{
-						Key:    []byte("loooooong key 2"),
-						Value:  []byte("loooooong value 2"),
-						Offset: 3<<32 | 1,
+						Key:         []byte("loooooong key 2"),
+						Value:       []byte("loooooong value 2"),
+						LeaderEpoch: 3,
+						Offset:      1,
 					},
 				},
 			},
@@ -376,14 +381,16 @@ func BenchmarkAppendBatch(b *testing.B) {
 							{"header key 1", []byte("header value 1")},
 							{"header key 2", []byte("header value 2")},
 						},
-						Offset: 1<<32 | 2,
+						LeaderEpoch: 1,
+						Offset:      2,
 					},
 				},
 				{
 					Record: &Record{
-						Key:    []byte("key 2"),
-						Value:  bytes.Repeat([]byte("value 2"), 1000),
-						Offset: 3<<32 | 4,
+						Key:         []byte("key 2"),
+						Value:       bytes.Repeat([]byte("value 2"), 1000),
+						LeaderEpoch: 3,
+						Offset:      4,
 					},
 				},
 			},

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kbin"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // This file contains golden tests against kmsg AppendTo's to ensure our custom

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type producer struct {

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -443,6 +443,7 @@ func (p *producer) finishPromises(b batchPromise) {
 start:
 	p.promisesMu.Lock()
 	for i, pr := range b.recs {
+		pr.LeaderEpoch = 0
 		pr.Offset = b.baseOffset + int64(i)
 		pr.Partition = b.partition
 		pr.ProducerID = b.pid

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -154,12 +154,13 @@ type Record struct {
 // When buffering records, we calculate the length and tsDelta ahead of time
 // (also because number width affects encoding length). We repurpose the Offset
 // field to save space.
-func (r *Record) setLengthAndTimestampDelta(length, tsDelta int32) {
-	r.Offset = int64(uint64(uint32(length))<<32 | uint64(uint32(tsDelta)))
+func (r *Record) setLengthAndTimestampDelta(length int32, tsDelta int64) {
+	r.LeaderEpoch = length
+	r.Offset = tsDelta
 }
 
-func (r *Record) lengthAndTimestampDelta() (length, tsDelta int32) {
-	return int32(uint32(uint64(r.Offset) >> 32)), int32(uint32(uint64(r.Offset)))
+func (r *Record) lengthAndTimestampDelta() (length int32, tsDelta int64) {
+	return r.LeaderEpoch, r.Offset
 }
 
 // AppendFormat appends a record to b given the layout or returns an error if

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1376,7 +1376,7 @@ type recBatch struct {
 
 	attrs             int16 // updated during apending; read and converted to RecordAttrs on success
 	firstTimestamp    int64 // since unix epoch, in millis
-	maxTimestampDelta int32
+	maxTimestampDelta int64
 
 	mu      sync.Mutex    // guards appendTo's reading of records against failAllRecords emptying it
 	records []promisedRec // record w/ length, ts calculated
@@ -1775,7 +1775,7 @@ func messageSet1Length(r *Record) int32 {
 // Returns the numbers for a record if it were added to the record batch.
 func (b *recBatch) calculateRecordNumbers(r *Record) recordNumbers {
 	tsMillis := r.Timestamp.UnixNano() / 1e6
-	tsDelta := int32(tsMillis - b.firstTimestamp)
+	tsDelta := tsMillis - b.firstTimestamp
 
 	// If this is to be the first record in the batch, then our timestamp
 	// delta is actually 0.
@@ -1786,7 +1786,7 @@ func (b *recBatch) calculateRecordNumbers(r *Record) recordNumbers {
 	offsetDelta := int32(len(b.records)) // since called before adding record, delta is the current end
 
 	l := 1 + // attributes, int8 unused
-		kbin.VarintLen(tsDelta) +
+		kbin.VarlongLen(tsDelta) +
 		kbin.VarintLen(offsetDelta) +
 		kbin.VarintLen(int32(len(r.Key))) +
 		len(r.Key) +
@@ -1813,7 +1813,7 @@ func uvarlen(l int) int32   { return int32(kbin.UvarintLen(uvar32(int32(l)))) }
 // recordNumbers tracks a few numbers for a record that is buffered.
 type recordNumbers struct {
 	lengthField int32 // the length field prefix of a record encoded on the wire
-	tsDelta     int32 // the ms delta of when the record was added against the first timestamp
+	tsDelta     int64 // the ms delta of when the record was added against the first timestamp
 }
 
 // wireLength is the wire length of a record including its length field prefix.
@@ -2036,7 +2036,7 @@ func (b seqRecBatch) appendTo(
 	dst = kbin.AppendInt16(dst, b.attrs)
 	dst = kbin.AppendInt32(dst, int32(len(b.records)-1)) // lastOffsetDelta
 	dst = kbin.AppendInt64(dst, b.firstTimestamp)
-	dst = kbin.AppendInt64(dst, b.firstTimestamp+int64(b.maxTimestampDelta))
+	dst = kbin.AppendInt64(dst, b.firstTimestamp+b.maxTimestampDelta)
 
 	seq := b.seq
 	if producerID < 0 { // a negative producer ID means we are not using idempotence
@@ -2092,7 +2092,7 @@ func (pr promisedRec) appendTo(dst []byte, offsetDelta int32) []byte {
 	length, tsDelta := pr.lengthAndTimestampDelta()
 	dst = kbin.AppendVarint(dst, length)
 	dst = kbin.AppendInt8(dst, 0) // attributes, currently unused
-	dst = kbin.AppendVarint(dst, tsDelta)
+	dst = kbin.AppendVarlong(dst, tsDelta)
 	dst = kbin.AppendVarint(dst, offsetDelta)
 	dst = kbin.AppendVarintBytes(dst, pr.Key)
 	dst = kbin.AppendVarintBytes(dst, pr.Value)
@@ -2116,7 +2116,7 @@ func (b seqRecBatch) appendToAsMessageSet(dst []byte, version uint8, compressor 
 			version,
 			0,
 			int64(i),
-			b.firstTimestamp+int64(tsDelta),
+			b.firstTimestamp+tsDelta,
 			pr.Record,
 		)
 	}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type sink struct {

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1470,7 +1470,7 @@ func recordToRecord(
 		Offset:        batch.FirstOffset + int64(record.OffsetDelta),
 	}
 	if r.Attrs.TimestampType() == 0 {
-		r.Timestamp = timeFromMillis(batch.FirstTimestamp + record.TimestampDelta)
+		r.Timestamp = timeFromMillis(batch.FirstTimestamp + int64(record.TimestampDelta))
 	} else {
 		r.Timestamp = timeFromMillis(batch.MaxTimestamp)
 	}

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type readerFrom interface {

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1470,7 +1470,7 @@ func recordToRecord(
 		Offset:        batch.FirstOffset + int64(record.OffsetDelta),
 	}
 	if r.Attrs.TimestampType() == 0 {
-		r.Timestamp = timeFromMillis(batch.FirstTimestamp + int64(record.TimestampDelta))
+		r.Timestamp = timeFromMillis(batch.FirstTimestamp + record.TimestampDelta64)
 	} else {
 		r.Timestamp = timeFromMillis(batch.MaxTimestamp)
 	}

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // TransactionEndTry is simply a named bool.

--- a/pkg/kversion/kversion.go
+++ b/pkg/kversion/kversion.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/twmb/franz-go/pkg/kmsg/v2"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // Versions is a list of versions, with each item corresponding to a Kafka key


### PR DESCRIPTION
v1.11.4 is retraced, and kmsg v2 we do not talk about.