### PR TITLE
sticky: decode userdata directly to avoid allocs

### DIFF
--- a/pkg/kgo/internal/sticky/help_test.go
+++ b/pkg/kgo/internal/sticky/help_test.go
@@ -145,8 +145,7 @@ func getStickiness(member string, memberPlan map[string][]int32, input []GroupMe
 	var priorPlan []topicPartition
 	for _, in := range input {
 		if in.ID == member {
-			s := kmsg.NewStickyMemberMetadata()
-			priorPlan, _ = deserializeUserData(&s, in.UserData, nil)
+			priorPlan, _ = deserializeUserData(in.UserData, nil)
 			break
 		}
 	}

--- a/pkg/kgo/internal/sticky/sticky.go
+++ b/pkg/kgo/internal/sticky/sticky.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -297,12 +298,10 @@ func (b *balancer) parseMemberMetadata() {
 	partitionConsumersByGeneration := make([]memberGeneration, cap(b.partOwners))
 
 	const highBit uint32 = 1 << 31
-	s := kmsg.NewStickyMemberMetadata()
 	var memberPlan []topicPartition
 	var gen uint32
 
 	for _, member := range b.members {
-		resetSticky(&s)
 		// KAFKA-13715 / KIP-792: cooperative-sticky now includes a
 		// generation directly with the currently-owned partitions, and
 		// we can avoid deserializing UserData. This guards against
@@ -319,7 +318,7 @@ func (b *balancer) parseMemberMetadata() {
 			}
 			gen = uint32(member.Generation)
 		} else {
-			memberPlan, gen = deserializeUserData(&s, member.UserData, memberPlan[:0])
+			memberPlan, gen = deserializeUserData(member.UserData, memberPlan[:0])
 		}
 		gen |= highBit
 		memberNum := b.memberNums[member.ID]
@@ -365,33 +364,33 @@ type topicPartition struct {
 	partition int32
 }
 
-func resetSticky(s *kmsg.StickyMemberMetadata) {
-	s.CurrentAssignment = s.CurrentAssignment[:0]
-}
-
 // deserializeUserData returns the topic partitions a member was consuming and
 // the join generation it was consuming from.
 //
 // If anything fails or we do not understand the userdata parsing generation,
 // we return empty defaults. The member will just be assumed to have no
 // history.
-func deserializeUserData(s *kmsg.StickyMemberMetadata, userdata []byte, base []topicPartition) (memberPlan []topicPartition, generation uint32) {
-	if err := s.UnsafeReadFrom(userdata); err != nil {
-		return nil, 0
-	}
+func deserializeUserData(userdata []byte, base []topicPartition) (memberPlan []topicPartition, generation uint32) {
 	memberPlan = base[:0]
-	// A generation of -1 is just as good of a generation as 0, so we use 0
-	// and then use the high bit to signify this generation has been set.
-	if s.Generation >= 0 {
-		generation = uint32(s.Generation)
-	}
-	for _, topicAssignment := range s.CurrentAssignment {
-		for _, partition := range topicAssignment.Partitions {
+	b := kbin.Reader{Src: userdata}
+	for numAssignments := b.ArrayLen(); numAssignments > 0; numAssignments-- {
+		topic := b.UnsafeString()
+		for numPartitions := b.ArrayLen(); numPartitions > 0; numPartitions-- {
 			memberPlan = append(memberPlan, topicPartition{
-				topicAssignment.Topic,
-				partition,
+				topic,
+				b.Int32(),
 			})
 		}
+	}
+	if len(b.Src) > 0 {
+		// A generation of -1 is just as good of a generation as 0, so we use 0
+		// and then use the high bit to signify this generation has been set.
+		if generationI32 := b.Int32(); generationI32 > 0 {
+			generation = uint32(generationI32)
+		}
+	}
+	if b.Complete() != nil {
+		memberPlan = memberPlan[:0]
 	}
 	return
 }


### PR DESCRIPTION
Drops allocs and CPU for pre-existing members a bit.

```
name                            old time/op    new time/op    delta
Large-12                          3.22ms ±13%    3.29ms ±15%     ~     (p=0.579 n=10+10)
LargeWithExisting-12              6.99ms ± 8%    6.96ms ±10%     ~     (p=0.684 n=10+10)
LargeImbalanced-12                4.00ms ± 6%    4.00ms ±16%     ~     (p=0.579 n=10+10)
LargeWithExistingImbalanced-12    7.13ms ± 4%    7.16ms ± 8%     ~     (p=0.842 n=9+10)
Java/large-12                      157ms ± 2%     157ms ± 1%     ~     (p=1.000 n=10+10)
Java/large_imbalance-12            195ms ± 1%     199ms ± 5%     ~     (p=0.070 n=7+10)
Java/medium-12                    14.4ms ±20%    13.2ms ±15%     ~     (p=0.123 n=10+10)
Java/medium_imbalance-12          16.2ms ±21%    16.9ms ±16%     ~     (p=0.247 n=10+10)
Java/small-12                     12.2ms ±10%    12.5ms ±21%     ~     (p=0.912 n=10+10)
Java/small_imbalance-12           13.9ms ±28%    13.9ms ±21%     ~     (p=0.971 n=10+10)

name                            old alloc/op   new alloc/op   delta
Large-12                          1.87MB ± 0%    1.87MB ± 0%     ~     (p=0.469 n=10+10)
LargeWithExisting-12              1.91MB ± 0%    1.90MB ± 0%   -0.46%  (p=0.000 n=10+9)
LargeImbalanced-12                2.08MB ± 1%    2.07MB ± 1%     ~     (p=0.123 n=10+10)
LargeWithExistingImbalanced-12    1.94MB ± 0%    1.93MB ± 0%   -0.45%  (p=0.000 n=9+10)
Java/large-12                      125MB ± 0%     125MB ± 0%     ~     (p=0.383 n=9+10)
Java/large_imbalance-12            129MB ± 0%     129MB ± 0%     ~     (p=0.796 n=9+10)
Java/medium-12                    7.69MB ± 0%    7.69MB ± 0%   -0.00%  (p=0.016 n=9+10)
Java/medium_imbalance-12          7.97MB ± 0%    7.97MB ± 0%     ~     (p=0.280 n=10+10)
Java/small-12                     6.11MB ± 0%    6.11MB ± 0%     ~     (p=0.434 n=9+10)
Java/small_imbalance-12           6.34MB ± 0%    6.34MB ± 0%     ~     (p=0.089 n=10+10)

name                            old allocs/op  new allocs/op  delta
Large-12                             335 ± 0%       335 ± 0%     ~     (all equal)
LargeWithExisting-12                 880 ± 1%       662 ± 0%  -24.68%  (p=0.000 n=9+10)
LargeImbalanced-12                   806 ± 9%       783 ± 5%     ~     (p=0.184 n=10+10)
LargeWithExistingImbalanced-12       901 ± 1%       687 ± 0%  -23.76%  (p=0.000 n=10+10)
Java/large-12                      6.04k ± 0%     6.04k ± 0%     ~     (all equal)
Java/large_imbalance-12            7.43k ± 0%     7.43k ± 0%     ~     (p=0.790 n=9+10)
Java/medium-12                     3.03k ± 0%     3.03k ± 0%     ~     (all equal)
Java/medium_imbalance-12           3.15k ± 0%     3.15k ± 0%     ~     (p=0.315 n=10+10)
Java/small-12                      2.46k ± 0%     2.46k ± 0%     ~     (all equal)
Java/small_imbalance-12            2.55k ± 0%     2.55k ± 0%     ~     (p=0.145 n=10+9)
```