### PR TITLE
kgo: fix potential deadlock when reaching max buffered (records|bytes)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,9 +24,9 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - copyloopvar
     - durationcheck
     - exhaustive
-    - exportloopref
     - gocritic
     - gofmt
     - gofumpt
@@ -74,6 +74,7 @@ linters-settings:
     excludes:
       - G104 # unhandled errors, we exclude for the same reason we do not use errcheck
       - G404 # we want math/rand
+      - G115 # irrelevant flags in this repo
 
   # Gocritic is a meta linter that has very good lints, and most of the
   # experimental ones are very good too. We opt into everything, which helps

--- a/generate/gen.go
+++ b/generate/gen.go
@@ -625,7 +625,7 @@ func (s Struct) WriteDefault(l *LineWriter) {
 
 func (s Struct) WriteDefn(l *LineWriter) {
 	if s.Comment != "" {
-		l.Write(s.Comment)
+		l.Write(s.Comment) //nolint:govet // ...
 	}
 	l.Write("type %s struct {", s.Name)
 	if s.TopLevel {
@@ -822,7 +822,7 @@ func (s Struct) WriteNewPtrFunc(l *LineWriter) {
 
 func (e Enum) WriteDefn(l *LineWriter) {
 	if e.Comment != "" {
-		l.Write(e.Comment)
+		l.Write(e.Comment) //nolint:govet // ...
 		l.Write("// ")
 	}
 	l.Write("// Possible values and their meanings:")
@@ -830,7 +830,7 @@ func (e Enum) WriteDefn(l *LineWriter) {
 	for _, v := range e.Values {
 		l.Write("// * %d (%s)", v.Value, v.Word)
 		if len(v.Comment) > 0 {
-			l.Write(v.Comment)
+			l.Write(v.Comment) //nolint:govet // ...
 		}
 		l.Write("//")
 	}

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -345,8 +345,8 @@ type FetchError struct {
 //     client for.
 //
 //  3. an untyped batch parse failure; these are usually unrecoverable by
-//     restarts, and it may be best to just let the client continue. However,
-//     restarting is an option, but you may need to manually repair your
+//     restarts, and it may be best to just let the client continue.
+//     Restarting is an option, but you may need to manually repair your
 //     partition.
 //
 //  4. an injected ErrClientClosed; this is a fatal informational error that


### PR DESCRIPTION
Problem:
* Record A exceeds max, is on path to block
* Record B finishes concurrently
* Record A's context cancels
* Record A's goroutine waiting to be unblocked returns, leaves accounting mutex in locked state
* Record A's select statement chooses context-canceled case, trying to grab the accounting mutex lock

See #831 for more details.

Closes #831.