### PR TITLE
sasl plain: ignore any challenge data

### DIFF
--- a/pkg/sasl/plain/plain.go
+++ b/pkg/sasl/plain/plain.go
@@ -3,7 +3,6 @@ package plain
 
 import (
 	"context"
-	"errors"
 
 	"github.com/twmb/franz-go/pkg/sasl"
 )
@@ -53,8 +52,5 @@ func (fn plain) Authenticate(ctx context.Context, _ string) (sasl.Session, []byt
 type session struct{}
 
 func (session) Challenge(resp []byte) (bool, []byte, error) {
-	if len(resp) != 0 {
-		return false, nil, errors.New("unexpected data in plain response")
-	}
 	return true, nil, nil
 }


### PR DESCRIPTION
Tencent apparently returns some data in the response to PLAIN authentication. Sarama just ignores the data. RFC4616 does not mention a server response (any challenge). RFC4422 secion 5b specifies valid mechanisms should indicate whether the server is expected to provide additional data indicating a successful outcome. RFC4616 does not indicate this. So, it's not clear why Tencent is sending this data, but again, we can just ignore it.