### PR TITLE
sr: fix body of cl.SetMode

### DIFF
--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -773,7 +773,10 @@ func (cl *Client) SetMode(ctx context.Context, mode Mode, subjects ...string) []
 		go func() {
 			defer wg.Done()
 			var m modeResponse
-			err := cl.put(ctx, pathMode(subject), mode, &m)
+			body := struct {
+				Mode Mode `json:"mode"`
+			}{mode}
+			err := cl.put(ctx, pathMode(subject), body, &m)
 			results[slot] = ModeResult{
 				Subject: subject,
 				Mode:    m.Mode,


### PR DESCRIPTION
The client missed the 'mode' key in the sr's PUT /mode body.

Documentation of the required body: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#put--mode