### PR TITLE
kfake: add SleepControl

### DIFF
--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -18,7 +18,7 @@ import (
 
 func init() { regKey(1, 4, 13) }
 
-func (c *Cluster) handleFetch(creq clientReq, w *watchFetch) (kmsg.Response, error) {
+func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, error) {
 	var (
 		req  = creq.kreq.(*kmsg.FetchRequest)
 		resp = req.ResponseKind().(*kmsg.FetchResponse)
@@ -182,7 +182,7 @@ type watchFetch struct {
 	need     int
 	needp    tps[int]
 	deadline time.Time
-	creq     clientReq
+	creq     *clientReq
 
 	in []*partData
 	cb func()

--- a/pkg/kfake/08_offset_commit.go
+++ b/pkg/kfake/08_offset_commit.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(8, 0, 8) }
 
-func (c *Cluster) handleOffsetCommit(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleOffsetCommit(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.OffsetCommitRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetCommitResponse)
 

--- a/pkg/kfake/09_offset_fetch.go
+++ b/pkg/kfake/09_offset_fetch.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(9, 0, 8) }
 
-func (c *Cluster) handleOffsetFetch(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleOffsetFetch(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.OffsetFetchRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/pkg/kfake/11_join_group.go
+++ b/pkg/kfake/11_join_group.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(11, 0, 9) }
 
-func (c *Cluster) handleJoinGroup(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleJoinGroup(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.JoinGroupRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/pkg/kfake/12_heartbeat.go
+++ b/pkg/kfake/12_heartbeat.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(12, 0, 4) }
 
-func (c *Cluster) handleHeartbeat(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleHeartbeat(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.HeartbeatRequest)
 	resp := req.ResponseKind().(*kmsg.HeartbeatResponse)
 

--- a/pkg/kfake/13_leave_group.go
+++ b/pkg/kfake/13_leave_group.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(13, 0, 5) }
 
-func (c *Cluster) handleLeaveGroup(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleLeaveGroup(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.LeaveGroupRequest)
 	resp := req.ResponseKind().(*kmsg.LeaveGroupResponse)
 

--- a/pkg/kfake/14_sync_group.go
+++ b/pkg/kfake/14_sync_group.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(14, 0, 5) }
 
-func (c *Cluster) handleSyncGroup(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleSyncGroup(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.SyncGroupRequest)
 	resp := req.ResponseKind().(*kmsg.SyncGroupResponse)
 

--- a/pkg/kfake/15_describe_groups.go
+++ b/pkg/kfake/15_describe_groups.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(15, 0, 5) }
 
-func (c *Cluster) handleDescribeGroups(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleDescribeGroups(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.DescribeGroupsRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/pkg/kfake/16_list_groups.go
+++ b/pkg/kfake/16_list_groups.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(16, 0, 4) }
 
-func (c *Cluster) handleListGroups(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleListGroups(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.ListGroupsRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/pkg/kfake/17_sasl_handshake.go
+++ b/pkg/kfake/17_sasl_handshake.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(17, 1, 1) }
 
-func (c *Cluster) handleSASLHandshake(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleSASLHandshake(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.SASLHandshakeRequest)
 	resp := req.ResponseKind().(*kmsg.SASLHandshakeResponse)
 

--- a/pkg/kfake/36_sasl_authenticate.go
+++ b/pkg/kfake/36_sasl_authenticate.go
@@ -9,7 +9,7 @@ import (
 
 func init() { regKey(36, 0, 2) }
 
-func (c *Cluster) handleSASLAuthenticate(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleSASLAuthenticate(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.SASLAuthenticateRequest)
 	resp := req.ResponseKind().(*kmsg.SASLAuthenticateResponse)
 

--- a/pkg/kfake/42_delete_groups.go
+++ b/pkg/kfake/42_delete_groups.go
@@ -6,7 +6,7 @@ import (
 
 func init() { regKey(42, 0, 2) }
 
-func (c *Cluster) handleDeleteGroups(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleDeleteGroups(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.DeleteGroupsRequest)
 
 	if err := checkReqVersion(req.Key(), req.Version); err != nil {

--- a/pkg/kfake/47_offset_delete.go
+++ b/pkg/kfake/47_offset_delete.go
@@ -7,7 +7,7 @@ import (
 
 func init() { regKey(47, 0, 0) }
 
-func (c *Cluster) handleOffsetDelete(creq clientReq) (kmsg.Response, error) {
+func (c *Cluster) handleOffsetDelete(creq *clientReq) (kmsg.Response, error) {
 	req := creq.kreq.(*kmsg.OffsetDeleteRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetDeleteResponse)
 

--- a/pkg/kfake/client_conn.go
+++ b/pkg/kfake/client_conn.go
@@ -25,8 +25,8 @@ type (
 		cc   *clientConn
 		kreq kmsg.Request
 		at   time.Time
-		corr int32
 		cid  string
+		corr int32
 		seq  uint32
 	}
 
@@ -38,7 +38,7 @@ type (
 	}
 )
 
-func (creq clientReq) empty() bool { return creq.cc == nil || creq.kreq == nil }
+func (creq *clientReq) empty() bool { return creq == nil || creq.cc == nil || creq.kreq == nil }
 
 func (cc *clientConn) read() {
 	defer cc.conn.Close()
@@ -101,7 +101,7 @@ func (cc *clientConn) read() {
 		}
 
 		select {
-		case cc.c.reqCh <- clientReq{cc, kreq, time.Now(), corr, cid, seq}:
+		case cc.c.reqCh <- &clientReq{cc, kreq, time.Now(), cid, corr, seq}:
 			seq++
 		case <-cc.c.die:
 			return
@@ -141,6 +141,9 @@ func (cc *clientConn) write() {
 			case <-cc.c.die:
 				return
 			}
+		} else {
+			delete(oooresp, seq)
+			seq++
 		}
 		if err := resp.err; err != nil {
 			cc.c.cfg.logger.Logf(LogLevelInfo, "client %s request unable to be handled: %v", who, err)

--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -38,7 +38,7 @@ type (
 		protocols    map[string]int
 		protocol     string
 
-		reqCh     chan clientReq
+		reqCh     chan *clientReq
 		controlCh chan func()
 
 		nJoining int
@@ -58,7 +58,7 @@ type (
 
 		// waitingReply is non-nil if a client is waiting for a reply
 		// from us for a JoinGroupRequest or a SyncGroupRequest.
-		waitingReply clientReq
+		waitingReply *clientReq
 
 		assignment []byte
 
@@ -105,7 +105,7 @@ func (c *Cluster) coordinator(id string) *broker {
 	return c.bs[n]
 }
 
-func (c *Cluster) validateGroup(creq clientReq, group string) *kerr.Error {
+func (c *Cluster) validateGroup(creq *clientReq, group string) *kerr.Error {
 	switch key := kmsg.Key(creq.kreq.Key()); key {
 	case kmsg.OffsetCommit, kmsg.OffsetFetch, kmsg.DescribeGroups, kmsg.DeleteGroups:
 	default:
@@ -132,7 +132,7 @@ func generateMemberID(clientID string, instanceID *string) string {
 ////////////
 
 // handleJoin completely hijacks the incoming request.
-func (gs *groups) handleJoin(creq clientReq) {
+func (gs *groups) handleJoin(creq *clientReq) {
 	if gs.gs == nil {
 		gs.gs = make(map[string]*group)
 	}
@@ -147,7 +147,7 @@ start:
 			members:   make(map[string]*groupMember),
 			pending:   make(map[string]*groupMember),
 			protocols: make(map[string]int),
-			reqCh:     make(chan clientReq),
+			reqCh:     make(chan *clientReq),
 			controlCh: make(chan func()),
 			quitCh:    make(chan struct{}),
 		}
@@ -165,7 +165,7 @@ start:
 
 // Returns true if the request is hijacked and handled, otherwise false if the
 // group does not exist.
-func (gs *groups) handleHijack(group string, creq clientReq) bool {
+func (gs *groups) handleHijack(group string, creq *clientReq) bool {
 	if gs.gs == nil {
 		return false
 	}
@@ -181,27 +181,27 @@ func (gs *groups) handleHijack(group string, creq clientReq) bool {
 	}
 }
 
-func (gs *groups) handleSync(creq clientReq) bool {
+func (gs *groups) handleSync(creq *clientReq) bool {
 	return gs.handleHijack(creq.kreq.(*kmsg.SyncGroupRequest).Group, creq)
 }
 
-func (gs *groups) handleHeartbeat(creq clientReq) bool {
+func (gs *groups) handleHeartbeat(creq *clientReq) bool {
 	return gs.handleHijack(creq.kreq.(*kmsg.HeartbeatRequest).Group, creq)
 }
 
-func (gs *groups) handleLeave(creq clientReq) bool {
+func (gs *groups) handleLeave(creq *clientReq) bool {
 	return gs.handleHijack(creq.kreq.(*kmsg.LeaveGroupRequest).Group, creq)
 }
 
-func (gs *groups) handleOffsetCommit(creq clientReq) bool {
+func (gs *groups) handleOffsetCommit(creq *clientReq) bool {
 	return gs.handleHijack(creq.kreq.(*kmsg.OffsetCommitRequest).Group, creq)
 }
 
-func (gs *groups) handleOffsetDelete(creq clientReq) bool {
+func (gs *groups) handleOffsetDelete(creq *clientReq) bool {
 	return gs.handleHijack(creq.kreq.(*kmsg.OffsetDeleteRequest).Group, creq)
 }
 
-func (gs *groups) handleList(creq clientReq) *kmsg.ListGroupsResponse {
+func (gs *groups) handleList(creq *clientReq) *kmsg.ListGroupsResponse {
 	req := creq.kreq.(*kmsg.ListGroupsRequest)
 	resp := req.ResponseKind().(*kmsg.ListGroupsResponse)
 
@@ -233,7 +233,7 @@ func (gs *groups) handleList(creq clientReq) *kmsg.ListGroupsResponse {
 	return resp
 }
 
-func (gs *groups) handleDescribe(creq clientReq) *kmsg.DescribeGroupsResponse {
+func (gs *groups) handleDescribe(creq *clientReq) *kmsg.DescribeGroupsResponse {
 	req := creq.kreq.(*kmsg.DescribeGroupsRequest)
 	resp := req.ResponseKind().(*kmsg.DescribeGroupsResponse)
 
@@ -285,7 +285,7 @@ func (gs *groups) handleDescribe(creq clientReq) *kmsg.DescribeGroupsResponse {
 	return resp
 }
 
-func (gs *groups) handleDelete(creq clientReq) *kmsg.DeleteGroupsResponse {
+func (gs *groups) handleDelete(creq *clientReq) *kmsg.DeleteGroupsResponse {
 	req := creq.kreq.(*kmsg.DeleteGroupsRequest)
 	resp := req.ResponseKind().(*kmsg.DeleteGroupsResponse)
 
@@ -324,7 +324,7 @@ func (gs *groups) handleDelete(creq clientReq) *kmsg.DeleteGroupsResponse {
 	return resp
 }
 
-func (gs *groups) handleOffsetFetch(creq clientReq) *kmsg.OffsetFetchResponse {
+func (gs *groups) handleOffsetFetch(creq *clientReq) *kmsg.OffsetFetchResponse {
 	req := creq.kreq.(*kmsg.OffsetFetchRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetFetchResponse)
 
@@ -423,7 +423,7 @@ func (gs *groups) handleOffsetFetch(creq clientReq) *kmsg.OffsetFetchResponse {
 	return resp
 }
 
-func (g *group) handleOffsetDelete(creq clientReq) *kmsg.OffsetDeleteResponse {
+func (g *group) handleOffsetDelete(creq *clientReq) *kmsg.OffsetDeleteResponse {
 	req := creq.kreq.(*kmsg.OffsetDeleteRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetDeleteResponse)
 
@@ -588,7 +588,7 @@ func (g *group) quitOnce() {
 // to the client to immediately rejoin if a new client enters the group.
 //
 // If this returns nil, the request will be replied to later.
-func (g *group) handleJoin(creq clientReq) (kmsg.Response, bool) {
+func (g *group) handleJoin(creq *clientReq) (kmsg.Response, bool) {
 	req := creq.kreq.(*kmsg.JoinGroupRequest)
 	resp := req.ResponseKind().(*kmsg.JoinGroupResponse)
 
@@ -664,7 +664,7 @@ func (g *group) handleJoin(creq clientReq) (kmsg.Response, bool) {
 }
 
 // Handles a sync, which can transition us to stable.
-func (g *group) handleSync(creq clientReq) kmsg.Response {
+func (g *group) handleSync(creq *clientReq) kmsg.Response {
 	req := creq.kreq.(*kmsg.SyncGroupRequest)
 	resp := req.ResponseKind().(*kmsg.SyncGroupResponse)
 
@@ -715,7 +715,7 @@ func (g *group) handleSync(creq clientReq) kmsg.Response {
 
 // Handles a heartbeat, a relatively simple request that just delays our
 // session timeout timer.
-func (g *group) handleHeartbeat(creq clientReq) kmsg.Response {
+func (g *group) handleHeartbeat(creq *clientReq) kmsg.Response {
 	req := creq.kreq.(*kmsg.HeartbeatRequest)
 	resp := req.ResponseKind().(*kmsg.HeartbeatResponse)
 
@@ -751,7 +751,7 @@ func (g *group) handleHeartbeat(creq clientReq) kmsg.Response {
 
 // Handles a leave. We trigger a rebalance for every member leaving in a batch
 // request, but that's fine because of our manage serialization.
-func (g *group) handleLeave(creq clientReq) kmsg.Response {
+func (g *group) handleLeave(creq *clientReq) kmsg.Response {
 	req := creq.kreq.(*kmsg.LeaveGroupRequest)
 	resp := req.ResponseKind().(*kmsg.LeaveGroupResponse)
 
@@ -784,7 +784,7 @@ func (g *group) handleLeave(creq clientReq) kmsg.Response {
 				g.stopPending(p)
 			}
 		} else {
-			g.updateMemberAndRebalance(m, clientReq{}, nil)
+			g.updateMemberAndRebalance(m, nil, nil)
 		}
 	}
 
@@ -806,7 +806,7 @@ func fillOffsetCommit(req *kmsg.OffsetCommitRequest, resp *kmsg.OffsetCommitResp
 }
 
 // Handles a commit.
-func (g *group) handleOffsetCommit(creq clientReq) *kmsg.OffsetCommitResponse {
+func (g *group) handleOffsetCommit(creq *clientReq) *kmsg.OffsetCommitResponse {
 	req := creq.kreq.(*kmsg.OffsetCommitRequest)
 	resp := req.ResponseKind().(*kmsg.OffsetCommitResponse)
 
@@ -985,7 +985,7 @@ func (g *group) completeLeaderSync(req *kmsg.SyncGroupRequest) {
 
 func (g *group) updateHeartbeat(m *groupMember) {
 	g.atSessionTimeout(m, func() {
-		g.updateMemberAndRebalance(m, clientReq{}, nil)
+		g.updateMemberAndRebalance(m, nil, nil)
 	})
 }
 
@@ -1024,7 +1024,7 @@ func (g *group) atSessionTimeout(m *groupMember, fn func()) {
 
 // This is used to update a member from a new join request, or to clear a
 // member from failed heartbeats.
-func (g *group) updateMemberAndRebalance(m *groupMember, waitingReply clientReq, newJoin *kmsg.JoinGroupRequest) {
+func (g *group) updateMemberAndRebalance(m *groupMember, waitingReply *clientReq, newJoin *kmsg.JoinGroupRequest) {
 	for _, p := range m.join.Protocols {
 		g.protocols[p.Name]--
 	}
@@ -1050,7 +1050,7 @@ func (g *group) updateMemberAndRebalance(m *groupMember, waitingReply clientReq,
 }
 
 // Adds a new member to the group and rebalances.
-func (g *group) addMemberAndRebalance(m *groupMember, waitingReply clientReq, join *kmsg.JoinGroupRequest) {
+func (g *group) addMemberAndRebalance(m *groupMember, waitingReply *clientReq, join *kmsg.JoinGroupRequest) {
 	g.stopPending(m)
 	m.join = join
 	for _, p := range m.join.Protocols {
@@ -1132,14 +1132,14 @@ members:
 	return metadata
 }
 
-func (g *group) reply(creq clientReq, kresp kmsg.Response, m *groupMember) {
+func (g *group) reply(creq *clientReq, kresp kmsg.Response, m *groupMember) {
 	select {
 	case creq.cc.respCh <- clientResp{kresp: kresp, corr: creq.corr, seq: creq.seq}:
 	case <-g.c.die:
 		return
 	}
 	if m != nil {
-		m.waitingReply = clientReq{}
+		m.waitingReply = nil
 		g.updateHeartbeat(m)
 	}
 }

--- a/pkg/kfake/sasl.go
+++ b/pkg/kfake/sasl.go
@@ -47,7 +47,7 @@ const (
 	saslStageComplete
 )
 
-func (c *Cluster) handleSASL(creq clientReq) (allow bool) {
+func (c *Cluster) handleSASL(creq *clientReq) (allow bool) {
 	switch creq.cc.saslStage {
 	case saslStageBegin:
 		switch creq.kreq.(type) {


### PR DESCRIPTION
This function allows you to sleep a function you are controlling until your wakeup function returns. The control function effectively yields to other requests. Note that since requests must be handled in order, you need to be a bit careful to not block other requests (unless you intentionally do that).

This basically does what it says on the tin. The behavior of everything else is unchanged -- you can KeepControl, you can return false to say it wasn't handled, etc.

The logic and control flow is a good bit ugly, but it works and is fairly documented and "well contained".

In working on this, I also found and fixed a bug that resulted in correllation errors when handling join&sync.

kgo group tests still work against kfake's "hidden" main.go, and I have tested SleepControl with/without KeepControl, and with/without returning handled=true.