### PR TITLE
kgo: add DialTLS option

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -248,6 +248,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.dialFn}
 	case namefn(DialTLSConfig):
 		return []any{cfg.dialTLS}
+	case namefn(DialTLS):
+		return []any{cfg.dialTLS != nil}
 	case namefn(SeedBrokers):
 		return []any{cfg.seedBrokers}
 	case namefn(MaxVersions):

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -642,6 +642,12 @@ func DialTLSConfig(c *tls.Config) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.dialTLS = c }}
 }
 
+// DialTLS opts into dialing brokers with TLS. This is a shortcut for
+// DialTLSConfig with an empty config. See DialTLSConfig for more details.
+func DialTLS() Opt {
+	return DialTLSConfig(new(tls.Config))
+}
+
 // SeedBrokers sets the seed brokers for the client to use, overriding the
 // default 127.0.0.1:9092.
 //


### PR DESCRIPTION
Opts into TLS without requiring a tls.Config