### PR TITLE
pkg/sr: require go 1.22

### DIFF
--- a/pkg/sr/go.mod
+++ b/pkg/sr/go.mod
@@ -1,5 +1,5 @@
 module github.com/twmb/franz-go/pkg/sr
 
-go 1.21
+go 1.22
 
 toolchain go1.22.0


### PR DESCRIPTION
No real reason, no real reason not to. This also allows one commit after the top level franz tag.