### PR TITLE
pkg/sr: improve base URL and resource path joining

### DIFF
--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -404,7 +404,7 @@ func (cl *Client) DeleteSubject(ctx context.Context, subject string, how DeleteH
 	// DELETE /subjects/{subject}?permanent={x}
 	path := pathSubject(subject)
 	if how == HardDelete {
-		path += "?permanent=true"
+		ctx = WithParams(ctx, hardDelete)
 	}
 	var versions []int
 	defer func() { sort.Ints(versions) }()
@@ -419,7 +419,7 @@ func (cl *Client) DeleteSchema(ctx context.Context, subject string, version int,
 	// DELETE /subjects/{subject}/versions/{version}?permanent={x}
 	path := pathSubjectVersion(subject, version)
 	if how == HardDelete {
-		path += "?permanent=true"
+		ctx = WithParams(ctx, hardDelete)
 	}
 	return cl.delete(ctx, path, nil)
 }

--- a/pkg/sr/params.go
+++ b/pkg/sr/params.go
@@ -22,6 +22,7 @@ type Param struct {
 	subject         string
 	page            *int
 	limit           int
+	hardDelete      bool
 }
 
 // WithParams adds query parameters to the given context. This is a merge
@@ -83,6 +84,9 @@ func (p Param) apply(req *http.Request) {
 	if p.limit > 0 {
 		q.Set("limit", fmt.Sprintf("%d", p.limit))
 	}
+	if p.hardDelete {
+		q.Set("permanent", "true")
+	}
 	req.URL.RawQuery = q.Encode()
 }
 
@@ -130,6 +134,9 @@ func mergeParams(p ...Param) Param {
 		if p.limit > 0 {
 			merged.limit = p.limit
 		}
+		if p.hardDelete {
+			merged.hardDelete = p.hardDelete
+		}
 	}
 	return merged
 }
@@ -167,6 +174,9 @@ var (
 	// DeletedOnly is a Param that configures whether to return only
 	// deleted schemas or subjects in certain get operations.
 	DeletedOnly = Param{deletedOnly: true}
+
+	// hardDelete is internal, and set when DeleteHow == HardDelete.
+	hardDelete = Param{hardDelete: true}
 )
 
 // Format returns a Param that configures how schema's are returned in certain


### PR DESCRIPTION
While working with the schema registry client in `pkg/sr`, we started to receive "not found" HTTP errors seemingly out of nowhere while registering schemas with `CreateSchema()`.

After closer examination, I found that the culrpit was that the base URL for the schema registry had a trailing slash in some of our configurations. For example `http://localhost:18081/` instead of `http://localhost:18081`.

After further examination, I traced back the issue to this line:
https://github.com/twmb/franz-go/blob/c09dc92d2db141d00c9eeb8ea229f72869222ca3/pkg/sr/client.go#L103

Where it is evident that the complete request URL results in the form `http://localhost:18081//path/to/resource` (incorrect).
I observed that the "not found" errors happen in both, Confluent Schema Registry and Redpanda.

To resolve the issue, in this PR the base URL is joined to the resource path using `url.JoinPath()` instead (from package `net/url`). This function takes care of cleaning up any ./ or ../ element in the base path. Also, Any sequences of multiple / characters will be reduced to a single / as well. Therefore, the resulting joined path is normalized properly.

~~Given that `url.JoinPath()` also escapes `?` characters (not meant to be in an actual path but as the separator for upcoming query parameters), I also refactored to support passing query parameters to the client's request functions explicitly and separately instead of embedded in the path argument. This also provides for formal encoding of query parameters thanks to the `Encode()` method of the `url.Values` type. The only instances that use query parameters are `DeleteSubject()` and `DeleteSchema()`.~~  EDIT: see comments below for a better suggested approach.