### PR TITLE
kfake: Support custom topic configuration validation

### DIFF
--- a/pkg/kfake/19_create_topics.go
+++ b/pkg/kfake/19_create_topics.go
@@ -65,12 +65,12 @@ topics:
 			continue
 		}
 		configs := make(map[string]*string)
-		for _, c := range rt.Configs {
-			if ok := validateSetTopicConfig(c.Name, c.Value); !ok {
+		for _, cf := range rt.Configs {
+			if ok := c.cfg.validateSetTopicConfig(cf.Name, cf.Value); !ok {
 				donet(rt.Topic, kerr.InvalidConfig.Code)
 				continue topics
 			}
-			configs[c.Name] = c.Value
+			configs[cf.Name] = cf.Value
 		}
 		c.data.mkt(rt.Topic, int(rt.NumPartitions), int(rt.ReplicationFactor), configs)
 		st := donet(rt.Topic, 0)

--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"net"
 	"strconv"
@@ -98,6 +99,9 @@ func NewCluster(opts ...Opt) (*Cluster, error) {
 		maxSessionTimeout: 5 * time.Minute,
 
 		sasls: make(map[struct{ m, u string }]string),
+
+		validTopicConfigs: maps.Clone(validTopicConfigs),
+		validateSetConfig: maps.Clone(validateSetConfig),
 	}
 	for _, opt := range opts {
 		opt.apply(&cfg)

--- a/pkg/kfake/config.go
+++ b/pkg/kfake/config.go
@@ -36,6 +36,10 @@ type cfg struct {
 	tls        *tls.Config
 
 	sleepOutOfOrder bool
+
+	// Support custom topic configuration
+	validTopicConfigs map[string]string
+	validateSetConfig map[string]func(*string) bool
 }
 
 // NumBrokers sets the number of brokers to start in the fake cluster.
@@ -123,4 +127,14 @@ func SeedTopics(partitions int32, ts ...string) Opt {
 // advance when you know another request is actively being handled.
 func SleepOutOfOrder() Opt {
 	return opt{func(cfg *cfg) { cfg.sleepOutOfOrder = true }}
+}
+
+// CustomTopicValidation installs additional topic configurables.
+func CustomTopicValidation(name string, validate func(*string) bool) Opt {
+	return opt{func(cfg *cfg) {
+		if _, ok := cfg.validTopicConfigs[name]; !ok {
+			cfg.validTopicConfigs[name] = ""
+		}
+		cfg.validateSetConfig[name] = validate
+	}}
 }

--- a/pkg/kfake/data.go
+++ b/pkg/kfake/data.go
@@ -255,7 +255,7 @@ func (c *Cluster) setBrokerConfig(k string, v *string, dry bool) bool {
 }
 
 func (d *data) setTopicConfig(t string, k string, v *string, dry bool) bool {
-	if !validateSetTopicConfig(k, v) {
+	if !d.c.cfg.validateSetTopicConfig(k, v) {
 		return false
 	}
 	if dry {
@@ -268,11 +268,11 @@ func (d *data) setTopicConfig(t string, k string, v *string, dry bool) bool {
 	return true
 }
 
-func validateSetTopicConfig(k string, v *string) bool {
-	if _, ok := validTopicConfigs[k]; !ok {
+func (c cfg) validateSetTopicConfig(k string, v *string) bool {
+	if _, ok := c.validTopicConfigs[k]; !ok {
 		return false
 	}
-	fn, ok := validateSetConfig[k]
+	fn, ok := c.validateSetConfig[k]
 	if !ok {
 		return false
 	}

--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -102,7 +102,7 @@ func (gs groupState) String() string {
 
 func (c *Cluster) coordinator(id string) *broker {
 	gen := c.coordinatorGen.Load()
-	n := hashString(fmt.Sprint("%d", gen)+"\x00\x00"+id) % uint64(len(c.bs))
+	n := hashString(fmt.Sprintf("%d", gen)+"\x00\x00"+id) % uint64(len(c.bs))
 	return c.bs[n]
 }
 


### PR DESCRIPTION
This adds an option to kfake to permit the installation of custom topic config validation functions in a `Cluster`.

(Additional topic configuration is stored, but not otherwise acted upon.)