### PR TITLE
kgo: add ConsumeRecreatedTopics option, for UNKNOWN_TOPIC_ID

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -140,8 +140,9 @@ type cfg struct {
 	rack           string
 	preferLagFn    PreferLagFn
 
-	maxConcurrentFetches int
-	disableFetchSessions bool
+	maxConcurrentFetches   int
+	disableFetchSessions   bool
+	consumeRecreatedTopics bool
 
 	topics     map[string]*regexp.Regexp   // topics to consume; if regex is true, values are compiled regular expressions
 	partitions map[string]map[int32]Offset // partitions to directly consume from
@@ -610,7 +611,7 @@ func DialTimeout(timeout time.Duration) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.dialTimeout = timeout }}
 }
 
-// DialTLSConfig opts in to dialing brokers with the given TLS config with a
+// DialTLSConfig opts into dialing brokers with the given TLS config with a
 // 10s dial timeout. This is a shortcut for manually specifying a tls dialer
 // using the Dialer option. You can also change the default 10s timeout with
 // DialTimeout.
@@ -1276,7 +1277,7 @@ func ConsumeRegex() ConsumerOpt {
 //
 // A "fetch session" is is a way to reduce bandwidth for fetch requests &
 // responses, and to potentially reduce the amount of work that brokers have to
-// do to handle fetch requests. A fetch session opts in to the broker tracking
+// do to handle fetch requests. A fetch session opts into the broker tracking
 // some state of what the client is interested in. For example, say that you
 // are interested in thousands of topics, and most of these topics are
 // receiving data only rarely. A fetch session allows the client to register
@@ -1322,6 +1323,22 @@ func ConsumePreferringLagFn(fn PreferLagFn) ConsumerOpt {
 	return consumerOpt{func(cfg *cfg) { cfg.preferLagFn = fn }}
 }
 
+// ConsumeRecreatedTopics opts into consuming topics that are recreated in
+// Kafka 3.1+. Starting in 3.1, Kafka uses unique topic IDs when fetching, and
+// if you delete and recreate your topic while a consumer is active, the
+// consumer will begin failing because the topic ID has changed. This option
+// lets you opt into consuming the recreated topic.
+//
+// Internally, this option causes the client to purge the topic from the
+// consumer and then re-add it, which likely will cause rebalances for consumer
+// groups. As well, other consumers in the consumer group will independently
+// discover the topic ID has changed, so they will rejoin at different points.
+// These rejoins likely will all happen close together, but be aware there will
+// be a rebalance storm if you recreate your topic.
+func ConsumeRecreatedTopics() ConsumerOpt {
+	return consumerOpt{func(cfg *cfg) { cfg.consumeRecreatedTopics = true }}
+}
+
 //////////////////////////////////
 // CONSUMER GROUP CONFIGURATION //
 //////////////////////////////////
@@ -1348,7 +1365,7 @@ func ConsumerGroup(group string) GroupOpt {
 // For balancing, Kafka chooses the first protocol that all group members agree
 // to support.
 //
-// Note that if you opt in to cooperative-sticky rebalancing, cooperative group
+// Note that if you opt into cooperative-sticky rebalancing, cooperative group
 // balancing is incompatible with eager (classical) rebalancing and requires a
 // careful rollout strategy (see KIP-429).
 func Balancers(balancers ...GroupBalancer) GroupOpt {
@@ -1584,7 +1601,7 @@ func DisableAutoCommit() GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.autocommitDisable = true }}
 }
 
-// GreedyAutoCommit opts in to committing everything that has been polled when
+// GreedyAutoCommit opts into committing everything that has been polled when
 // autocommitting (the dirty offsets), rather than committing what has
 // previously been polled. This option may result in message loss if your
 // application crashes.

--- a/pkg/kgo/consumer_test.go
+++ b/pkg/kgo/consumer_test.go
@@ -1,0 +1,86 @@
+package kgo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/kversion"
+)
+
+func TestConsumeRecreated(t *testing.T) {
+	for _, group := range []string{"", "fill"} {
+		group := group
+		t.Run("group_"+group, func(t *testing.T) {
+			t.Parallel()
+
+			if group != "" {
+				randGroup, groupCleanup := tmpGroup(t)
+				defer groupCleanup()
+				group = randGroup
+			}
+
+			topic, cleanup := tmpTopic(t)
+			defer cleanup()
+
+			cl, _ := NewClient(
+				getSeedBrokers(),
+				DefaultProduceTopic(topic),
+				UnknownTopicRetries(-1),
+				ConsumeTopics(topic),
+				FetchMaxWait(time.Second),
+				ConsumeRecreatedTopics(),
+				ConsumerGroup(group),
+			)
+			defer cl.Close()
+
+			{
+				req := kmsg.NewPtrApiVersionsRequest()
+				resp, err := req.RequestWith(context.Background(), cl)
+				if err != nil {
+					t.Fatalf("unable to request api version: %v", err)
+				}
+				v := kversion.FromApiVersionsResponse(resp)
+				if max, ok := v.LookupMaxKeyVersion(1); !ok || max < 13 {
+					t.Skip("skipping test, the broker does not support topic IDs, so we consume the recreated topic by default and reset to the end with OffsetForLeaderEpoch")
+					return
+				}
+			}
+
+			produce := func() {
+				for {
+					err := cl.ProduceSync(context.Background(), StringRecord("foo")).FirstErr()
+					switch err {
+					case nil:
+						return
+					case errMissingMetadataPartition:
+					default:
+						t.Fatalf("produce failure, group %q: %v", group, err)
+					}
+				}
+			}
+
+			checkPoll := func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+
+				fs := cl.PollFetches(ctx)
+				if errs := fs.Errors(); len(errs) != 0 {
+					t.Fatalf("consume failure, group %q: %v", group, errs)
+				}
+				recs := fs.Records()
+				if len(recs) != 1 || string(recs[0].Value) != "foo" {
+					t.Fatalf("consume records incorrect, group %q: %v", group, recs)
+				}
+			}
+
+			produce()
+			checkPoll()
+			cleanup()
+			tmpNamedTopic(t, topic)
+			produce()
+			checkPoll()
+		})
+	}
+}

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -164,6 +164,8 @@ var (
 	// Returned for all buffered produce records when a user purges topics.
 	errPurged = errors.New("topic purged while buffered")
 
+	errMissingMetadataPartition = errors.New("metadata update is missing a partition that we were previously using")
+
 	//////////////
 	// EXTERNAL //
 	//////////////

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -712,7 +712,7 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 		s.session.reset()
 		return
 
-	case kerr.FetchSessionTopicIDError, kerr.UnknownTopicID, kerr.InconsistentTopicID:
+	case kerr.FetchSessionTopicIDError, kerr.InconsistentTopicID:
 		s.cl.cfg.logger.Log(LogLevelInfo, "topic id issues, resetting session and updating metadata", "broker", logID(s.nodeID), "err", err)
 		s.session.reset()
 		s.cl.triggerUpdateMetadataNow("topic id issues")
@@ -860,7 +860,11 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				// the topic has been recreated and we will never
 				// consume the topic again anymore. This is an error
 				// worth bubbling up.
-				keep = true
+				if s.cl.cfg.consumeRecreatedTopics {
+					s.cl.consumer.reloadUnknownTopicID(topic)
+				} else {
+					keep = true
+				}
 
 			case kerr.OffsetOutOfRange:
 				// If we are out of range, we reset to what we can.


### PR DESCRIPTION
FOR CONSUMING

This is a bit of an involved change for consuming, but overall, it works as it says on the tin.

FOR PRODUCING

We cannot have this same type of logic in the producer until produce requests support topic IDs. As well, the producer will be more complicated -- we will need to worry about ordering issues. So, we avoid doing anything for producers until the day comes.

For now, if a person recreates a topic, the person will most likely receive an OutOfOrderSequenceNumber error which looks like data loss.

If a person recreates a topic with fewer partitions, the partitions that were deleted now have all records failed on them (and are no longer considered writeable). The client will enter a state of permanently failing any record that is consistently hashed to the old partition, and permanently trying to reload metadata. The best fix is for the user to purge the deleted topic from the client.

A more involved, more complicated, better change would be to react to the topic ID changing within the metadata loop, but that requires some more complicated changes such as making the topic ID atomic, and there are race conditions that frankly aren't worth diving into at the moment (we need to track current and last topic ID -- this was initially the approach I was taking for consuming, but it's not needed there, but it is needed for producing).

Closes #358.