### PR TITLE
Fix for segment benchmark

### DIFF
--- a/examples/bench/compare/segment/main.go
+++ b/examples/bench/compare/segment/main.go
@@ -137,6 +137,7 @@ func main() {
 			Brokers:         brokers,
 			Topic:           *topic,
 			ReadLagInterval: -1,
+			CommitInterval:  time.Second * 5,
 		}
 		if *group != "" {
 			cfg.GroupID = *group


### PR DESCRIPTION
This PR enables async commits to have a fair comparison with franz-go.
