### PR TITLE
kgo: pin AddPartitionsToTxn to v3 when using one transaction

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -69,7 +69,7 @@ jobs:
     container: golang:1.21.3
     services:
       redpanda:
-        image: vectorized/redpanda-nightly:latest
+        image: redpandadata/redpanda
         ports:
           - 9092:9092
         env:

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -3420,10 +3420,17 @@ func (cl *addPartitionsToTxnSharder) shard(ctx context.Context, kreq kmsg.Reques
 
 	var issues []issueShard
 	for id, req := range brokerReqs {
-		issues = append(issues, issueShard{
-			req:    req,
-			broker: id,
-		})
+		if len(req.Transactions) <= 1 || len(req.Transactions) == 1 && !req.Transactions[0].VerifyOnly {
+			issues = append(issues, issueShard{
+				req:    &pinReq{Request: req, pinMax: true, max: 3},
+				broker: id,
+			})
+		} else {
+			issues = append(issues, issueShard{
+				req:    req,
+				broker: id,
+			})
+		}
 	}
 	for _, unkerr := range unkerrs {
 		issues = append(issues, issueShard{


### PR DESCRIPTION
KIP-890 has been updated such that v3 must be used by clients. We will pin to v3 unless multiple transactions are being added, or unless any transaction is verify only.

Closes #609.