### PR TITLE
sr SubjectVersions calls pathSubjectWithVersion

### DIFF
--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -261,7 +261,7 @@ func pathMode(subject string) string {
 func (cl *Client) SubjectVersions(ctx context.Context, subject string) ([]int, error) {
 	// GET /subjects/{subject}/versions
 	var versions []int
-	err := cl.get(ctx, pathSubject(subject), &versions)
+	err := cl.get(ctx, pathSubjectWithVersion(subject), &versions)
 	return versions, err
 }
 


### PR DESCRIPTION
SubjectVersions calls pathSubjectWithVersion instead of pathSubject to build a path to retrieve all versions for a given subject.