### PR TITLE
kadm: Fix AllFailed check in FetchOffsetsResponses

### DIFF
--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -902,7 +902,7 @@ func (rs FetchOffsetsResponses) EachError(fn func(FetchOffsetsResponse)) {
 func (rs FetchOffsetsResponses) AllFailed() bool {
 	var n int
 	rs.EachError(func(FetchOffsetsResponse) { n++ })
-	return n == len(rs)
+	return len(rs) > 0 && n == len(rs)
 }
 
 // CommittedPartitions returns the set of unique topics and partitions that


### PR DESCRIPTION
When requesting many offsets without specifying any group, you'd expect zero responses. In that case the existing logic will yield true for AllFailed().