### PR TITLE
pkg/sr: update for new APIs and to be forward compatible

### DIFF
--- a/pkg/sr/client.go
+++ b/pkg/sr/client.go
@@ -50,16 +50,15 @@ func (e *ResponseError) Error() string {
 // Client talks to a schema registry and contains helper functions to serialize
 // and deserialize objects according to schemas.
 type Client struct {
-	urls   []string
-	httpcl *http.Client
-	ua     string
+	urls      []string
+	httpcl    *http.Client
+	ua        string
+	defParams Param
 
 	basicAuth *struct {
 		user string
 		pass string
 	}
-
-	normalize bool
 }
 
 // NewClient returns a new schema registry client.
@@ -123,6 +122,7 @@ start:
 	if cl.basicAuth != nil {
 		req.SetBasicAuth(cl.basicAuth.user, cl.basicAuth.pass)
 	}
+	cl.applyParams(ctx, req)
 
 	resp, err := cl.httpcl.Do(req)
 	if err != nil {

--- a/pkg/sr/config.go
+++ b/pkg/sr/config.go
@@ -67,14 +67,6 @@ func DialTLSConfig(c *tls.Config) Opt {
 	}}
 }
 
-// Normalize sets the client to add the "?normalize=true" query parameter when
-// getting or creating schemas. This can help collapse duplicate schemas into
-// one, but can also be done with a configuration parameter on the schema
-// registry itself.
-func Normalize() Opt {
-	return opt{func(cl *Client) { cl.normalize = true }}
-}
-
 // BasicAuth sets basic authorization to use for every request.
 func BasicAuth(user, pass string) Opt {
 	return opt{func(cl *Client) {
@@ -82,5 +74,12 @@ func BasicAuth(user, pass string) Opt {
 			user string
 			pass string
 		}{user, pass}
+	}}
+}
+
+// DefaultParams sets default parameters to apply to every request.
+func DefaultParams(ps ...Param) Opt {
+	return opt{func(cl *Client) {
+		cl.defParams = mergeParams(ps...)
 	}}
 }

--- a/pkg/sr/enums.go
+++ b/pkg/sr/enums.go
@@ -157,3 +157,110 @@ func (m *Mode) UnmarshalText(text []byte) error {
 	}
 	return nil
 }
+
+// SchemaRuleKind as an enum representing the kind of schema rule.
+type SchemaRuleKind int
+
+const (
+	SchemaRuleKindTransform SchemaRuleKind = iota
+	SchemaRuleKindCondition
+)
+
+func (k SchemaRuleKind) String() string {
+	switch k {
+	case SchemaRuleKindTransform:
+		return "TRANSFORM"
+	case SchemaRuleKindCondition:
+		return "CONDITION"
+	default:
+		return ""
+	}
+}
+
+func (k SchemaRuleKind) MarshalText() ([]byte, error) {
+	s := k.String()
+	if s == "" {
+		return nil, fmt.Errorf("unknown schema rule kind %d", k)
+	}
+	return []byte(s), nil
+}
+
+func (k *SchemaRuleKind) UnmarshalText(text []byte) error {
+	switch s := strings.ToUpper(string(text)); s {
+	default:
+		return fmt.Errorf("unknown schema rule kind %q", s)
+	case "TRANSFORM":
+		*k = SchemaRuleKindTransform
+	case "CONDITION":
+		*k = SchemaRuleKindCondition
+	}
+	return nil
+}
+
+// Mode specifies a schema rule's mode.
+//
+// Migration rules can be specified for an UPGRADE, DOWNGRADE, or both
+// (UPDOWN). Migration rules are used during complex schema evolution.
+//
+// Domain rules can be specified during serialization (WRITE), deserialization
+// (READ) or both (WRITEREAD).
+//
+// Domain rules can be used to transform the domain values in a message
+// payload.
+type SchemaRuleMode int
+
+const (
+	SchemaRuleModeUpgrade SchemaRuleMode = iota
+	SchemaRuleModeDowngrade
+	SchemaRuleModeUpdown
+	SchemaRuleModeWrite
+	SchemaRuleModeRead
+	SchemaRuleModeWriteRead
+)
+
+func (m SchemaRuleMode) String() string {
+	switch m {
+	case SchemaRuleModeUpgrade:
+		return "UPGRADE"
+	case SchemaRuleModeDowngrade:
+		return "DOWNGRADE"
+	case SchemaRuleModeUpdown:
+		return "UPDOWN"
+	case SchemaRuleModeWrite:
+		return "WRITE"
+	case SchemaRuleModeRead:
+		return "READ"
+	case SchemaRuleModeWriteRead:
+		return "WRITEREAD"
+	default:
+		return ""
+	}
+}
+
+func (m SchemaRuleMode) MarshalText() ([]byte, error) {
+	s := m.String()
+	if s == "" {
+		return nil, fmt.Errorf("unknown schema rule mode %d", m)
+	}
+	return []byte(s), nil
+}
+
+func (m *SchemaRuleMode) UnmarshalText(text []byte) error {
+	switch s := strings.ToUpper(string(text)); s {
+	default:
+		return fmt.Errorf("unknown schema rule mode %q", s)
+	case "UPGRADE":
+		*m = SchemaRuleModeUpgrade
+	case "DOWNGRADE":
+		*m = SchemaRuleModeDowngrade
+	case "UPDOWN":
+		*m = SchemaRuleModeUpdown
+	case "WRITE":
+		*m = SchemaRuleModeWrite
+	case "READ":
+		*m = SchemaRuleModeRead
+	case "WRITEREAD":
+		*m = SchemaRuleModeWriteRead
+	}
+	return nil
+}

--- a/pkg/sr/params.go
+++ b/pkg/sr/params.go
@@ -1,0 +1,195 @@
+package sr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Param is a parameter that can be passed to various APIs. Each API documents
+// the parameters they accept.
+type Param struct {
+	normalize       bool
+	verbose         bool
+	fetchMaxID      bool
+	defaultToGlobal bool
+	force           bool
+	latestOnly      bool
+	showDeleted     bool
+	deletedOnly     bool
+	format          string
+	subjectPrefix   string
+	subject         string
+	page            *int
+	limit           int
+}
+
+// WithParams adds query parameters to the given context. This is a merge
+// operation: any non-zero parameter is kept. The variadic nature of this
+// allows for a nicer api:
+//
+//	sr.WithParams(ctx, sr.Format("default"), sr.FetchMaxID)
+func WithParams(ctx context.Context, p ...Param) context.Context {
+	return context.WithValue(ctx, &paramsKey, mergeParams(p...))
+}
+
+func (cl *Client) applyParams(ctx context.Context, req *http.Request) {
+	p := cl.defParams
+	user, ok := ctx.Value(&paramsKey).(Param)
+	if ok {
+		p = mergeParams(p, user)
+	}
+	p.apply(req)
+}
+
+func (p Param) apply(req *http.Request) {
+	q := req.URL.Query()
+	if p.normalize {
+		q.Set("normalize", "true")
+	}
+	if p.verbose {
+		q.Set("verbose", "true")
+	}
+	if p.fetchMaxID {
+		q.Set("fetchMaxId", "true")
+	}
+	if p.defaultToGlobal {
+		q.Set("defaultToGlobal", "true")
+	}
+	if p.force {
+		q.Set("force", "true")
+	}
+	if p.latestOnly {
+		q.Set("latestOnly", "true")
+	}
+	if p.showDeleted {
+		q.Set("deleted", "true")
+	}
+	if p.deletedOnly {
+		q.Set("deletedOnly", "true")
+	}
+	if p.format != "" {
+		q.Set("format", p.format)
+	}
+	if p.subjectPrefix != "" {
+		q.Set("subjectPrefix", p.subjectPrefix)
+	}
+	if p.subject != "" {
+		q.Set("subject", p.subject)
+	}
+	if p.page != nil && *p.page >= 0 {
+		q.Set("page", fmt.Sprintf("%d", *p.page))
+	}
+	if p.limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", p.limit))
+	}
+	req.URL.RawQuery = q.Encode()
+}
+
+var paramsKey = "params_key"
+
+func mergeParams(p ...Param) Param {
+	var merged Param
+	for _, p := range p {
+		if p.normalize {
+			merged.normalize = true
+		}
+		if p.verbose {
+			merged.verbose = true
+		}
+		if p.fetchMaxID {
+			merged.fetchMaxID = true
+		}
+		if p.defaultToGlobal {
+			merged.defaultToGlobal = true
+		}
+		if p.force {
+			merged.force = true
+		}
+		if p.latestOnly {
+			merged.latestOnly = true
+		}
+		if p.showDeleted {
+			merged.showDeleted = true
+		}
+		if p.deletedOnly {
+			merged.deletedOnly = true
+		}
+		if p.format != "" {
+			merged.format = p.format
+		}
+		if p.subjectPrefix != "" {
+			merged.subjectPrefix = p.subjectPrefix
+		}
+		if p.subject != "" {
+			merged.subject = p.subject
+		}
+		if p.page != nil && *p.page >= 0 {
+			merged.page = p.page
+		}
+		if p.limit > 0 {
+			merged.limit = p.limit
+		}
+	}
+	return merged
+}
+
+var (
+	// Normalize is a Param that configures whether or not to normalize
+	// schema's in certain create- or get-schema operations.
+	Normalize = Param{normalize: true}
+
+	// Verbose is a Param that configures whether or not to return verbose
+	// error messages when checking compatibility.
+	Verbose = Param{verbose: true}
+
+	// FetchMaxID is a Param that configures whether or not to fetch the
+	// max schema ID in certain get-schema operations.
+	FetchMaxID = Param{fetchMaxID: true}
+
+	// DefaultToGlobal is a Param that changes get-compatibility or
+	// get-mode to return the global compatibility or mode if the requested
+	// subject does not exist.
+	DefaultToGlobal = Param{defaultToGlobal: true}
+
+	// Force is a Param that updating the mode if you are setting the mode
+	// to IMPORT and schemas currently exist.
+	Force = Param{force: true}
+
+	// LatestOnly is a Param that configures whether or not to return only
+	// the latest schema in certain get-schema operations.
+	LatestOnly = Param{latestOnly: true}
+
+	// ShowDeleted is a Param that configures whether or not to return
+	// deleted schemas or subjects in certain get operations.
+	ShowDeleted = Param{showDeleted: true}
+
+	// DeletedOnly is a Param that configures whether to return only
+	// deleted schemas or subjects in certain get operations.
+	DeletedOnly = Param{deletedOnly: true}
+)
+
+// Format returns a Param that configures how schema's are returned in certain
+// get-schema operations.
+//
+// For Avro schemas, the Format param supports "default" or "resolved". For
+// Protobuf schemas, the Format param supports "default", "ignore_extensions",
+// or "serialized".
+func Format(f string) Param { return Param{format: f} }
+
+// SubjectPrefix returns a Param that filters subjects by prefix when listing
+// schemas.
+func SubjectPrefix(pfx string) Param { return Param{subjectPrefix: pfx} }
+
+// Subject returns a Param limiting which subject is returned in certain
+// list-schema or list-subject operations.
+func Subject(s string) Param { return Param{subject: s} }
+
+/*
+TODO once we know the header that is returned for pagination, we can use these.
+// Page returns a Param for certain paginating APIs.
+func Page(page int) Param { return Param{page: &page} }
+
+// Limit returns a Param for certain paginating APIs.
+func Limit(limit int) Param { return Param{limit: limit} }
+*/


### PR DESCRIPTION
With an HTTP API, the API can add query parameters periodically, any addition of which breaks a Go API where all query parameters are spelled out as method arguments.

Now, we have moved all query parameters into values in a context, and added a helper sr.WithParams to make it easy to build parameters. All APIs document which parameters they support. We also have global parameters on the client itself, if you always want to show deleted or something.

This also adds metadata and ruleset to the schema type, even though the validation of these is really only possible in the Java client (as documented via limitations).

Lastly, this adds support for a few missing APIs:
* SubjectsByID
* SchemaVersionsByID
* SubjectVersions
* SchemaTextByVersion
* AllSchemas

This breaks all CompatibilityLevel APIs, since the compatibility level stuff has been expanded to a whole bunch of compatibility / configuration settings. Namely, we just drop the "Level".

This breaks all APIs that had ShowHideDeleted arguments, favoring instead the new ShowDeleted Param.

We keep the DeleteHow param, because it is important at call sites to see that you are using hard deletion.