### PR TITLE
kgo: add EnsureProduceConnectionIsOpen

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -41,6 +41,8 @@ func (p *pinReq) SetVersion(v int16) {
 	p.Request.SetVersion(v)
 }
 
+type forceOpenReq struct{ kmsg.Request }
+
 type promisedReq struct {
 	ctx     context.Context
 	req     kmsg.Request
@@ -408,6 +410,16 @@ start:
 	default:
 	}
 
+	if _, isForceOpen := req.(*forceOpenReq); isForceOpen {
+		// We issue ApiVersions with v0; we could try to bound the
+		// version by going to the start above, but it really does
+		// not matter much.
+		kreq := kmsg.NewPtrApiVersionsRequest()
+		kreq.ClientSoftwareName = b.cl.cfg.softwareName
+		kreq.ClientSoftwareVersion = b.cl.cfg.softwareVersion
+		req = kreq
+	}
+
 	// Produce requests (and only produce requests) can be written
 	// without receiving a reply. If we see required acks is 0,
 	// then we immediately call the promise with no response.
@@ -766,6 +778,7 @@ start:
 			maxVersion = 0
 			goto start
 		}
+		cxn.cl.cfg.logger.Log(LogLevelDebug, "broker does not know our ApiVersions version but replied with all keys, deserializing as v0", "broker", logID(cxn.b.meta.NodeID))
 		resp.Version = 0
 	}
 
@@ -1471,6 +1484,11 @@ func (cxn *brokerCxn) handleResp(pr promisedResp) {
 		pr.promise(nil, err)
 		cxn.die()
 		return
+	}
+
+	if pr.resp.Key() == 18 && len(rawResp) > 2 && rawResp[1] == 35 {
+		cxn.b.cl.cfg.logger.Log(LogLevelDebug, "ApiVersions response returned with UNSUPPORTED_VERSION error at byte 1, downgraded to v0 to deserialize response")
+		pr.resp.SetVersion(0)
 	}
 
 	cxn.successes++

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -101,6 +101,83 @@ func (cl *Client) BufferedProduceBytes() int64 {
 	return cl.producer.bufferedBytes + cl.producer.blockedBytes
 }
 
+// EnsureProduceConnectionIsOpen attempts to open a produce connection to all
+// specified brokers, or all brokers if `brokers` is empty or contains -1.
+//
+// This can be used in an attempt to reduce the latency when producing if your
+// application produces infrequently: you can force open a produce connection a
+// bit earlier than you intend to produce, rather than at the moment you
+// produce. In rare circumstances, it is possible that a connection that was
+// ensured to be open may close before you produce.
+//
+// This returns an errors.Join'd error that merges a message for all brokers
+// that failed to be opened as well as why.
+func (cl *Client) EnsureProduceConnectionIsOpen(ctx context.Context, brokers ...int32) error {
+	var (
+		keep = brokers[:0]
+		all  bool
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+	for _, b := range brokers {
+		switch {
+		case b < -1:
+		case b == -1:
+			all = true
+		case b > -1:
+			keep = append(keep, b)
+		}
+	}
+	var toOpen []*broker
+	if all || len(brokers) == 0 {
+		cl.brokersMu.RLock()
+		toOpen = cl.brokers
+		if len(toOpen) == 0 {
+			cl.brokersMu.RUnlock()
+			if err := cl.fetchBrokerMetadata(ctx); err != nil {
+				return err
+			}
+			cl.brokersMu.RLock()
+			toOpen = cl.brokers
+		}
+		cl.brokersMu.RUnlock()
+	} else {
+		for _, b := range brokers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				br, err := cl.brokerOrErr(ctx, b, errUnknownBroker)
+
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%d: %w", b, err))
+					return
+				}
+				toOpen = append(toOpen, br)
+			}()
+		}
+		wg.Wait()
+	}
+
+	for _, br := range toOpen {
+		wg.Add(1)
+		br.do(ctx, &forceOpenReq{new(kmsg.ProduceRequest)}, func(_ kmsg.Response, err error) {
+			defer wg.Done()
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("%d: %w", br.meta.NodeID, err))
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+
+	return errors.Join(errs...)
+}
+
 type unknownTopicProduces struct {
 	buffered []promisedRec
 	wait     chan error // retryable errors


### PR DESCRIPTION
This can help reduce latency if you produce infrequently, but know you'll be producing shortly.

Closes #807.