### PR TITLE
fix: Skip calculate lag when a topic has no offset commits

### DIFF
--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -1585,6 +1585,9 @@ func CalculateGroupLag(
 			}
 
 			tcommit := commit[t.Topic]
+			if tcommit == nil {
+				continue
+			}
 			tend := endOffsets[t.Topic]
 			for _, p := range t.Partitions {
 				var (
@@ -1594,15 +1597,14 @@ func CalculateGroupLag(
 					ok      bool
 				)
 
-				if tcommit != nil {
-					if pcommit, ok = tcommit[p]; !ok {
-						pcommit = OffsetResponse{Offset: Offset{
-							Topic:     t.Topic,
-							Partition: p,
-							At:        -1,
-						}}
-					}
+				if pcommit, ok = tcommit[p]; !ok {
+					pcommit = OffsetResponse{Offset: Offset{
+						Topic:     t.Topic,
+						Partition: p,
+						At:        -1,
+					}}
 				}
+
 				if tend == nil {
 					perr = errListMissing
 				} else {


### PR DESCRIPTION
If topic has no commit offset for a consumer group, then we should not calculate lag for it.

For example, topic A current high water offset is 100, but has no message because of delete mode

And there will not be any offset commits for consumer group because there is no messages to consume

Function CalculateGroupLag will calculate lag 100 for the consumer group, which is wrong.