### PR TITLE
pkg/kmsg: do not retract v2, because it is impossible

### DIFF
--- a/pkg/kmsg/go.mod
+++ b/pkg/kmsg/go.mod
@@ -1,8 +1,3 @@
 module github.com/twmb/franz-go/pkg/kmsg
 
 go 1.18
-
-retract (
-	v2.0.1 // This forced a breaking change in kgo, which is not wanted at the moment.
-	v2.0.0 // This forced a breaking change in kgo, which is not wanted at the moment.
-)

--- a/plugin/klogrus/klogrus.go
+++ b/plugin/klogrus/klogrus.go
@@ -1,6 +1,8 @@
 package klogrus
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -27,7 +29,7 @@ func (l *Logger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 	if levelMatched {
 		fields := make(logrus.Fields, len(keyvals)/2)
 		for i := 0; i < len(keyvals); i += 2 {
-			fields[keyvals[i].(string)] = keyvals[i+1]
+			fields[fmt.Sprint(keyvals[i])] = keyvals[i+1]
 		}
 		l.lr.WithFields(fields).Log(logrusLevel, msg)
 	}


### PR DESCRIPTION
v1 modules cannot retract a v2 module so it seems.

Also sneaks in a paranoia improvement to klogrus.