### PR TITLE
kgo: fix accounting when topics/partitions are {,un}paused for PollRecords

### DIFF
--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -350,7 +350,9 @@ type HookProduceRecordPartitioned interface {
 // As an example, if using HookProduceRecordBuffered for a gauge of how many
 // record bytes are buffered, this hook can be used to decrement the gauge.
 //
-// Note that this hook will slow down high-volume producing a bit.
+// Note that this hook will slow down high-volume producing a bit. As well,
+// records that were buffered but are paused (and stripped internally before
+// being returned to the user) will still be passed to this hook.
 type HookProduceRecordUnbuffered interface {
 	// OnProduceRecordUnbuffered is passed a record that is just about to
 	// have its produce promise called, as well as the error that the


### PR DESCRIPTION
Topics or partitions that were paused (in `takeNBuffered` specifically, which is used by PollRecords) did not have proper accounting for stripped (removed) topics or partitions. PollFetches does not have this problem because the logic is different -- we build a big fetch, call our accounting logic, and then remove the stripped topics & partitions. Instead in takeNBuffered, we skip topics and partitions as we build a fetch and then once the fetch is built, do the accounting.

The fix is to build a separate internal-only fetch of everything that was stripped and pass that to our accounting hooks.

Fixes #865.