### PR TITLE
Be totally lenient with correlation IDs

### DIFF
--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -160,9 +160,11 @@ type clientReq struct {
 	cc   *clientConn
 	kreq kmsg.Request
 	at   time.Time
+	corr int32
 }
 type clientResp struct {
 	kresp kmsg.Response
+	corr  int32
 	err   error
 }
 
@@ -218,7 +220,7 @@ func (c *Cluster) run() {
 		}
 
 		select {
-		case creq.cc.respCh <- clientResp{kresp: kresp, err: err}:
+		case creq.cc.respCh <- clientResp{kresp: kresp, corr: creq.corr, err: err}:
 		case <-c.die:
 			return
 		}


### PR DESCRIPTION
Clients can, (and do - cf the SASL reserved correlation IDs in Kafka's client) do basically anything they like with these, so just reflect back the request's value.