### PR TITLE
SR: prevent panic when no decode function is registered

### DIFF
--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -387,7 +387,7 @@ func (s *Serde) decodeFind(b []byte) ([]byte, tserde, error) {
 			t = t.subindex[idx]
 		}
 	}
-	if !t.exists {
+	if !t.exists || t.decode == nil {
 		return nil, tserde{}, ErrNotRegistered
 	}
 	return b, t, nil

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -53,6 +53,7 @@ func TestSerde(t *testing.T) {
 	serde.Register(3, idx4{}, Index(0, 0, 1))
 	serde.Register(3, idx3{}, Index(0, 0))
 	serde.Register(5, oneidx{}, Index(0), GenerateFn(func() any { return &oneidx{Foo: "defoo", Bar: "debar"} }))
+	serde.Register(101, struct{}{}, DecodeFn(nil))
 
 	for i, test := range []struct {
 		enc    any
@@ -154,8 +155,8 @@ func TestSerde(t *testing.T) {
 	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 99}); err != ErrNotRegistered {
 		t.Errorf("got %v != exp ErrNotRegistered", err)
 	}
-	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 100, 0}); err != ErrNotRegistered {
-		// schema is registered but type is unknown
+	if _, err := serde.DecodeNew([]byte{0, 0, 0, 0, 101, 0}); err != ErrNotRegistered {
+		// schema is registered but no decode function
 		t.Errorf("got %v != exp ErrNotRegistered", err)
 	}
 }


### PR DESCRIPTION
A small fix for a possible panic when a type is registered without a decode function. The test kinda hides this possibility, because `Serde` has a default `DecodeFn` option. This case is more likely to hit when `Serde` is instantiated without that option.

I removed the decode test case for schema ID 100, as it was the same as the one for ID 99, instead I added one with ID 101 which has a registered type, but no decode function.