### PR TITLE
kgo: avoid / wakeup lingering if we hit max bytes or max records

### DIFF
--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1229,7 +1229,7 @@ func (recBuf *recBuf) tryStopLingerForDraining() bool {
 
 // Begins a linger timer unless the producer is being flushed.
 func (recBuf *recBuf) lockedMaybeStartLinger() bool {
-	if recBuf.cl.producer.flushing.Load() > 0 {
+	if recBuf.cl.producer.flushing.Load() > 0 || recBuf.cl.producer.blocked.Load() > 0 {
 		return false
 	}
 	recBuf.lingering = time.AfterFunc(recBuf.cl.cfg.linger, recBuf.sink.maybeDrain)


### PR DESCRIPTION
Currently if your linger is long and your max records small, it is possible to linger even if the client cannot buffer any more records.

Now, once max records or bytes is hit, we wakeup anything lingering and avoid entering the linger state again -- until we are no longer over max.

Closes #726.