### PR TITLE
Don't set nil config when seeding topics in kfake cluster

### DIFF
--- a/pkg/kfake/data.go
+++ b/pkg/kfake/data.go
@@ -92,7 +92,9 @@ func (d *data) mkt(t string, nparts int, nreplicas int, configs map[string]*stri
 	d.id2t[id] = t
 	d.t2id[t] = id
 	d.treplicas[t] = nreplicas
-	d.tcfgs[t] = configs
+	if configs != nil {
+		d.tcfgs[t] = configs
+	}
 	for i := 0; i < nparts; i++ {
 		d.tps.mkp(t, int32(i), d.c.newPartData)
 	}


### PR DESCRIPTION
Setting the configs to `nil` causes it to panic later when trying to alter the topic configs, as [it only checks for entry in the map not being present, not for it not being nil](https://github.com/colega/franz-go/blob/f1cded5cc755374d6cac290c23da247ce5eb4e7a/pkg/kfake/data.go#L259-L261).

