### PR TITLE
Remove unnecessary condition  in if statements

### DIFF
--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -429,7 +429,7 @@ retry:
 			"state_currently_committed", currentCommit,
 		)
 		s.cl.setOffsets(currentCommit, false)
-	} else if willTryCommit && endTxnErr == nil {
+	} else if willTryCommit {
 		s.cl.cfg.logger.Log(LogLevelInfo, "transact session successful, setting to newly committed state",
 			"tried_commit", willTryCommit,
 			"postcommit", postcommit,


### PR DESCRIPTION
The code satisfies the condition in the first line when `endTxnErr` is not `nil`.
Therefore, when it reaches the third line, `endTxnErr` must always be `nil`. As a result, I think the `endTxnErr == nil` check in the third line is redundant.

```go
if !willTryCommit || endTxnErr != nil {
    ...
} else if willTryCommit && endTxnErr == nil {
    ...
}
```

