### PR TITLE
README: `kafka-go` also works with Confluent Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This library attempts to provide an intuitive API while interacting with Kafka t
 
 - [**Redpanda**](https://vectorized.io/): the fastest and most efficient Kafka compatible event streaming platform
 - **Kafka**: the original Java project
+- **Confluent Platform**
 - **Microsoft Event Hubs**
   - Event Hubs does [not support][MSEH] producing with compression; be sure to use `kgo.ProducerBatchCompression(kgo.NoCompression)`.
 - **Amazon MSK**


### PR DESCRIPTION
This simple PR updates the main README file to mention that `kafka-go` also works with Confluent Platform clusters.

We have been using this library for a while in production against Confluent Platform clusters with excellent results.
Therefore, make it clear that a user can expect this library to work well with CP as well.
