### PR TITLE
kgo.RecordReader: support %v{json} to read json values

### DIFF
--- a/pkg/kgo/record_formatter.go
+++ b/pkg/kgo/record_formatter.go
@@ -367,6 +367,9 @@ func NewRecordFormatter(layout string) (*RecordFormatter, error) {
 			var appendFn func([]byte, []byte) []byte
 			if handledBrace = isOpenBrace; handledBrace {
 				switch {
+				case strings.HasPrefix(layout, "}"):
+					layout = layout[len("}"):]
+					appendFn = appendPlain
 				case strings.HasPrefix(layout, "base64}"):
 					appendFn = appendBase64
 					layout = layout[len("base64}"):]
@@ -1298,6 +1301,8 @@ func (r *RecordReader) parseReadLayout(layout string) error {
 			var isJson bool
 			if handledBrace = isOpenBrace; handledBrace {
 				switch {
+				case strings.HasPrefix(layout, "}"):
+					layout = layout[len("}"):]
 				case strings.HasPrefix(layout, "base64}"):
 					decodeFn = decodeBase64
 					layout = layout[len("base64}"):]

--- a/pkg/kgo/record_formatter_test.go
+++ b/pkg/kgo/record_formatter_test.go
@@ -44,6 +44,10 @@ func TestRecordFormatter(t *testing.T) {
 			layout: "%v",
 			expR:   "value",
 		},
+		{
+			layout: "%v{}",
+			expR:   "value",
+		},
 
 		{
 			layout: "%T{hex16}%t %V{ascii} %v %V{little16} %k %K{big32} %o",
@@ -230,6 +234,11 @@ func TestRecordReader(t *testing.T) {
 	}{
 		{
 			layout: "%v",
+			in:     "foo bar biz\nbaz",
+			exp:    []*Record{StringRecord("foo bar biz\nbaz")},
+		},
+		{
+			layout: "%v{}",
 			in:     "foo bar biz\nbaz",
 			exp:    []*Record{StringRecord("foo bar biz\nbaz")},
 		},


### PR DESCRIPTION
This also handles arbitrary spacing, so `{  "foo": true }` reads (and can then be produced as) `{"foo":true}`.