### PR TITLE
kfake: do not return early when running control functions if the cluster is closed

### DIFF
--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -310,8 +310,6 @@ outer:
 		inner:
 			for {
 				select {
-				case <-c.die:
-					return
 				case admin := <-c.adminCh:
 					admin()
 					continue inner
@@ -604,8 +602,6 @@ func (c *Cluster) tryControlKey(key int16, creq *clientReq) (kmsg.Response, erro
 		res := c.runControl(cctx, creq)
 		for {
 			select {
-			case <-c.die:
-				return nil, nil, false
 			case admin := <-c.adminCh:
 				admin()
 				continue


### PR DESCRIPTION
If we return while running a control function (which is expected to be fast), we may unlock a mutex that is currently unlocked and only relocked after the control function exits.

Notably, tryControl was panicking because a cluster was closed while a control function was running.