### PR TITLE
sarama-compatible hasher

### DIFF
--- a/pkg/kgo/partitioner.go
+++ b/pkg/kgo/partitioner.go
@@ -487,10 +487,9 @@ func KafkaHasher(hashFn func([]byte) uint32) PartitionerHasher {
 	}
 }
 
-// SaramaHasher is not compatible with Sarama's default default partitioner.
-// If you need sarama compatibility use SaramaCompatHasher instead.
-// This function is left as is to provide compatibility with older versions of
-// this library.
+// Deprecated: SaramaHasher is not compatible with Sarama's default partitioner
+// and only remains to avoid re-keying records for existing users of this API. See
+// [SaramaCompatHasher] for a correct partitioner.
 func SaramaHasher(hashFn func([]byte) uint32) PartitionerHasher {
 	return func(key []byte, n int) int {
 		p := int(hashFn(key)) % n


### PR DESCRIPTION
Looks like `SaramaHasher` is not exactly compatible with sarama.
I switched from `segmentio/kafka-go` to `franz-go` and noticed that now my keys map to different partition (this is a no-go for my usecase).

I have created [a test to check key->partiton mapping consistency](https://github.com/C-Pro/partitioners/blob/master/partitioners_test.go) between sarama, segmentio and franz.
`kgo.StickyKeyPartitioner(SaramaCompatHasher(fnv32a))` returns different partition number.

Test output shows[ franz yields different partition numbers](https://github.com/C-Pro/partitioners/actions/runs/6956276996/job/18926787234).

So I added new `SaramaCompatHasher` that behaves exactly like sarama's and segmentio ones (uses int32 instead of int).
I opted to create a new instead of changing the existing `SaramaHasher` to maintain compatibility with old library versions. 
