### PR TITLE
kotel: add fetch_records.count and produce_records.count metrics

### DIFF
--- a/plugin/kotel/README.md
+++ b/plugin/kotel/README.md
@@ -152,7 +152,9 @@ messaging.kafka.write_bytes{node_id = "#{node}"}
 messaging.kafka.read_errors.count{node_id = "#{node}"}
 messaging.kafka.read_bytes.count{node_id = "#{node}"}
 messaging.kafka.produce_bytes.count{node_id = "#{node}", topic = "#{topic}"}
+messaging.kafka.produce_records.count{node_id = "#{node}", topic = "#{topic}"}
 messaging.kafka.fetch_bytes.count{node_id = "#{node}", topic = "#{topic}"}
+messaging.kafka.fetch_records.count{node_id = "#{node}", topic = "#{topic}"}
 ```
 
 ### Getting started


### PR DESCRIPTION
We are considering switching to this awesome library in our company from sarama.
We are currently visualizing the throughput of consumers and producers by the number of records they consume and produce.
While the number of bytes gives a good indication of the throughput, I think that adding the number of messages in the default metrics would be a good addition, as together with the number of bytes would paint a more complete picture on the throughput. 