### PR TITLE
Fencepost error in pushAndValidate

### DIFF
--- a/pkg/kfake/pid.go
+++ b/pkg/kfake/pid.go
@@ -75,7 +75,7 @@ func (seqs *pidseqs) pushAndValidate(firstSeq, numRecs int32) (ok, dup bool) {
 	var (
 		seq    = firstSeq
 		seq64  = int64(seq)
-		next64 = (seq64 + int64(numRecs) + 1) % math.MaxInt32
+		next64 = (seq64 + int64(numRecs)) % math.MaxInt32
 		next   = int32(next64)
 	)
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
If we have n records starting at m, then next record we expect to see after that should be n+m, not n+m+1.