### PR TITLE
kgo.Client: add UpdateSeedBrokers(...string) error

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ generation.
 | [KIP-841](https://cwiki.apache.org/confluence/display/KAFKA/KIP-841%3A+Fenced+replicas+should+not+be+allowed+to+join+the+ISR+in+KRaft) — `AlterPartition.TopicID` | 3.3 | Supported |
 | [KIP-866](https://cwiki.apache.org/confluence/display/KAFKA/KIP-866+ZooKeeper+to+KRaft+Migration) — ZK to Raft RPC changes | 3.4 | Supported |
 | [KIP-893](https://cwiki.apache.org/confluence/display/KAFKA/KIP-893%3A+The+Kafka+protocol+should+support+nullable+structs) — Nullable structs in the protocol | 3.5 | Supported |
+| [KIP-899](https://cwiki.apache.org/confluence/display/KAFKA/KIP-899%3A+Allow+clients+to+rebootstrap) — Allow clients to rebootstrap | ? | Supported (`UpdateSeedBrokers`) |
 
 Missing from above but included in librdkafka is:
 

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -559,9 +559,10 @@ func (cl *Client) reapConnectionsLoop() {
 
 func (cl *Client) reapConnections(idleTimeout time.Duration) (total int) {
 	cl.brokersMu.Lock()
-	brokers := make([]*broker, 0, len(cl.brokers)+len(cl.seeds))
+	seeds := cl.loadSeeds()
+	brokers := make([]*broker, 0, len(cl.brokers)+len(seeds))
 	brokers = append(brokers, cl.brokers...)
-	brokers = append(brokers, cl.seeds...)
+	brokers = append(brokers, seeds...)
 	cl.brokersMu.Unlock()
 
 	for _, broker := range brokers {

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1703,7 +1703,7 @@ func (s *consumerSession) mapLoadsToBrokers(loads listOrEpochLoads) map[*broker]
 	defer s.c.cl.brokersMu.RUnlock()
 
 	brokers := s.c.cl.brokers
-	seed := s.c.cl.seeds[0]
+	seed := s.c.cl.loadSeeds()[0]
 
 	topics := s.tps.load()
 	for _, loads := range []struct {


### PR DESCRIPTION
This allows an end user to update seed brokers, which can be valuable in long lived clients if the original set of seeds has completely rotated and no longer exist.

This satisfies KIP-899, allowing the client to "rebootstrap".

Closes #316.