### PR TITLE
Add Conduit to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ In alphabetical order,
 * [Alpaca](https://alpaca.markets/blog/alpaca-launches-next-gen-order-management-system/)
 * [Banyan](https://banyan.com)
 * [Benthos](https://www.benthos.dev/)
+* [Conduit](https://github.com/ConduitIO/conduit)
 * [DeltaStream](https://deltastream.io/)
 * [EasyPost](https://easypost.com/)
 * [Eoitek](https://eoitek.com/)


### PR DESCRIPTION
@twmb A huge thanks for this project!

We use it in Conduit, but also a few related but separate projects (our Kafka connector and our own schema registry). 

By the way, what do you think about removing Benthos, given that it's now Redpanda Connect? 