### PR TITLE
kgo: export the wrapped error from ErrGroupSession

### DIFF
--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -298,11 +298,11 @@ func (e *errUnknownCoordinator) Error() string {
 // consumer group member was kicked from the group or was never able to join
 // the group.
 type ErrGroupSession struct {
-	err error
+	Err error
 }
 
 func (e *ErrGroupSession) Error() string {
-	return fmt.Sprintf("unable to join group session: %v", e.err)
+	return fmt.Sprintf("unable to join group session: %v", e.Err)
 }
 
-func (e *ErrGroupSession) Unwrap() error { return e.err }
+func (e *ErrGroupSession) Unwrap() error { return e.Err }


### PR DESCRIPTION
We want to test in a unit test the behaviour exposed in this question: https://github.com/twmb/franz-go/issues/784, where we rely on this error type. So we need to create this kind of error, with another wrapped one inside it in the tests.

Would this change be ok? The only side efect of it is that clients of the lib would be able to create it too.