### PR TITLE
Add Opts method for sr.Client

### DIFF
--- a/pkg/sr/client.go
+++ b/pkg/sr/client.go
@@ -55,6 +55,7 @@ type Client struct {
 	httpcl    *http.Client
 	ua        string
 	defParams Param
+	opts      []ClientOpt
 
 	basicAuth *struct {
 		user string
@@ -69,6 +70,7 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 		urls:   []string{"http://localhost:8081"},
 		httpcl: &http.Client{Timeout: 5 * time.Second},
 		ua:     "franz-go",
+		opts:   opts,
 	}
 
 	for _, opt := range opts {
@@ -80,6 +82,13 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 	}
 
 	return cl, nil
+}
+
+// Opts returns the options that were used to create this client. This can be
+// as a base to generate a new client, where you can add override options to
+// the end of the original input list.
+func (cl *Client) Opts() []ClientOpt {
+	return cl.opts
 }
 
 func (cl *Client) get(ctx context.Context, path string, into any) error {


### PR DESCRIPTION
This adds the equivalent of `kgo.Client.Opts()` to the `sr.Client` implementation. The use-case would be if you want to initialize a Schema Registry client with an existing Schema Registry client, but say do something like change the credentials being used for authentication.