### PR TITLE
Clarify bytes metrics description

### DIFF
--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -176,7 +176,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Subsystem:   subsystem,
 		ConstLabels: constLabels,
 		Name:        "write_bytes_total",
-		Help:        "Total number of bytes written",
+		Help:        "Total number of bytes written to the TCP connection. The bytes count is tracked after compression (when used).",
 	}, []string{"node_id"})
 
 	m.writeErrorsTotal = factory.NewCounterVec(prometheus.CounterOpts{
@@ -212,7 +212,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Subsystem:   subsystem,
 		ConstLabels: constLabels,
 		Name:        "read_bytes_total",
-		Help:        "Total number of bytes read",
+		Help:        "Total number of bytes read from the TCP connection. The bytes count is tracked before uncompression (when used).",
 	}, []string{"node_id"})
 
 	m.readErrorsTotal = factory.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Earlier today I was wondering where exactly `write_bytes_total` and `read_bytes_total` are tracked, and I realized it counts the bytes we write and read from the wire.

What do you think if we clarify it in the metric description, including a specific mention with regards to compression?