### PR TITLE
kgo: bugfix transaction ending & beginning

### DIFF
--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -1015,6 +1015,8 @@ func (p *producer) maybeAddInflight() bool {
 
 func (p *producer) decInflight() {
 	if p.inflight.Add(-1)>>48 > 0 {
+		p.mu.Lock()
+		p.mu.Unlock() //nolint:gocritic,staticcheck // We use the lock as a barrier, unlocking immediately is safe.
 		p.c.Broadcast()
 	}
 }

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -398,7 +398,7 @@ func (s *sink) doSequenced(
 		wait.br = br
 	}
 
-	if first, _ := s.seqResps.push(wait); first {
+	if first := s.seqResps.push(wait); first {
 		go s.handleSeqResps(wait)
 	}
 }
@@ -410,7 +410,7 @@ start:
 	<-wait.done
 	wait.promise(wait.br, wait.resp, wait.err)
 
-	wait, more, _ = s.seqResps.dropPeek()
+	wait, more = s.seqResps.dropPeek()
 	if more {
 		goto start
 	}


### PR DESCRIPTION
Not having a mutext lock & unlock caused a race where a transaction could
1 A call .pause to pause inflight
2 A that could load that there _are_ inflight requests 3 B inflight could finish and broadcast
4 A could then signal.Wait
The broadcast needed to trigger the wait in step 4, but the broadcast already happened because there was no lock.

Also removes some redundant returns that made some aspects of seqRingResp confusing.