### PR TITLE
kgo: purge missing-from-meta topics while regex consuming

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -23,17 +23,18 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.1
+          go-version: 1.20.3
       - uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout=5m
 
   integration-test-kafka:
     if: github.repository == 'twmb/franz-go'
     needs: golangci
     runs-on: ubuntu-latest
     name: "integration test kafka"
-    container: golang:1.20.1
+    container: golang:1.20.3
     services:
       kafka:
         image: bitnami/kafka:latest
@@ -48,7 +49,7 @@ jobs:
           KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
           # Set this to "PLAINTEXT://127.0.0.1:9092" if you want to run this container on localhost via Docker
           KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-          KAFKA_CFG_BROKER_ID: 1
+          KAFKA_CFG_NODE_ID: 1
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_KRAFT_CLUSTER_ID: XkpGZQ27R3eTl3OdTm2LYA # 16 byte base64-encoded UUID
     steps:
@@ -65,7 +66,7 @@ jobs:
     needs: golangci
     runs-on: ubuntu-latest
     name: "integration test redpanda"
-    container: golang:1.20.1
+    container: golang:1.20.3
     services:
       redpanda:
         image: vectorized/redpanda-nightly:latest

--- a/pkg/kgo/consumer_direct_test.go
+++ b/pkg/kgo/consumer_direct_test.go
@@ -2,10 +2,13 @@ package kgo
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
 
+// Allow adding a topic to consume after the client is initialized with nothing
+// to consume.
 func TestIssue325(t *testing.T) {
 	t.Parallel()
 
@@ -17,6 +20,8 @@ func TestIssue325(t *testing.T) {
 		DefaultProduceTopic(topic),
 		UnknownTopicRetries(-1),
 	)
+	defer cl.Close()
+
 	if err := cl.ProduceSync(context.Background(), StringRecord("foo")).FirstErr(); err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +35,7 @@ func TestIssue325(t *testing.T) {
 	}
 }
 
+// Ensure we only consume one partition if we only ask for one partition.
 func TestIssue337(t *testing.T) {
 	t.Parallel()
 
@@ -45,6 +51,7 @@ func TestIssue337(t *testing.T) {
 			topic: {0: NewOffset().At(0)},
 		}),
 	)
+	defer cl.Close()
 
 	if err := cl.ProduceSync(context.Background(),
 		&Record{Partition: 0, Value: []byte("foo")},
@@ -91,6 +98,7 @@ func TestDirectPartitionPurge(t *testing.T) {
 			topic: {0: NewOffset().At(0)},
 		}),
 	)
+	defer cl.Close()
 
 	if err := cl.ProduceSync(context.Background(),
 		&Record{Partition: 0, Value: []byte("foo")},
@@ -130,5 +138,64 @@ func TestDirectPartitionPurge(t *testing.T) {
 	}
 	if len(exp) > 0 {
 		t.Errorf("did not see expected values %v", exp)
+	}
+}
+
+// Ensure a deleted topic while regex consuming is no longer fetched.
+func TestIssue434(t *testing.T) {
+	t.Parallel()
+
+	var (
+		t1, cleanup1 = tmpTopicPartitions(t, 1)
+		t2, cleanup2 = tmpTopicPartitions(t, 1)
+	)
+	defer cleanup1()
+	defer cleanup2()
+
+	cl, _ := NewClient(
+		getSeedBrokers(),
+		UnknownTopicRetries(-1),
+		ConsumeTopics(fmt.Sprintf("(%s|%s)", t1, t2)),
+		ConsumeRegex(),
+		FetchMaxWait(100*time.Millisecond),
+		keepFetchRetryableErrors(),
+	)
+	defer cl.Close()
+
+	if err := cl.ProduceSync(context.Background(),
+		&Record{Topic: t1, Value: []byte("t1")},
+		&Record{Topic: t2, Value: []byte("t2")},
+	).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	cleanup2()
+
+	// This test is a slight heuristic check test. We are keeping retryable
+	// errors, so if the purge is successful, then we expect no response
+	// and we expect the fetch to just contain context.DeadlineExceeded.
+	//
+	// We can get the topic in the response for a little bit if our fetch
+	// is fast enough, so we ignore any errors (UNKNOWN_TOPIC_ID) at the
+	// start. We want to ensure the topic is just outright missing from
+	// the response because that will mean it is internally purged.
+	start := time.Now()
+	var missingTopic int
+	for missingTopic < 2 {
+		if time.Since(start) > 2*time.Second {
+			t.Fatal("still seeing topic after 2s")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		fs := cl.PollFetches(ctx)
+		cancel()
+		var foundTopic bool
+		fs.EachTopic(func(ft FetchTopic) {
+			if ft.Topic == t2 {
+				foundTopic = true
+			}
+		})
+		if !foundTopic {
+			missingTopic++
+		}
 	}
 }

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -156,8 +156,14 @@ issue:
 		tb.Fatalf("unable to create topic %q: %v", topic, err)
 	}
 
+	var cleaned bool
 	return topic, func() {
 		tb.Helper()
+
+		if cleaned {
+			return
+		}
+		cleaned = true
 
 		if tb.Failed() {
 			tb.Logf("FAILED TESTING -- NOT DELETING TOPIC %s", topic)


### PR DESCRIPTION
While regex consuming, if a topic is deleted, we previously would forever continue to try fetching it. Now, if a topic is missing from a metadata response, we internally purge it.

We delete immediately with the assumption that once a topic is discovered, there is enough broker consensus that it will not be somehow accidentally missing on the next metadata update -- i.e., if a topic is missing, it's definitely deleted.

We only do this for regex consuming; for non-regex, the assumption is that if you specify topics to consume, you want them. If they are missing in a metadata response, we will continue to try to update the metadata even if the topic was deleted (and we will continue trying to fetch).

Closes #434