### PR TITLE
kfake: add DropControl, SleepOutOfOrder, CoordinatorFor, RehashCoordinators

### DIFF
--- a/pkg/kfake/config.go
+++ b/pkg/kfake/config.go
@@ -34,6 +34,8 @@ type cfg struct {
 	enableSASL bool
 	sasls      map[struct{ m, u string }]string // cleared after client initialization
 	tls        *tls.Config
+
+	sleepOutOfOrder bool
 }
 
 // NumBrokers sets the number of brokers to start in the fake cluster.
@@ -112,4 +114,13 @@ func TLS(c *tls.Config) Opt {
 // options, the last specification wins.
 func SeedTopics(partitions int32, ts ...string) Opt {
 	return opt{func(cfg *cfg) { cfg.seedTopics = append(cfg.seedTopics, seedTopics{partitions, ts}) }}
+}
+
+// SleepOutOfOrder allows functions to be handled out of order when control
+// functions are sleeping. The functions are be handled internally out of
+// order, but responses still wait for the sleeping requests to finish. This
+// can be used to set up complicated chains of control where functions only
+// advance when you know another request is actively being handled.
+func SleepOutOfOrder() Opt {
+	return opt{func(cfg *cfg) { cfg.sleepOutOfOrder = true }}
 }

--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -101,7 +101,8 @@ func (gs groupState) String() string {
 }
 
 func (c *Cluster) coordinator(id string) *broker {
-	n := hashString(id) % uint64(len(c.bs))
+	gen := c.coordinatorGen.Load()
+	n := hashString(fmt.Sprint("%d", gen)+"\x00\x00"+id) % uint64(len(c.bs))
 	return c.bs[n]
 }
 


### PR DESCRIPTION
* Sleeping was a bit limited because if two requests came in on the same connection, you could not really chain logic. Sleeping out of order allows you to at least run some logic to gate how requests behave with each other. It's not the most obvious, so it is not the default.

* Adds SleepOutOfOrder

* Adds CoordinatorFor so you can see which "broker" a coordinator request will go to

* Adds RehashCoordinators to change where requests are hashed to

The latter two allow you to loop rehashing until a coordinator for your key changes, if you want to force NotCoordinator requests.