### PR TITLE
Fix producer ids; fix searchOffset

### DIFF
--- a/pkg/kfake/data.go
+++ b/pkg/kfake/data.go
@@ -106,7 +106,7 @@ func (pd *partData) searchOffset(o int64) (index int, found bool, atEnd bool) {
 	}
 
 	index, found = slices.BinarySearchFunc(pd.batches, o, func(b partBatch, o int64) int {
-		if b.FirstOffset+int64(b.NumRecords) < o {
+		if b.FirstOffset+int64(b.NumRecords) <= o {
 			return -1
 		}
 		if b.FirstOffset > o {

--- a/pkg/kfake/pid.go
+++ b/pkg/kfake/pid.go
@@ -52,10 +52,10 @@ func (pids *pids) create(txnalID *string) pid {
 	if txnalID != nil {
 		hasher := fnv.New64()
 		hasher.Write([]byte(*txnalID))
-		id = int64(hasher.Sum64())
+		id = int64(hasher.Sum64()) & math.MaxInt64
 	} else {
 		for {
-			id = int64(rand.Uint64())
+			id = int64(rand.Uint64()) & math.MaxInt64
 			if _, exists := (*pids)[id]; !exists {
 				break
 			}


### PR DESCRIPTION
A couple of small fixes:

Producer IDs should always be positive.

SearchOffset had an off-by-one error looking for the appropriate batch.