### PR TITLE
group consuming: block LeaveGroup between join&sync

### DIFF
--- a/pkg/kgo/txn_test.go
+++ b/pkg/kgo/txn_test.go
@@ -170,7 +170,7 @@ func (c *testConsumer) transact(txnsBeforeQuit int) {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		fetches := txnSess.PollFetches(ctx)
 		cancel()
-		if fetches.Err() == context.DeadlineExceeded || fetches.Err() == ErrClientClosed {
+		if err := fetches.Err(); err == context.DeadlineExceeded || err == context.Canceled || err == ErrClientClosed {
 			if consumed := int(c.consumed.Load()); consumed == testRecordLimit {
 				return
 			} else if consumed > testRecordLimit {


### PR DESCRIPTION
An extension of the prior patches -- LeaveGroup would quit join or sync, but the requests could be in flight and result in a final commit error. We need to wait for join&sync to finish before LeaveGroup succeeds.

This may block shutdown a bit.