### PR TITLE
kgo: fix race condition when closing the client

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -948,7 +948,7 @@ func (cl *Client) Close() {
 
 	sessCloseCtx, sessCloseCancel := context.WithTimeout(cl.ctx, time.Second)
 	var wg sync.WaitGroup
-	for _, sns := range cl.sinksAndSources {
+	cl.allSinksAndSources(func(sns sinkAndSource) {
 		if sns.source.session.id != 0 {
 			sns := sns
 			wg.Add(1)
@@ -957,7 +957,7 @@ func (cl *Client) Close() {
 				sns.source.killSessionOnClose(sessCloseCtx)
 			}()
 		}
-	}
+	})
 	wg.Wait()
 	sessCloseCancel()
 


### PR DESCRIPTION
There seems to be a race condition between `NewClient` and `Close`:

```
WARNING: DATA RACE
Read at 0x00c000783fb0 by goroutine 192:
  runtime.mapiterinit()
      /opt/hostedtoolcache/go/1.20.3/x64/src/runtime/map.go:815 +0x0
  github.com/twmb/franz-go/pkg/kgo.(*Client).Close()
      /home/runner/go/pkg/mod/github.com/twmb/franz-go@v1.13.3/pkg/kgo/client.go:951 +0x2ad
  github.com/firebolt-analytics/services/pkg/gootstrap/gateways/kafka/kafkaconsumer.(*consumerImpl).Run.func1()
      /home/runner/work/services/services/pkg/gootstrap/gateways/kafka/kafkaconsumer/consumer.go:104 +0x48
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.20.3/x64/src/runtime/panic.go:476 +0x32
  github.com/firebolt-analytics/services/pkg/gootstrap/orchestrator.executeRunners.func1()
      /home/runner/work/services/services/pkg/gootstrap/orchestrator/orchestrator.go:107 +0x73
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/runner/go/pkg/mod/golang.org/x/sync@v0.2.0/errgroup/errgroup.go:75 +0x82

Previous write at 0x00c000783fb0 by goroutine 79:
  runtime.mapassign_fast32()
      /opt/hostedtoolcache/go/1.20.3/x64/src/runtime/map_fast32.go:93 +0x0
  github.com/twmb/franz-go/pkg/kgo.(*Client).fetchTopicMetadata()
      /home/runner/go/pkg/mod/github.com/twmb/franz-go@v1.13.3/pkg/kgo/metadata.go:598 +0xd8b
  github.com/twmb/franz-go/pkg/kgo.(*Client).updateMetadata()
      /home/runner/go/pkg/mod/github.com/twmb/franz-go@v1.13.3/pkg/kgo/metadata.go:332 +0x2f7
  github.com/twmb/franz-go/pkg/kgo.(*Client).updateMetadataLoop()
      /home/runner/go/pkg/mod/github.com/twmb/franz-go@v1.13.3/pkg/kgo/metadata.go:227 +0x8c4
  github.com/twmb/franz-go/pkg/kgo.NewClient.func8()
      /home/runner/go/pkg/mod/github.com/twmb/franz-go@v1.13.3/pkg/kgo/client.go:508 +0x39
```