### PR TITLE
kgo: do not add all topics to internal tps map when regex consuming

### DIFF
--- a/pkg/kgo/consumer_direct.go
+++ b/pkg/kgo/consumer_direct.go
@@ -65,29 +65,11 @@ func (*directConsumer) getSetAssigns(setOffsets map[string]map[int32]EpochOffset
 func (d *directConsumer) findNewAssignments() map[string]map[int32]Offset {
 	topics := d.tps.load()
 
-	var rns reNews
-	if d.cfg.regex {
-		defer rns.log(d.cfg)
-	}
-
 	toUse := make(map[string]map[int32]Offset, 10)
 	for topic, topicPartitions := range topics {
 		var useTopic bool
 		if d.cfg.regex {
-			want, seen := d.reSeen[topic]
-			if !seen {
-				for rawRe, re := range d.cfg.topics {
-					if want = re.MatchString(topic); want {
-						rns.add(rawRe, topic)
-						break
-					}
-				}
-				if !want {
-					rns.skip(topic)
-				}
-				d.reSeen[topic] = want
-			}
-			useTopic = want
+			useTopic = d.reSeen[topic]
 		} else {
 			useTopic = d.m.onlyt(topic)
 		}

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -350,6 +350,14 @@ func (cl *Client) updateMetadata() (retryWhy multiUpdateWhy, err error) {
 		for topic := range latest {
 			allTopics = append(allTopics, topic)
 		}
+
+		// We filter out topics will not match any of our regex's.
+		// This ensures that the `tps` field does not contain topics
+		// we will never use (the client works with misc. topics in
+		// there, but it's better to avoid it -- and allows us to use
+		// `tps` in GetConsumeTopics).
+		allTopics = c.filterMetadataAllTopics(allTopics)
+
 		tpsConsumerLoad = tpsConsumer.ensureTopics(allTopics)
 		defer tpsConsumer.storeData(tpsConsumerLoad)
 


### PR DESCRIPTION
The internal tps map is meant to be what we store topicPartitions in that we are candidates to be consumed. This is filtered in assignPartitions to only opt-in partitions that are actually being consumed.

It's not BAD if we store all topics in that map, but it's not the intent. The rest of the client worked fine even with extra topics in the map.

When regex consuming, the metadata function previously put all topics into the map always. Now, we move the regex evaluation logic -- duplicated in both the direct and group consumers -- into one function and use that for filtering within metadata.

This introduces a required sequence of filtering THEN finding assignments, which is fine / was the way things operated anyway.

Moving the filtering to metadata (only in the regex consuming logic) means that we no longer store information for topics we are not consuming. Indirectly, this fixes a bug where `GetConsumeTopics` would always return ALL topics when regex consuming, because `GetConsumeTopics` always just returned what was in the `tps` field.

This adds a test for the fixed behavior, as well as tests that NOT regex consuming always returns all topics the user is interested in.

Closes #810.