### PR TITLE
kgo: avoiding context.Canceled fetch from List/Epoch, improve testing&logs

### DIFF
--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -93,6 +93,10 @@ func isDialErr(err error) bool {
 	return errors.As(err, &ne) && ne.Op == "dial"
 }
 
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
 func isSkippableBrokerErr(err error) bool {
 	// Some broker errors are not retryable for the given broker itself,
 	// but we *could* skip the broker and try again on the next broker. For
@@ -106,9 +110,7 @@ func isSkippableBrokerErr(err error) bool {
 		return true
 	}
 	var ne *net.OpError
-	if errors.As(err, &ne) &&
-		!errors.Is(err, context.Canceled) &&
-		!errors.Is(err, context.DeadlineExceeded) {
+	if errors.As(err, &ne) && !isContextErr(err) {
 		return true
 	}
 	return false

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -159,6 +159,11 @@ issue:
 	return topic, func() {
 		tb.Helper()
 
+		if tb.Failed() {
+			tb.Logf("FAILED TESTING -- NOT DELETING TOPIC %s", topic)
+			return
+		}
+
 		tb.Logf("deleting topic %s", topic)
 
 		req := kmsg.NewPtrDeleteTopicsRequest()
@@ -184,6 +189,11 @@ func tmpGroup(tb testing.TB) (string, func()) {
 
 	return group, func() {
 		tb.Helper()
+
+		if tb.Failed() {
+			tb.Logf("FAILED TESTING -- NOT DELETING GROUP %s", group)
+			return
+		}
 		tb.Logf("deleting group %s", group)
 
 		req := kmsg.NewPtrDeleteGroupsRequest()
@@ -273,8 +283,6 @@ func testChainETL(
 	transactional bool,
 	balancer GroupBalancer,
 ) {
-	t.Helper()
-
 	var (
 		/////////////
 		// LEVEL 1 //


### PR DESCRIPTION
It was possible to inject a context.Canceled error into a fetch by 1) assignPartitions stops a session
2) stopping a session cancels the context
3) canceling the context kills list/epoch inflight requests 4) error injected into a fetch response
5) user polls
6) stopping session finally strips any old fetches, but they were
   already drained

We now avoid injecting a context.Canceled or context.DeadlineExceeded error. The other two possible injected errors are still relevant (data loss, group management problem).

This also:
* Adds debug logs for the prior join&sync vs. commit blocking behavior
* Adds an info log for injected errors
* Removes the internal offsetEpoch in favor of the exported EpochOffset, meaning existing debug logs now use the same order consistently
* Avoids deleting topics/groups when a test failure happens so they can be inspected
* Changes tests to error if a fetch with context.Canceled or context.DeadlineExceeded _also_ has records that could be processed