### PR TITLE
kgo: add AllowRebalance and CloseAllowingRebalance to GroupTransactSession

### DIFF
--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -157,6 +157,18 @@ func (s *GroupTransactSession) Close() {
 	s.cl.Close()
 }
 
+// AllowRebalance is a wrapper around Client.AllowRebalance, with the exact
+// same semantics. Refer to that function's documentation.
+func (s *GroupTransactSession) AllowRebalance() {
+	s.cl.AllowRebalance()
+}
+
+// CloseAllowingRebalance is a wrapper around Client.CloseAllowingRebalance,
+// with the exact same semantics. Refer to that function's documentation.
+func (s *GroupTransactSession) CloseAllowingRebalance() {
+	s.cl.CloseAllowingRebalance()
+}
+
 // PollFetches is a wrapper around Client.PollFetches, with the exact same
 // semantics. Refer to that function's documentation.
 //


### PR DESCRIPTION
These two functions are basically required if you use the BlockRebalanceOnPoll function when initializing a GroupTransactSession, so, it seems worth it to promote these to direct APIs on GTS.

Closes #753.