### PR TITLE
all: bump to go1.19

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     name: "golangci-lint on amd64"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 'stable'
       - uses: golangci/golangci-lint-action@v3
         with:
           version: latest
@@ -34,7 +34,7 @@ jobs:
     needs: golangci
     runs-on: ubuntu-latest
     name: "integration test kafka"
-    container: golang:1.21.3
+    container: golang:latest
     services:
       kafka:
         image: bitnami/kafka:latest
@@ -54,7 +54,7 @@ jobs:
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_KRAFT_CLUSTER_ID: XkpGZQ27R3eTl3OdTm2LYA # 16 byte base64-encoded UUID
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: go test ./...
         env:
           KGO_TEST_RF: 1
@@ -66,7 +66,7 @@ jobs:
     needs: golangci
     runs-on: ubuntu-latest
     name: "integration test redpanda"
-    container: golang:1.21.3
+    container: golang:latest
     services:
       redpanda:
         image: redpandadata/redpanda
@@ -75,7 +75,7 @@ jobs:
         env:
           REDPANDA_ADVERTISE_KAFKA_ADDRESS: redpanda:9092
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: go test ./...
         env:
           KGO_TEST_RF: 1

--- a/bump-deps.sh
+++ b/bump-deps.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-minlang="1.18"
+minlang="1.19"
 for modfile in $(find . -name 'go.mod' -print0 | xargs -0)
 do
     moddir=$(dirname "$modfile")

--- a/examples/bench/compare/sarama/go.mod
+++ b/examples/bench/compare/sarama/go.mod
@@ -2,7 +2,7 @@ module saram
 
 go 1.20
 
-require github.com/Shopify/sarama v1.38.1
+require github.com/IBM/sarama v1.42.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/examples/bench/compare/sarama/go.sum
+++ b/examples/bench/compare/sarama/go.sum
@@ -1,6 +1,5 @@
-github.com/Shopify/sarama v1.38.1 h1:lqqPUPQZ7zPqYlWpTh+LQ9bhYNu2xJL6k1SJN4WVe2A=
-github.com/Shopify/sarama v1.38.1/go.mod h1:iwv9a67Ha8VNa+TifujYoWGxWnu2kNVAQdSdZ4X2o5g=
-github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
+github.com/IBM/sarama v1.42.1 h1:wugyWa15TDEHh2kvq2gAy1IHLjEjuYOYgXz/ruC/OSQ=
+github.com/IBM/sarama v1.42.1/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -49,8 +48,8 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -68,7 +67,7 @@ golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/examples/bench/compare/sarama/main.go
+++ b/examples/bench/compare/sarama/main.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Shopify/sarama"
+	"github.com/IBM/sarama"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/twmb/franz-go
 
-go 1.18
+go 1.19
 
 require (
-	github.com/klauspost/compress v1.16.7
+	github.com/klauspost/compress v1.17.4
 	github.com/pierrec/lz4/v4 v4.1.19
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0
 	golang.org/x/crypto v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
-github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
+github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/pierrec/lz4/v4 v4.1.19 h1:tYLzDnjDXh9qIxSTKHwXwOYmm9d887Y7Y1ZkyXYHAN4=
 github.com/pierrec/lz4/v4 v4.1.19/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/twmb/franz-go/pkg/kmsg v1.7.0 h1:a457IbvezYfA5UkiBvyV3zj0Is3y1i8EJgqjJYoij2E=

--- a/pkg/kgo/internal/sticky/sticky.go
+++ b/pkg/kgo/internal/sticky/sticky.go
@@ -2,7 +2,7 @@
 // complete overhaul to be faster, more understandable, and optimal.
 //
 // For some points on how Java's strategy is flawed, see
-// https://github.com/Shopify/sarama/pull/1416/files/b29086bdaae0da7ce71eae3f854d50685fd6b631#r315005878
+// https://github.com/IBM/sarama/pull/1416/files/b29086bdaae0da7ce71eae3f854d50685fd6b631#r315005878
 package sticky
 
 import (

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1144,7 +1144,7 @@ func (recBuf *recBuf) bufferRecord(pr promisedRec, abortOnNewBatch bool) bool {
 	defer recBuf.mu.Unlock()
 
 	// We truncate to milliseconds to avoid some accumulated rounding error
-	// problems (see Shopify/sarama#1455)
+	// problems (see IBM/sarama#1455)
 	if pr.Timestamp.IsZero() {
 		pr.Timestamp = time.Now()
 	}

--- a/pkg/kmsg/go.mod
+++ b/pkg/kmsg/go.mod
@@ -1,3 +1,3 @@
 module github.com/twmb/franz-go/pkg/kmsg
 
-go 1.18
+go 1.19

--- a/pkg/sasl/kerberos/go.mod
+++ b/pkg/sasl/kerberos/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/pkg/sasl/kerberos
 
-go 1.18
+go 1.19
 
 require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4

--- a/plugin/kgmetrics/go.mod
+++ b/plugin/kgmetrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/plugin/kgmetrics
 
-go 1.18
+go 1.19
 
 require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475

--- a/plugin/klogr/go.mod
+++ b/plugin/klogr/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/plugin/klogr
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.3.0

--- a/plugin/klogrus/go.mod
+++ b/plugin/klogrus/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/plugin/klogrus
 
-go 1.18
+go 1.19
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/plugin/kprom/go.mod
+++ b/plugin/kprom/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/plugin/kprom
 
-go 1.18
+go 1.19
 
 require (
 	github.com/prometheus/client_golang v1.17.0

--- a/plugin/kzap/go.mod
+++ b/plugin/kzap/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/plugin/kzap
 
-go 1.18
+go 1.19
 
 require (
 	github.com/twmb/franz-go v1.15.3

--- a/plugin/kzerolog/go.mod
+++ b/plugin/kzerolog/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go/plugin/kzerolog
 
-go 1.18
+go 1.19
 
 require (
 	github.com/rs/zerolog v1.31.0


### PR DESCRIPTION
For GH workflows, use latest stable