### PR TITLE
fix: clear lastAssigned when revoking eager consumer

### DIFF
--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -639,6 +639,7 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 			g.cfg.onRevoked(g.cl.ctx, g.cl, g.nowAssigned.read())
 		}
 		g.nowAssigned.store(nil)
+		g.lastAssigned = nil
 
 		// After nilling uncommitted here, nothing should recreate
 		// uncommitted until a future fetch after the group is


### PR DESCRIPTION
If a consumer that can be cooperative but is currently eager revokes its assigned partitions as part of a rebalance it should also clear its tracking state between rebalances as it has revoked all of its partitions.

This was leading to some inconsistent behaviour when migrating from eager consumers to cooperative consumers following the migration instructions in [KIP-429](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429%3A+Kafka+Consumer+Incremental+Rebalance+Protocol#KIP429:KafkaConsumerIncrementalRebalanceProtocol-Consumer).

Fixes #686