### PR TITLE
Fix handling of invalid base offsets

### DIFF
--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -553,7 +553,13 @@ start:
 	p.promisesMu.Lock()
 	for i, pr := range b.recs {
 		pr.LeaderEpoch = 0
-		pr.Offset = b.baseOffset + int64(i)
+		if b.baseOffset == -1 {
+			// if the base offset is invalid/unknown (-1), all record offsets should
+			// be treated as unknown
+			pr.Offset = -1
+		} else {
+			pr.Offset = b.baseOffset + int64(i)
+		}
 		pr.Partition = b.partition
 		pr.ProducerID = b.pid
 		pr.ProducerEpoch = b.epoch

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1773,7 +1773,11 @@ func recordToRecord(
 		ProducerID:    batch.ProducerID,
 		ProducerEpoch: batch.ProducerEpoch,
 		LeaderEpoch:   batch.PartitionLeaderEpoch,
-		Offset:        batch.FirstOffset + int64(record.OffsetDelta),
+	}
+	if batch.FirstOffset == -1 {
+		r.Offset = -1
+	} else {
+		r.Offset = batch.FirstOffset + int64(record.OffsetDelta)
 	}
 	if r.Attrs.TimestampType() == 0 {
 		r.Timestamp = timeFromMillis(batch.FirstTimestamp + record.TimestampDelta64)


### PR DESCRIPTION
When a successfully produced batch is returned with an invalid base offset (-1) but no error, the records' internal offsets are being miscomputed from this value. An invalid offset is returned with a non-errored batch primarily in situations where a duplicate idempotent produce is detected, but the actual base offset cannot be provided. [Apache Kafka's producer client handles this](https://github.com/apache/kafka/blob/9d65ff8077fdfe1c2f1ec647fe5c0e6dac405622/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java#L49C1-L50C1) by setting all record offsets to -1 if the batch's base offset is -1.

This patch makes this correction in the kgo producer callback logic, as well as in the `recordToRecord` function (though an invalid offset is probably impossible on the fetch side).