### PR TITLE
kotel: Update span operation name from 'send' to 'publish'

### DIFF
--- a/examples/hooks_and_logging/plugin_kotel/README.md
+++ b/examples/hooks_and_logging/plugin_kotel/README.md
@@ -9,7 +9,7 @@ records and extracted from consume records. The following spans will be linked
 with a trace ID:
 
 1) request
-2) topic send
+2) topic publish
 3) topic receive
 4) topic process
 

--- a/plugin/kotel/README.md
+++ b/plugin/kotel/README.md
@@ -19,12 +19,12 @@ franz-go projects.
 
 kotel provides tracing capabilities for Kafka using OpenTelemetry
 specifications. It allows for the creation of three different span
-operations: "send", "receive", and "process". Additionally, it also provides a
-set of attributes to use with these spans.
+operations: "publish", "receive", and "process". Additionally, it also provides
+a set of attributes to use with these spans.
 
 ### How it works
 
-The kotel tracer module uses hooks to automatically create and close "send"
+The kotel tracer module uses hooks to automatically create and close "publish"
 and "receive" spans as a `kgo.Record` flows through the application. However,
 for the "process" span, it uses a convenience method that must be manually
 invoked and closed in the consumer code to capture processing.
@@ -34,8 +34,8 @@ span operations:
 
 | Order | Hook/Method                     | Operation | State |
 |-------|---------------------------------|-----------|-------|
-| 1     | kgo.HookProduceRecordBuffered   | Send      | Start |
-| 2     | kgo.HookProduceRecordUnbuffered | Send      | End   |
+| 1     | kgo.HookProduceRecordBuffered   | Publish   | Start |
+| 2     | kgo.HookProduceRecordUnbuffered | Publish   | End   |
 | 3     | kgo.HookFetchRecordBuffered     | Receive   | Start |
 | 4     | kgo.HookFetchRecordUnbuffered   | Receive   | End   |
 | 5     | kotel.Tracer.WithProcessSpan    | Process   | Start |

--- a/plugin/kotel/tracer.go
+++ b/plugin/kotel/tracer.go
@@ -151,7 +151,7 @@ func (t *Tracer) WithProcessSpan(r *kgo.Record) (context.Context, trace.Span) {
 
 // Hooks ----------------------------------------------------------------------
 
-// OnProduceRecordBuffered starts a new span for the "send" operation on a
+// OnProduceRecordBuffered starts a new span for the "publish" operation on a
 // buffered record.
 //
 // It sets span options and injects the span context into record and updates
@@ -163,6 +163,7 @@ func (t *Tracer) OnProduceRecordBuffered(r *kgo.Record) {
 		semconv.MessagingSystemKey.String("kafka"),
 		semconv.MessagingDestinationKindTopic,
 		semconv.MessagingDestinationName(r.Topic),
+		semconv.MessagingOperationPublish,
 	}
 	attrs = t.maybeKeyAttr(attrs, r)
 	if t.clientID != "" {
@@ -172,19 +173,19 @@ func (t *Tracer) OnProduceRecordBuffered(r *kgo.Record) {
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindProducer),
 	}
-	// Start the "send" span.
-	ctx, _ := t.tracer.Start(r.Context, r.Topic+" send", opts...)
+	// Start the "publish" span.
+	ctx, _ := t.tracer.Start(r.Context, r.Topic+" publish", opts...)
 	// Inject the span context into the record.
 	t.propagators.Inject(ctx, NewRecordCarrier(r))
 	// Update the record context.
 	r.Context = ctx
 }
 
-// OnProduceRecordUnbuffered continues and ends the "send" span for an
+// OnProduceRecordUnbuffered continues and ends the "publish" span for an
 // unbuffered record.
 //
 // It sets attributes with values unset when producing and records any error
-// that occurred during the send operation.
+// that occurred during the publish operation.
 func (t *Tracer) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 	span := trace.SpanFromContext(r.Context)
 	defer span.End()


### PR DESCRIPTION
Building on PR #449, this PR follows the new messaging semantic by renaming the span operation for producing from 'send' to 'publish'.