### PR TITLE
refactor: replace sliceWriter with bytes.Buffer and use it in decompression 

### DIFF
--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -14,15 +14,7 @@ import (
 	"github.com/pierrec/lz4/v4"
 )
 
-// sliceWriter a reusable slice as an io.Writer
-type sliceWriter struct{ inner []byte }
-
-func (s *sliceWriter) Write(p []byte) (int, error) {
-	s.inner = append(s.inner, p...)
-	return len(p), nil
-}
-
-var sliceWriters = sync.Pool{New: func() any { r := make([]byte, 8<<10); return &sliceWriter{inner: r} }}
+var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, 8<<10)) }}
 
 type codecType int8
 
@@ -175,9 +167,7 @@ type zstdEncoder struct {
 //
 // The writer should be put back to its pool after the returned slice is done
 // being used.
-func (c *compressor) compress(dst *sliceWriter, src []byte, produceRequestVersion int16) ([]byte, codecType) {
-	dst.inner = dst.inner[:0]
-
+func (c *compressor) compress(dst *bytes.Buffer, src []byte, produceRequestVersion int16) ([]byte, codecType) {
 	var use codecType
 	for _, option := range c.options {
 		if option == codecZstd && produceRequestVersion < 7 {
@@ -187,6 +177,7 @@ func (c *compressor) compress(dst *sliceWriter, src []byte, produceRequestVersio
 		break
 	}
 
+	var out []byte
 	switch use {
 	case codecNone:
 		return src, 0
@@ -200,10 +191,7 @@ func (c *compressor) compress(dst *sliceWriter, src []byte, produceRequestVersio
 		if err := gz.Close(); err != nil {
 			return nil, -1
 		}
-
-	case codecSnappy:
-		dst.inner = s2.EncodeSnappy(dst.inner[:cap(dst.inner)], src)
-
+		out = dst.Bytes()
 	case codecLZ4:
 		lz := c.lz4Pool.Get().(*lz4.Writer)
 		defer c.lz4Pool.Put(lz)
@@ -214,13 +202,34 @@ func (c *compressor) compress(dst *sliceWriter, src []byte, produceRequestVersio
 		if err := lz.Close(); err != nil {
 			return nil, -1
 		}
+		out = dst.Bytes()
+	case codecSnappy:
+		// Because the Snappy and Zstd codecs do not accept an io.Writer interface
+		// and directly take a []byte slice, here, the underlying []byte slice (`dst`)
+		// obtained from the bytes.Buffer{} from the pool is passed.
+		// As the `Write()` method on the buffer isn't used, its internal
+		// book-keeping goes out of sync, making the buffer unusable for further
+		// reading and writing via it's (eg: accessing via `Byte()`). For subsequent
+		// reads, the underlying slice has to be used directly.
+		//
+		// In this particular context, it is acceptable as there there are no subsequent
+		// operations performed on the buffer and it is immediately returned to the
+		// pool and `Reset()` the next time it is obtained and used where `compress()`
+		// is called.
+		if l := s2.MaxEncodedLen(len(src)); l > dst.Cap() {
+			dst.Grow(l)
+		}
+		out = s2.EncodeSnappy(dst.Bytes(), src)
 	case codecZstd:
 		zstdEnc := c.zstdPool.Get().(*zstdEncoder)
 		defer c.zstdPool.Put(zstdEnc)
-		dst.inner = zstdEnc.inner.EncodeAll(src, dst.inner)
+		if l := zstdEnc.inner.MaxEncodedSize(len(src)); l > dst.Cap() {
+			dst.Grow(l)
+		}
+		out = zstdEnc.inner.EncodeAll(src, dst.Bytes())
 	}
 
-	return dst.inner, use
+	return out, use
 }
 
 type decompressor struct {
@@ -259,38 +268,51 @@ type zstdDecoder struct {
 }
 
 func (d *decompressor) decompress(src []byte, codec byte) ([]byte, error) {
-	switch codecType(codec) {
-	case codecNone:
+	// Early return in case there is no compression
+	compCodec := codecType(codec)
+	if compCodec == codecNone {
 		return src, nil
+	}
+	out := byteBuffers.Get().(*bytes.Buffer)
+	out.Reset()
+	defer byteBuffers.Put(out)
+
+	switch compCodec {
 	case codecGzip:
 		ungz := d.ungzPool.Get().(*gzip.Reader)
 		defer d.ungzPool.Put(ungz)
 		if err := ungz.Reset(bytes.NewReader(src)); err != nil {
 			return nil, err
 		}
-		out := new(bytes.Buffer)
 		if _, err := io.Copy(out, ungz); err != nil {
 			return nil, err
 		}
-		return out.Bytes(), nil
+		return append([]byte(nil), out.Bytes()...), nil
 	case codecSnappy:
 		if len(src) > 16 && bytes.HasPrefix(src, xerialPfx) {
 			return xerialDecode(src)
 		}
-		return s2.Decode(nil, src)
+		decoded, err := s2.Decode(out.Bytes(), src)
+		if err != nil {
+			return nil, err
+		}
+		return append([]byte(nil), decoded...), nil
 	case codecLZ4:
 		unlz4 := d.unlz4Pool.Get().(*lz4.Reader)
 		defer d.unlz4Pool.Put(unlz4)
 		unlz4.Reset(bytes.NewReader(src))
-		out := new(bytes.Buffer)
 		if _, err := io.Copy(out, unlz4); err != nil {
 			return nil, err
 		}
-		return out.Bytes(), nil
+		return append([]byte(nil), out.Bytes()...), nil
 	case codecZstd:
 		unzstd := d.unzstdPool.Get().(*zstdDecoder)
 		defer d.unzstdPool.Put(unzstd)
-		return unzstd.inner.DecodeAll(src, nil)
+		decoded, err := unzstd.inner.DecodeAll(src, out.Bytes())
+		if err != nil {
+			return nil, err
+		}
+		return append([]byte(nil), decoded...), nil
 	default:
 		return nil, errors.New("unknown compression codec")
 	}

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -163,7 +163,9 @@ func TestRecBatchAppendTo(t *testing.T) {
 	compressor, _ = newCompressor(CompressionCodec{codec: 2}) // snappy
 	{
 		kbatch.Attributes |= 0x0002 // snappy
-		kbatch.Records, _ = compressor.compress(sliceWriters.Get().(*sliceWriter), kbatch.Records, version)
+		w := byteBuffers.Get().(*bytes.Buffer)
+		w.Reset()
+		kbatch.Records, _ = compressor.compress(w, kbatch.Records, version)
 	}
 
 	fixFields()
@@ -254,7 +256,9 @@ func TestMessageSetAppendTo(t *testing.T) {
 		Offset:     1,
 		Attributes: 0x02,
 	}
-	kset0c.Value, _ = compressor.compress(sliceWriters.Get().(*sliceWriter), kset0raw, 1) // version 0, 1 use message set 0
+	w := byteBuffers.Get().(*bytes.Buffer)
+	w.Reset()
+	kset0c.Value, _ = compressor.compress(w, kset0raw, 1) // version 0, 1 use message set 0
 	kset0c.CRC = int32(crc32.ChecksumIEEE(kset0c.AppendTo(nil)[16:]))
 	kset0c.MessageSize = int32(len(kset0c.AppendTo(nil)[12:]))
 
@@ -265,7 +269,9 @@ func TestMessageSetAppendTo(t *testing.T) {
 		Attributes: 0x02,
 		Timestamp:  kset11.Timestamp,
 	}
-	kset1c.Value, _ = compressor.compress(sliceWriters.Get().(*sliceWriter), kset1raw, 2) // version 2 use message set 1
+	wbuf := byteBuffers.Get().(*bytes.Buffer)
+	wbuf.Reset()
+	kset1c.Value, _ = compressor.compress(wbuf, kset1raw, 2) // version 2 use message set 1
 	kset1c.CRC = int32(crc32.ChecksumIEEE(kset1c.AppendTo(nil)[16:]))
 	kset1c.MessageSize = int32(len(kset1c.AppendTo(nil)[12:]))
 

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -2094,8 +2094,9 @@ func (b seqRecBatch) appendTo(
 	m.CompressedBytes = m.UncompressedBytes
 
 	if compressor != nil {
-		w := sliceWriters.Get().(*sliceWriter)
-		defer sliceWriters.Put(w)
+		w := byteBuffers.Get().(*bytes.Buffer)
+		defer byteBuffers.Put(w)
+		w.Reset()
 
 		compressed, codec := compressor.compress(w, toCompress, version)
 		if compressed != nil && // nil would be from an error
@@ -2175,8 +2176,9 @@ func (b seqRecBatch) appendToAsMessageSet(dst []byte, version uint8, compressor 
 	m.CompressedBytes = m.UncompressedBytes
 
 	if compressor != nil {
-		w := sliceWriters.Get().(*sliceWriter)
-		defer sliceWriters.Put(w)
+		w := byteBuffers.Get().(*bytes.Buffer)
+		defer byteBuffers.Put(w)
+		w.Reset()
 
 		compressed, codec := compressor.compress(w, toCompress, int16(version))
 		inner := &Record{Value: compressed}


### PR DESCRIPTION
This MR resolves #623 by using a byte buffer in decompression instead of always creating a new one. It also replaces the custom `sliceWriter` with the standard `bytes.Buffer` everywhere.