### PR TITLE
check hooks and flatten slices of hooks

### DIFF
--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+////////////////////////////////////////////////////////////////
+// NOTE:                                                      //
+// NOTE: Make sure new hooks are checked in implementsAnyHook //
+// NOTE:                                                      //
+////////////////////////////////////////////////////////////////
+
 // Hook is a hook to be called when something happens in kgo.
 //
 // The base Hook interface is useless, but wherever a hook can occur in kgo,
@@ -355,4 +361,30 @@ type HookFetchRecordUnbuffered interface {
 	// "unbuffered" within the client, and whether the record is being
 	// returned from polling.
 	OnFetchRecordUnbuffered(r *Record, polled bool)
+}
+
+/////////////
+// HELPERS //
+/////////////
+
+// implementsAnyHook will check the incoming Hook for any Hook implementation
+func implementsAnyHook(h Hook) bool {
+	switch h.(type) {
+	case HookNewClient,
+		HookBrokerConnect,
+		HookBrokerDisconnect,
+		HookBrokerWrite,
+		HookBrokerRead,
+		HookBrokerE2E,
+		HookBrokerThrottle,
+		HookGroupManageError,
+		HookProduceBatchWritten,
+		HookFetchBatchRead,
+		HookProduceRecordBuffered,
+		HookProduceRecordUnbuffered,
+		HookFetchRecordBuffered,
+		HookFetchRecordUnbuffered:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Since `kgo.Hook` is an empty interface `[]kgo.Hook` also satisfies the empty interface which leads to silent failures if not passed to `kgo.WithHooks` properly.

```golang
kgo.WithHooks(hooks...) // works
kgo.WithHooks(hooks) // nothing called
```

By doing a little extra work inside of the config validation these mistakes can be fixed up or be turned into runtime errors.

Closes #365.