### PR TITLE
feat(kslog): implemented kgo.Logger plugin with slog

### DIFF
--- a/plugin/kslog/README.md
+++ b/plugin/kslog/README.md
@@ -1,0 +1,13 @@
+kslog
+===
+
+kslog is a plug-in package to use [slog](https://pkg.go.dev/log/slog) as a [`kgo.Logger`](https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#Logger)
+
+To use,
+
+```go
+cl, err := kgo.NewClient(
+        kgo.WithLogger(kslog.New(slog.Default())),
+        // ...other opts
+)
+```

--- a/plugin/kslog/go.mod
+++ b/plugin/kslog/go.mod
@@ -1,0 +1,11 @@
+module github.com/utilitywarehouse/franz-go/plugin/kslog
+
+go 1.21.0
+
+require github.com/twmb/franz-go v1.15.0
+
+require (
+	github.com/klauspost/compress v1.16.7 // indirect
+	github.com/pierrec/lz4/v4 v4.1.18 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v1.6.1 // indirect
+)

--- a/plugin/kslog/go.mod
+++ b/plugin/kslog/go.mod
@@ -1,4 +1,4 @@
-module github.com/utilitywarehouse/franz-go/plugin/kslog
+module github.com/twmb/franz-go/plugin/kslog
 
 go 1.21.0
 

--- a/plugin/kslog/go.sum
+++ b/plugin/kslog/go.sum
@@ -1,0 +1,8 @@
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
+github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/twmb/franz-go v1.15.0 h1:bw5n1COKJzWpkCXG/kMtHrurcS9HSWV6e3If5CUdc+M=
+github.com/twmb/franz-go v1.15.0/go.mod h1:nMAvTC2kHtK+ceaSHeHm4dlxC78389M/1DjpOswEgu4=
+github.com/twmb/franz-go/pkg/kmsg v1.6.1 h1:tm6hXPv5antMHLasTfKv9R+X03AjHSkSkXhQo2c5ALM=
+github.com/twmb/franz-go/pkg/kmsg v1.6.1/go.mod h1:se9Mjdt0Nwzc9lnjJ0HyDtLyBnaBDAd7pCje47OhSyw=

--- a/plugin/kslog/kslog.go
+++ b/plugin/kslog/kslog.go
@@ -1,0 +1,66 @@
+// Package kslog provides a plug-in kgo.Logger wrapping slog.Logger for usage in
+// a kgo.Client.
+//
+// This can be used like so:
+//
+//	cl, err := kgo.NewClient(
+//	        kgo.WithLogger(kslog.New(slog.Default())),
+//	        // ...other opts
+//	)
+package kslog
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// Logger provides the kgo.Logger interface for usage in kgo.WithLogger when
+// initializing a client.
+type Logger struct {
+	sl *slog.Logger
+}
+
+// New returns a new kgo.Logger that wraps an slog.Logger.
+func New(sl *slog.Logger) *Logger {
+	return &Logger{sl}
+}
+
+// Level is for the kgo.Logger interface.
+func (l *Logger) Level() kgo.LogLevel {
+	ctx := context.Background()
+	switch {
+	case l.sl.Enabled(ctx, slog.LevelDebug):
+		return kgo.LogLevelDebug
+	case l.sl.Enabled(ctx, slog.LevelInfo):
+		return kgo.LogLevelInfo
+	case l.sl.Enabled(ctx, slog.LevelWarn):
+		return kgo.LogLevelWarn
+	case l.sl.Enabled(ctx, slog.LevelError):
+		return kgo.LogLevelError
+	default:
+		return kgo.LogLevelNone
+	}
+}
+
+// Log is for the kgo.Logger interface.
+func (l *Logger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
+	l.sl.Log(context.Background(), kgoToSlogLevel(level), msg, keyvals...)
+}
+
+func kgoToSlogLevel(level kgo.LogLevel) slog.Level {
+	switch level {
+	case kgo.LogLevelError:
+		return slog.LevelError
+	case kgo.LogLevelWarn:
+		return slog.LevelWarn
+	case kgo.LogLevelInfo:
+		return slog.LevelInfo
+	case kgo.LogLevelDebug:
+		return slog.LevelDebug
+	default:
+		// Using the default level for slog
+		return slog.LevelInfo
+	}
+}

--- a/plugin/kslog/kslog_test.go
+++ b/plugin/kslog/kslog_test.go
@@ -1,0 +1,14 @@
+package kslog
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestNew(_ *testing.T) {
+	l := New(slog.Default())
+
+	l.Log(kgo.LogLevelInfo, "test message", "test-key", "test-val")
+}

--- a/plugin/kslog/kslog_test.go
+++ b/plugin/kslog/kslog_test.go
@@ -1,14 +1,15 @@
-package kslog
+package kslog_test
 
 import (
 	"log/slog"
-	"testing"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/plugin/kslog"
 )
 
-func TestNew(_ *testing.T) {
-	l := New(slog.Default())
+func ExampleNew() {
+	l := kslog.New(slog.Default())
 
 	l.Log(kgo.LogLevelInfo, "test message", "test-key", "test-val")
+	// Output:
 }


### PR DESCRIPTION
This is a kgo.Logger wrapping [slog](https://pkg.go.dev/log/slog).
It will be really useful to us, as we're switching to it, so I though it might help others too.

slog is not experimental any more only from go 1.21, so whoever wants to use this plugin will need to use go version >= 1.21