### PR TITLE
Add DeltaStream to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ In alphabetical order,
 * [Alpaca](https://alpaca.markets/blog/alpaca-launches-next-gen-order-management-system/)
 * [Banyan](https://banyan.com)
 * [Benthos](https://www.benthos.dev/)
+* [DeltaStream](https://deltastream.io/)
 * [Eoitek](https://eoitek.com/)
 * [Mux](https://mux.com/blog/processing-cdn-logs-exactly-once-with-kafka-transactions/)
 * [Redpanda Console](https://github.com/redpanda-data/console/)


### PR DESCRIPTION
DeltaStream uses franz-go internally for all go microservices.