### PR TITLE
sticky: optimize more

### DIFF
--- a/pkg/kgo/internal/sticky/go120.go
+++ b/pkg/kgo/internal/sticky/go120.go
@@ -1,0 +1,46 @@
+package sticky
+
+import (
+	"math"
+	"reflect"
+	"unsafe"
+)
+
+func (b *balancer) partitionConsumersByGenerationSlice() []memberGeneration {
+	var partitionConsumersByGeneration []memberGeneration
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&partitionConsumersByGeneration)) //nolint:gosec // known way to convert string to slice
+	hdr.Data = ((*reflect.SliceHeader)(unsafe.Pointer(&b.partOwners))).Data        //nolint:gosec // known way to convert string to slice
+	hdr.Len = b.nparts
+	hdr.Cap = b.nparts
+	return partitionConsumersByGeneration
+}
+
+func (b *balancer) partitionConsumersSlice() []partitionConsumer {
+	if b.nparts == 0 {
+		return nil
+	}
+	space := b.partOwners[b.nparts : b.nparts*2]
+	for i := range space {
+		space[i] = math.MaxUint32
+	}
+	var partitionConsumers []partitionConsumer
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&partitionConsumers)) //nolint:gosec // known way to convert string to slice
+	hdr.Data = ((*reflect.SliceHeader)(unsafe.Pointer(&space))).Data   //nolint:gosec // known way to convert string to slice
+	hdr.Len = b.nparts
+	hdr.Cap = b.nparts
+	return partitionConsumers
+}
+
+func (b *balancer) topicPotentialsBufSlice() []uint16 {
+	l := len(b.topicNums) * len(b.members)
+	if l == 0 {
+		return nil
+	}
+	space := b.partOwners[b.nparts*2 : cap(b.partOwners)]
+	var topicPotentialsBuf []uint16
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&topicPotentialsBuf)) //nolint:gosec // known way to convert string to slice
+	hdr.Data = ((*reflect.SliceHeader)(unsafe.Pointer(&space))).Data   //nolint:gosec // known way to convert string to slice
+	hdr.Len = l
+	hdr.Cap = l
+	return topicPotentialsBuf
+}

--- a/pkg/kgo/internal/sticky/go121.go
+++ b/pkg/kgo/internal/sticky/go121.go
@@ -1,0 +1,35 @@
+package sticky
+
+// TODO https://github.com/golang/go/issues/58554
+// TODO We likely need to gate this file behind go1.21 rather than 1.20, any
+// non-patched 1.20 version will fail to compile.
+
+//
+// import (
+// 	"math"
+// 	"unsafe"
+// )
+//
+// func (b *balancer) partitionConsumersByGenerationSlice() []memberGeneration {
+// 	return unsafe.Slice((*memberGeneration)(unsafe.Pointer(unsafe.SliceData(b.partOwners))), b.nparts)
+// }
+//
+// func (b *balancer) partitionConsumersSlice() []partitionConsumer {
+// 	if b.nparts == 0 {
+// 		return nil
+// 	}
+// 	space := b.partOwners[b.nparts : b.nparts*2]
+// 	for i := range space {
+// 		space[i] = math.MaxUint32
+// 	}
+// 	return unsafe.Slice((*partitionConsumer)(unsafe.Pointer(unsafe.SliceData(space))), b.nparts)
+// }
+//
+// func (b *balancer) topicPotentialsBufSlice() []uint16 {
+// 	l := len(b.topicNums) * len(b.members)
+// 	if l == 0 {
+// 		return nil
+// 	}
+// 	space := b.partOwners[b.nparts*2 : cap(b.partOwners)]
+// 	return unsafe.Slice((*uint16)(unsafe.Pointer(unsafe.SliceData(space))), l)
+// }

--- a/pkg/kgo/internal/sticky/help_test.go
+++ b/pkg/kgo/internal/sticky/help_test.go
@@ -145,8 +145,7 @@ func getStickiness(member string, memberPlan map[string][]int32, input []GroupMe
 	var priorPlan []topicPartition
 	for _, in := range input {
 		if in.ID == member {
-			s := kmsg.NewStickyMemberMetadata()
-			priorPlan, _ = deserializeUserData(&s, in.UserData, nil)
+			priorPlan, _ = deserializeUserData(in.UserData, nil)
 			break
 		}
 	}


### PR DESCRIPTION
* Uses some unsafe tricks to reduce some allocations in the sticky package
* Extensively documents the reasoning behind the unsafe
* Decodes userdata directly to drop pre-existing member allocations a good amount