### PR TITLE
Added a config variable to default to the leader epoch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ TESTING
 generate/generate
 go.work
 go.work.sum
+/vendor

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -398,6 +398,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.requireStable}
 	case namefn(SessionTimeout):
 		return []any{cfg.sessionTimeout}
+	case namefn(DefaultToLeaderEpoch()):
+		return []any{cfg.defaultToLeaderEpoch}
 	default:
 		return nil
 	}

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -184,6 +184,8 @@ type cfg struct {
 	autocommitMarks    bool
 	autocommitInterval time.Duration
 	commitCallback     func(*Client, *kmsg.OffsetCommitRequest, *kmsg.OffsetCommitResponse, error)
+
+	defaultToLeaderEpoch bool
 }
 
 func (cfg *cfg) validate() error {
@@ -1739,4 +1741,11 @@ func AutoCommitCallback(fn func(*Client, *kmsg.OffsetCommitRequest, *kmsg.Offset
 			cfg.commitCallback, cfg.setCommitCallback = fn, true
 		}
 	}}
+}
+
+// DefaultToLeaderEpoch sets the client to default to using leader epochs when
+// fetching offsets. This is useful if you are using a Kafka 2.5+ broker and
+// want to ensure that you are fetching the most recent offset for a partition.
+func DefaultToLeaderEpoch() GroupOpt {
+	return groupOpt{func(cfg *cfg) { cfg.defaultToLeaderEpoch = true }}
 }

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1873,6 +1873,11 @@ func (s *consumerSession) mapLoadsToBrokers(loads listOrEpochLoads) map[*broker]
 					if tryBroker := findBroker(brokers, brokerID); tryBroker != nil {
 						broker = tryBroker
 					}
+
+					if offset.epoch != topicPartition.leaderEpoch && s.c.cl.cfg.defaultToLeaderEpoch {
+						offset.epoch = topicPartition.leaderEpoch // sets the epoch to the leader's epoch if we are defaulting to leader epoch
+					}
+
 					offset.currentEpoch = topicPartition.leaderEpoch // ensure we set our latest epoch for the partition
 				}
 


### PR DESCRIPTION
Recently I've been encountering an issue where I get a non-retriable error stating 
`topic <topic name> partition <partition> lost records; the client consumed to offset <last offset> but was reset to offset <earliest offset>`

After some digging I found the consumer group was stuck on epoch 0. I forced to onto the leader epoch and everything seemed to start working again. But on restart of the service, it encountered the same error. I'm not setting the epoch anywhere in my code for this so I'm not sure why it would jump back to epoch 0.

This is only occurring with a specific topic (the topic only has 1 partition). To commit we're calling `CommitRecords` with the record after processing. We don't alter the record at all.

The "unique" thing about the specific topic thats encountering this error is that we only consume messages every 3 hours. So during that 3 hours I call `PauseFetchPartitions` and put the goroutine to sleep. After the 3 hours I call `ResumeFetchPartitions`, process the records, and call `CommitRecords`. 

My initial thought was that during the 3 hour window, the epoch leader changes but I then commit a record to the older epoch, but that doesn't make sense for it to be stuck on the epoch 0. I would also assume that a change in the epoch would likely trigger a rebalance, in which case we wouldn't commit the stale records.

I made these changes to help bypass that specific error but I'm guessing theres a risk of data loss in doing this but I'm not super familiar with how epochs work.