### PR TITLE
Fix typo (update default Acks in comment) in config.go

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -869,7 +869,7 @@ func DefaultProduceTopic(t string) ProducerOpt {
 // This controls the durability of written records and corresponds to "acks" in
 // Kafka's Producer Configuration documentation.
 //
-// The default is LeaderAck.
+// The default is AllISRAcks.
 type Acks struct {
 	val int16
 }


### PR DESCRIPTION
Type `Acks` description contains a mistake in the default value. According to the default config, the default value of acks is AllISRAcks (code https://github.com/twmb/franz-go/blob/7641d9e673e31217cc353ee8cfc473ba0946891d/pkg/kgo/config.go#L495)