### PR TITLE
kfake: fix handling ListOffsets when Timestamp is requested

### DIFF
--- a/pkg/kfake/02_list_offsets.go
+++ b/pkg/kfake/02_list_offsets.go
@@ -75,10 +75,11 @@ func (c *Cluster) handleListOffsets(b *broker, kreq kmsg.Request) (kmsg.Response
 					sp.Offset = pd.highWatermark
 				}
 			default:
+				// returns the index of the first batch _after_ the requested timestamp
 				idx, _ := sort.Find(len(pd.batches), func(idx int) int {
 					maxEarlier := pd.batches[idx].maxEarlierTimestamp
 					switch {
-					case maxEarlier < rp.Timestamp:
+					case maxEarlier > rp.Timestamp:
 						return -1
 					case maxEarlier == rp.Timestamp:
 						return 0


### PR DESCRIPTION
Closes #706 

This PR fixes the behaviour of how `kfake` handles `ListOffsets` API, when the request includes partition's timestamp. That is, the expected behaviour is to return the offset of the first batch _after_ the requested timestamp. As I pictured in #706, the current behaviour in the mainline is the opposite.

I didn't find a better way testing it, that to use the same example repo, I created to demo the problem. Refer to [this branch](https://github.com/narqo/test-kfake/tree/kfake-listoffsets-ts), where I replaced the `kfake` with my forked version.