### PR TITLE
Serde Header

### DIFF
--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -191,8 +191,11 @@ func (s *Serde) Register(id int, v any, opts ...SerdeOpt) {
 		}
 		return j
 	}
+	myDepth := len(t.index)
 	for i, idx := range t.index {
-		at.subindexDepth = max(at.subindexDepth, len(t.index)-i)
+		// SAFETY: tserdeMapClone deeply clones all maps through the index, so
+		// our modified value is being saved to a new map that is not being read.
+		at.subindexDepth = max(at.subindexDepth, myDepth-i)
 		m[k] = at
 
 		m = at.subindex

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -421,6 +421,9 @@ func (ConfluentHeader) DecodeIndex(b []byte, maxLength int) ([]int, []byte, erro
 	if l == 0 { // length 0 is a shortcut for length 1, index 0
 		return []int{0}, buf.Bytes(), nil
 	}
+	if l < 0 { // index length can't be negative
+		return nil, nil, ErrBadHeader
+	}
 	if maxLength > 0 && int(l) > maxLength { // index count is greater than expected
 		return nil, nil, ErrNotRegistered
 	}

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -131,7 +131,7 @@ func (s *Serde) SetDefaults(opts ...SerdeOpt) {
 	s.defaults = opts
 }
 
-// DecodeID decodes an ID from in, returning the ID and the remaining bytes,
+// DecodeID decodes an ID from b, returning the ID and the remaining bytes,
 // or an error.
 func (s *Serde) DecodeID(b []byte) (id int, out []byte, err error) {
 	return s.header().DecodeID(b)

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -185,18 +185,19 @@ func (s *Serde) Register(id int, v any, opts ...SerdeOpt) {
 	k := id
 	m := dupIDs
 	at := dupIDs[k]
+	depth := len(t.index)
 	max := func(i, j int) int {
 		if i > j {
 			return i
 		}
 		return j
 	}
-	myDepth := len(t.index)
-	for i, idx := range t.index {
+	for _, idx := range t.index {
 		// SAFETY: tserdeMapClone deeply clones all maps through the index, so
 		// our modified value is being saved to a new map that is not being read.
-		at.subindexDepth = max(at.subindexDepth, myDepth-i)
+		at.subindexDepth = max(at.subindexDepth, depth)
 		m[k] = at
+		depth--
 
 		m = at.subindex
 		k = idx

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -370,8 +370,8 @@ func (ConfluentHeader) AppendEncode(b []byte, id int, index []int) ([]byte, erro
 			b = append(b, 0) // first-index shortcut (one type in the protobuf)
 		} else {
 			b = binary.AppendVarint(b, int64(len(index)))
-			for i := len(index) - 1; i >= 0; i-- {
-				b = binary.AppendVarint(b, int64(index[i]))
+			for _, idx := range index {
+				b = binary.AppendVarint(b, int64(idx))
 			}
 		}
 	}
@@ -403,14 +403,13 @@ func (c ConfluentHeader) DecodeIndex(b []byte) ([]int, []byte, error) {
 		return []int{0}, buf.Bytes(), nil
 	}
 	index := make([]int, l)
-	for l > 0 {
+	for i := 0; i < int(l); i++ {
 		var idx int64
 		idx, err = binary.ReadVarint(buf)
 		if err != nil {
 			return nil, nil, err
 		}
-		index[l-1] = int(idx) // index is stored last to first
-		l--
+		index[i] = int(idx)
 	}
 	return index, buf.Bytes(), nil
 }

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -352,8 +352,14 @@ func (s *Serde) decodeFind(b []byte) ([]byte, tserde, error) {
 
 // SerdeHeader encodes and decodes a message header.
 type SerdeHeader interface {
+	// AppendEncode encodes a schema ID and optional index to b, returning the
+	// updated slice or an error.
 	AppendEncode(b []byte, id int, index []int) ([]byte, error)
+	// DecodeID decodes an ID from in, returning the ID and the remaining bytes,
+	// or an error.
 	DecodeID(in []byte) (id int, out []byte, err error)
+	// DecodeIndex decodes at most maxLength of a schema index from in,
+	// returning the index and remaining bytes, or an error.
 	DecodeIndex(in []byte, maxLength int) (index []int, out []byte, err error)
 }
 

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -403,9 +403,8 @@ func (c ConfluentHeader) DecodeIndex(b []byte) ([]int, []byte, error) {
 		return []int{0}, buf.Bytes(), nil
 	}
 	index := make([]int, l)
-	for i := 0; i < int(l); i++ {
-		var idx int64
-		idx, err = binary.ReadVarint(buf)
+	for i := range index {
+		idx, err := binary.ReadVarint(buf)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -382,7 +382,7 @@ func (ConfluentHeader) AppendEncode(b []byte, id int, index []int) ([]byte, erro
 // DecodeID strips and decodes the schema ID from b. It returns the ID alongside
 // the unread bytes. If the header does not contain the magic byte or b contains
 // less than 5 bytes it returns ErrBadHeader.
-func (c ConfluentHeader) DecodeID(b []byte) (int, []byte, error) {
+func (ConfluentHeader) DecodeID(b []byte) (int, []byte, error) {
 	if len(b) < 5 || b[0] != 0 {
 		return 0, nil, ErrBadHeader
 	}
@@ -393,7 +393,7 @@ func (c ConfluentHeader) DecodeID(b []byte) (int, []byte, error) {
 // DecodeIndex strips and decodes the index from b. It returns the index
 // alongside the unread bytes. It expects b to be the output of DecodeID (schema
 // ID should already be stripped away).
-func (c ConfluentHeader) DecodeIndex(b []byte) ([]int, []byte, error) {
+func (ConfluentHeader) DecodeIndex(b []byte) ([]int, []byte, error) {
 	buf := bytes.NewBuffer(b)
 	l, err := binary.ReadVarint(buf)
 	if err != nil {

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -131,12 +131,6 @@ func (s *Serde) SetDefaults(opts ...SerdeOpt) {
 	s.defaults = opts
 }
 
-// SetHeader configures which header should be used when encoding and decoding
-// values. If the header is set to nil it falls back to confluentHeader.
-func (s *Serde) SetHeader(header SerdeHeader) {
-	s.header = header
-}
-
 // Header returns the configured header.
 func (s *Serde) Header() SerdeHeader {
 	if s.header == nil {

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -83,7 +83,7 @@ func TestSerde(t *testing.T) {
 		},
 		{
 			enc:    idx4{Bingo: "bango"},
-			expEnc: append([]byte{0, 0, 0, 0, 3, 6, 2, 0, 0}, `{"bingo":"bango"}`...),
+			expEnc: append([]byte{0, 0, 0, 0, 3, 6, 0, 0, 2}, `{"bingo":"bango"}`...),
 		},
 		{
 			enc:    oneidx{Bar: "bar"},
@@ -152,7 +152,7 @@ func TestConfluentHeader(t *testing.T) {
 		{id: 256, index: nil, expEnc: []byte{0, 0, 0, 1, 0}},
 		{id: 2, index: []int{0}, expEnc: []byte{0, 0, 0, 0, 2, 0}},
 		{id: 3, index: []int{1}, expEnc: []byte{0, 0, 0, 0, 3, 2, 2}},
-		{id: 4, index: []int{1, 2, 3}, expEnc: []byte{0, 0, 0, 0, 4, 6, 6, 4, 2}},
+		{id: 4, index: []int{1, 2, 3}, expEnc: []byte{0, 0, 0, 0, 4, 6, 2, 4, 6}},
 	} {
 		b, err := h.AppendEncode(nil, test.id, test.index)
 		if err != nil {

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -144,7 +144,7 @@ func TestSerde(t *testing.T) {
 }
 
 func TestConfluentHeader(t *testing.T) {
-	var h ConfluentHeader
+	var h confluentHeader
 
 	for i, test := range []struct {
 		id     int

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -83,7 +83,7 @@ func TestSerde(t *testing.T) {
 		},
 		{
 			enc:    idx4{Bingo: "bango"},
-			expEnc: append([]byte{0, 0, 0, 0, 3, 6, 0, 0, 2}, `{"bingo":"bango"}`...),
+			expEnc: append([]byte{0, 0, 0, 0, 3, 6, 2, 0, 0}, `{"bingo":"bango"}`...),
 		},
 		{
 			enc:    oneidx{Bar: "bar"},
@@ -137,5 +137,75 @@ func TestSerde(t *testing.T) {
 	}
 	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 99}); err != ErrNotRegistered {
 		t.Errorf("got %v != exp ErrNotRegistered", err)
+	}
+}
+
+func TestConfluentHeader(t *testing.T) {
+	var h ConfluentHeader
+
+	for i, test := range []struct {
+		id     int
+		index  []int
+		expEnc []byte
+	}{
+		{id: 1, index: nil, expEnc: []byte{0, 0, 0, 0, 1}},
+		{id: 256, index: nil, expEnc: []byte{0, 0, 0, 1, 0}},
+		{id: 2, index: []int{0}, expEnc: []byte{0, 0, 0, 0, 2, 0}},
+		{id: 3, index: []int{1}, expEnc: []byte{0, 0, 0, 0, 3, 2, 2}},
+		{id: 4, index: []int{1, 2, 3}, expEnc: []byte{0, 0, 0, 0, 4, 6, 6, 4, 2}},
+	} {
+		b, err := h.AppendEncode(nil, test.id, test.index)
+		if err != nil {
+			t.Errorf("#%d AppendEncode: got unexpected err %v", i, err)
+			continue
+		}
+		if !bytes.Equal(b, test.expEnc) {
+			t.Errorf("#%d: AppendEncode(%v) != exp(%v)", i, b, test.expEnc)
+			continue
+		}
+
+		if b2, _ := h.AppendEncode([]byte("foo"), test.id, test.index); !bytes.Equal(b2, append([]byte("foo"), b...)) {
+			t.Errorf("#%d got AppendEncode(%v) != AppendEncode(foo%v)", i, b2, b)
+		}
+
+		id, b2, err := h.DecodeID(b)
+		if err != nil {
+			t.Errorf("#%d DecodeID: got unexpected err %v", i, err)
+			continue
+		}
+		if id != test.id {
+			t.Errorf("#%d: DecodeID: id(%v) != exp(%v)", i, id, test.id)
+			continue
+		}
+		if test.index == nil && len(b2) != 0 {
+			t.Errorf("#%d: DecodeID: bytes(%v) != exp([])", i, b2)
+			continue
+		}
+
+		if test.index != nil {
+			index, b3, err := h.DecodeIndex(b2)
+			if err != nil {
+				t.Errorf("#%d DecodeIndex: got unexpected err %v", i, err)
+				continue
+			}
+			if !reflect.DeepEqual(index, test.index) {
+				t.Errorf("#%d: DecodeIndex: index(%v) != exp(%v)", i, index, test.index)
+				continue
+			}
+			if len(b3) != 0 {
+				t.Errorf("#%d: DecodeIndex: bytes(%v) != exp([])", i, b3)
+				continue
+			}
+		}
+	}
+
+	if _, _, err := h.DecodeID([]byte{1, 0, 0, 0, 0, 1}); err != ErrBadHeader {
+		t.Errorf("got %v != exp ErrBadHeader", err)
+	}
+	if _, _, err := h.DecodeID([]byte{0, 0, 0, 0}); err != ErrBadHeader {
+		t.Errorf("got %v != exp ErrBadHeader", err)
+	}
+	if _, _, err := h.DecodeIndex([]byte{2}); err != io.EOF {
+		t.Errorf("got %v != exp io.EOF", err)
 	}
 }

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -135,6 +135,9 @@ func TestSerde(t *testing.T) {
 	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 3}); err != io.EOF {
 		t.Errorf("got %v != exp io.EOF", err)
 	}
+	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 3, 8}); err != ErrNotRegistered {
+		t.Errorf("got %v != exp ErrNotRegistered", err)
+	}
 	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 99}); err != ErrNotRegistered {
 		t.Errorf("got %v != exp ErrNotRegistered", err)
 	}
@@ -183,7 +186,7 @@ func TestConfluentHeader(t *testing.T) {
 		}
 
 		if test.index != nil {
-			index, b3, err := h.DecodeIndex(b2)
+			index, b3, err := h.DecodeIndex(b2, len(test.index))
 			if err != nil {
 				t.Errorf("#%d DecodeIndex: got unexpected err %v", i, err)
 				continue
@@ -205,7 +208,10 @@ func TestConfluentHeader(t *testing.T) {
 	if _, _, err := h.DecodeID([]byte{0, 0, 0, 0}); err != ErrBadHeader {
 		t.Errorf("got %v != exp ErrBadHeader", err)
 	}
-	if _, _, err := h.DecodeIndex([]byte{2}); err != io.EOF {
+	if _, _, err := h.DecodeIndex([]byte{2}, 1); err != io.EOF {
 		t.Errorf("got %v != exp io.EOF", err)
+	}
+	if _, _, err := h.DecodeIndex([]byte{6, 2, 4, 6}, 2); err != ErrNotRegistered {
+		t.Errorf("got %v != exp ErrNotRegistered", err)
 	}
 }

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -214,4 +214,7 @@ func TestConfluentHeader(t *testing.T) {
 	if _, _, err := h.DecodeIndex([]byte{6, 2, 4, 6}, 2); err != ErrNotRegistered {
 		t.Errorf("got %v != exp ErrNotRegistered", err)
 	}
+	if _, _, err := h.DecodeIndex([]byte{1}, 2); err != ErrBadHeader {
+		t.Errorf("got %v != exp ErrBadHeader", err)
+	}
 }


### PR DESCRIPTION
This PR introduces `SerdeHeader` and defines `ConfluentHeader` as the default implementation. The behavior of `Serde` is the same, ~one small but important difference is a fixed bug in the encoding of the message index (see the second part of the PR description)~. The changes are mostly just a refactoring and extraction of the header encoding/decoding logic. It makes `Serde` a bit more flexible and future-proof, since the header format can be switched to a different implementation.

The motivation behind this change is to expose the logic for encoding/decoding the Confluent wire format header. Using this change the caller can now decode the ID manually if needed and fetch the schema from the schema registry.

```go
val, err := serde.DecodeNew(b)
if errors.Is(err, sr.ErrNotRegistered) {
	id, _ := serde.Header().DecodeID(b)

	// fetch schema from schema registry using the ID...

	serde.Register(id, myVal, sr.DecodeFn(func(b []byte, v any) error {
		// decode using the schema ...
	})

	// retry decoding
	val, err = serde.DecodeNew(b)
}
```

The code above is just an illustration, I'm aware that the code would need to take care of request collapsing.

Related to the discussion in https://github.com/twmb/franz-go/issues/453.