### PR TITLE
sr: add support for using bearer tokens in client

### DIFF
--- a/pkg/sr/client.go
+++ b/pkg/sr/client.go
@@ -60,6 +60,7 @@ type Client struct {
 		user string
 		pass string
 	}
+	bearerToken string
 }
 
 // NewClient returns a new schema registry client.
@@ -126,6 +127,9 @@ start:
 	req.Header.Set("User-Agent", cl.ua)
 	if cl.basicAuth != nil {
 		req.SetBasicAuth(cl.basicAuth.user, cl.basicAuth.pass)
+	}
+	if cl.bearerToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cl.bearerToken))
 	}
 	cl.applyParams(ctx, req)
 

--- a/pkg/sr/clientopt.go
+++ b/pkg/sr/clientopt.go
@@ -77,6 +77,14 @@ func BasicAuth(user, pass string) ClientOpt {
 	}}
 }
 
+// BearerToken sets an Authorization header to use for every request.
+// The format will be: "Authorization: Bearer $token".
+func BearerToken(token string) ClientOpt {
+	return clientOpt{func(cl *Client) {
+		cl.bearerToken = token
+	}}
+}
+
 // DefaultParams sets default parameters to apply to every request.
 func DefaultParams(ps ...Param) ClientOpt {
 	return clientOpt{func(cl *Client) {


### PR DESCRIPTION
Add support for specifying bearer tokens in the schema registry client.