### PR TITLE
pkg/sr: use ptr type for SchemaMetadata and SchemaRuleSet

### DIFF
--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -80,10 +80,10 @@ type (
 		References []SchemaReference `json:"references,omitempty"`
 
 		// SchemaMetadata is arbitrary information about the schema.
-		SchemaMetadata SchemaMetadata `json:"metadata,omitempty"`
+		SchemaMetadata *SchemaMetadata `json:"metadata,omitempty"`
 
 		// SchemaRuleSet is a set of rules that govern the schema.
-		SchemaRuleSet SchemaRuleSet `json:"ruleSet,omitempty"`
+		SchemaRuleSet *SchemaRuleSet `json:"ruleSet,omitempty"`
 	}
 
 	// SubjectSchema pairs the subject, global identifier, and version of a
@@ -667,6 +667,7 @@ func (cl *Client) ResetCompatibility(ctx context.Context, subjects ...string) []
 		go func() {
 			defer wg.Done()
 			var c SetCompatibility // unmarshals with "compatibility"
+			fmt.Println("set comp", c)
 			err := cl.delete(ctx, pathConfig(subject), &c)
 			results[slot] = CompatibilityResult{
 				Subject:          subject,

--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -667,7 +667,6 @@ func (cl *Client) ResetCompatibility(ctx context.Context, subjects ...string) []
 		go func() {
 			defer wg.Done()
 			var c SetCompatibility // unmarshals with "compatibility"
-			fmt.Println("set comp", c)
 			err := cl.delete(ctx, pathConfig(subject), &c)
 			results[slot] = CompatibilityResult{
 				Subject:          subject,


### PR DESCRIPTION
`omitempty` doesn't work for structs, as a result, the schema contains zero value of SchemaMetadata and SchemaRuleSet which fails to create the schema on redpanda.

https://pkg.go.dev/encoding/json#Marshal