### PR TITLE
`*kgo.Record` pooling support

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -151,6 +151,8 @@ type cfg struct {
 	partitions map[string]map[int32]Offset // partitions to directly consume from
 	regex      bool
 
+	recordsPool recordsPool
+
 	////////////////////////////
 	// CONSUMER GROUP SECTION //
 	////////////////////////////
@@ -1345,6 +1347,18 @@ func ConsumePartitions(partitions map[string]map[int32]Offset) ConsumerOpt {
 // permanently is known to match, or is permanently known to not match.
 func ConsumeRegex() ConsumerOpt {
 	return consumerOpt{func(cfg *cfg) { cfg.regex = true }}
+}
+
+// EnableRecordsPool sets the client to obtain the *kgo.Record objects from a pool,
+// in order to minimize the number of allocations.
+//
+// By enabling this option, the records returned by PollFetches/PollRecords
+// can be sent back to the pool via ReuseRecords method in order to be recycled.
+//
+// This option is particularly useful for use cases where the volume of generated records is very high,
+// as it can negatively impact performance due to the extra GC overhead.
+func EnableRecordsPool() ConsumerOpt {
+	return consumerOpt{func(cfg *cfg) { cfg.recordsPool = newRecordsPool() }}
 }
 
 // DisableFetchSessions sets the client to not use fetch sessions (Kafka 1.0+).

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1353,7 +1353,7 @@ func ConsumeRegex() ConsumerOpt {
 // in order to minimize the number of allocations.
 //
 // By enabling this option, the records returned by PollFetches/PollRecords
-// can be sent back to the pool via ReuseRecords method in order to be recycled.
+// can be sent back to the pool via Reuse method in order to be recycled.
 //
 // This option is particularly useful for use cases where the volume of generated records is very high,
 // as it can negatively impact performance due to the extra GC overhead.

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -149,6 +149,19 @@ type Record struct {
 	// producer hooks. It can also be set in a consumer hook to propagate
 	// enrichment to consumer clients.
 	Context context.Context
+
+	// recordsPool is the pool that this record was fetched from, if any.
+	//
+	// When reused, record is returned to this pool.
+	recordsPool recordsPool
+}
+
+// Reuse releases the record back to the pool.
+//
+// Once this method has been called, any reference to the passed record should be considered invalid by the caller,
+// as it may be reused as a result of future calls to the PollFetches/PollRecords method.
+func (r *Record) Reuse() {
+	r.recordsPool.put(r)
 }
 
 func (r *Record) userSize() int64 {


### PR DESCRIPTION
This PR resolves https://github.com/twmb/franz-go/issues/823 by allowing to reuse consumed records via `kgo.(*Record).Reuse` method.