### PR TITLE
consumer: take 2 on fixing potential panic from PurgeTopicsFromClient

### DIFF
--- a/pkg/kgo/consumer_direct_test.go
+++ b/pkg/kgo/consumer_direct_test.go
@@ -2,7 +2,6 @@ package kgo
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 )
@@ -84,9 +83,6 @@ func TestDirectPartitionPurge(t *testing.T) {
 	cl, _ := NewClient(
 		getSeedBrokers(),
 		DefaultProduceTopic(topic),
-		WithLogger(BasicLogger(os.Stderr, LogLevelDebug, func() string {
-			return topic + " "
-		})),
 		RecordPartitioner(ManualPartitioner()),
 		ConsumePartitions(map[string]map[int32]Offset{
 			topic: {0: NewOffset().At(0)},


### PR DESCRIPTION
The keepFilter kept the topic being loaded since the prior function worked on a per-partition basis. If we invalidate the whole topic, we will not re-load it. Particularly, this showed up as a panic because if tps is empty, we return an empty consumer session.