### PR TITLE
pkg/kadm: fail List<> methods if the topic being listed does not exist

### DIFF
--- a/pkg/kadm/metadata.go
+++ b/pkg/kadm/metadata.go
@@ -403,6 +403,11 @@ func (cl *Client) listOffsets(ctx context.Context, isolation int8, timestamp int
 	if err != nil {
 		return nil, err
 	}
+	for _, td := range tds {
+		if td.Err != nil {
+			return nil, td.Err
+		}
+	}
 
 	// If we request with timestamps, we may request twice: once for after
 	// timestamps, and once for any -1 (and no error) offsets where the


### PR DESCRIPTION
Previously, if a topic did not exist, then List would proceed happily and not include any partitions for it in the response. This is rarely if ever desired.