### PR TITLE
use interface instead *logrus.Logger in plugin klogrus

### DIFF
--- a/plugin/klogrus/go.mod
+++ b/plugin/klogrus/go.mod
@@ -4,13 +4,16 @@ go 1.18
 
 require (
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.0
 	github.com/twmb/franz-go v1.15.3
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.19 // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/plugin/klogrus/go.sum
+++ b/plugin/klogrus/go.sum
@@ -22,6 +22,7 @@ github.com/twmb/franz-go/pkg/kmsg v1.7.0/go.mod h1:se9Mjdt0Nwzc9lnjJ0HyDtLyBnaBD
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/plugin/klogrus/klogrus_test.go
+++ b/plugin/klogrus/klogrus_test.go
@@ -1,0 +1,44 @@
+package klogrus_test
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/plugin/klogrus"
+)
+
+func ExampleNew() {
+	l := klogrus.New(logrus.New())
+
+	l.Log(kgo.LogLevelInfo, "test message", "test-key", "test-val")
+	// Output:
+}
+
+func TestFieldLogger(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	l := klogrus.NewFieldLogger(logger)
+
+	level := l.Level()
+	assert.Equal(t, kgo.LogLevelInfo, level)
+
+	l.Log(kgo.LogLevelInfo, "test message", "test-key", "test-val")
+
+	require.Equal(t, 1, len(hook.Entries))
+	lastEntry := hook.LastEntry()
+
+	assert.Equal(t, logrus.InfoLevel, lastEntry.Level)
+	assert.Equal(t, "test message", lastEntry.Message)
+
+	value, ok := lastEntry.Data["test-key"]
+	assert.True(t, ok)
+	assert.Equal(t, "test-val", value)
+
+	hook.Reset()
+	assert.Nil(t, hook.LastEntry())
+}


### PR DESCRIPTION
Hello

We use some wrappers around `*logrus.Logger` and we don't want to write a wrapper each time we need to set the kafka logger

Instead, since most of the time we use `logrus.FieldLogger` with some extra methods, I decided to send this small contribution where we can use this _minimal_ interface

```go
// FieldLogger interface.
type FieldLogger interface {
	logrus.FieldLogger
	GetLevel() logrus.Level
}
```

The result is still compatible with logrus, but on steroids.

I was thinking in use the pure `logrus.FieldLogger` and store the log level (using two constructors, for instance) but I think we need to react to possible changes in the log level in runtime. This solution is cleaner

Also I add one test based on kslog plugin.

Enjoy