### PR TITLE
Fix typo in parseReadSize

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -1166,7 +1166,7 @@ func (cxn *brokerCxn) parseReadSize(sizeBuf []byte) (int32, error) {
 		return 0, fmt.Errorf("invalid negative response size %d", size)
 	}
 	if maxSize := cxn.b.cl.cfg.maxBrokerReadBytes; size > maxSize {
-		if maxSize == 0x48545450 { // "HTTP"
+		if size == 0x48545450 { // "HTTP"
 			return 0, fmt.Errorf("invalid large response size %d > limit %d; the four size bytes are 'HTTP' in ascii, the beginning of an HTTP response; is your broker port correct?", size, maxSize)
 		}
 		// A TLS alert is 21, and a TLS alert has the version


### PR DESCRIPTION
Previously the check was against `maxSize`, which comes from the consumer configuration, so there's no point checking that to see if it is "HTTP".