### PR TITLE
fix: client.Lag doesn't calculate lag for all consumergroups with client.Lag(ctx)

### DIFF
--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -1460,7 +1460,12 @@ func (cl *Client) Lag(ctx context.Context, groups ...string) (DescribedGroupLags
 		}
 		if g.Err != nil {
 			delete(set, g.Group)
+			continue
 		}
+
+		// if no groups were specified for lag calculation, we will calculate lag for all groups
+		// adding groups to the set again.
+		set[g.Group] = struct{}{}
 	}
 	if len(set) == 0 {
 		return lags, nil

--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -1463,8 +1463,9 @@ func (cl *Client) Lag(ctx context.Context, groups ...string) (DescribedGroupLags
 			continue
 		}
 
-		// if no groups were specified for lag calculation, we will calculate lag for all groups
-		// adding groups to the set again.
+		// If the input set of groups is empty, DescribeGroups returns all groups.
+		// We add to `set` here so that the Lag function itself can calculate
+		// lag for all groups.
 		set[g.Group] = struct{}{}
 	}
 	if len(set) == 0 {


### PR DESCRIPTION
<img width="717" alt="image" src="https://github.com/twmb/franz-go/assets/45126881/fa78ad72-668d-4ca5-b20b-bd57f67f5793">

Getting lag as nil, in case Lag method was called as `client.Lag(ctx)`, other methods of this library defaults to listing offsets and describing to all the groups/topics incase no group/topic is specified, Assuming the same behaviour for this method. 

e.g.
[Client.DescribeGroups](https://pkg.go.dev/github.com/twmb/franz-go/pkg/kadm#Client.DescribeGroups)
> DescribeGroups describes either all groups specified, or all groups in the cluster if none are specified.

[Client.ListTopics](https://pkg.go.dev/github.com/twmb/franz-go/pkg/kadm#Client.ListTopics)
> ListTopics issues a metadata request and returns TopicDetails. Specific topics to describe can be passed as additional arguments. If no topics are specified, all topics are requested. Internal topics are not returned unless specifically requested. To see all topics including internal topics, use ListTopicsWithInternal.
