### PR TITLE
Making retry behaviour work as expected

### DIFF
--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1613,7 +1613,7 @@ func (b *recBatch) maybeFailErr(cfg *cfg) error {
 	switch {
 	case b.isTimedOut(cfg.recordTimeout):
 		return ErrRecordTimeout
-	case b.tries >= cfg.recordRetries:
+	case b.tries > cfg.recordRetries:
 		return ErrRecordRetries
 	case b.owner.cl.producer.isAborting():
 		return ErrAborting


### PR DESCRIPTION
If kgo.RecordRetries is set to 0 no record will be sent. This is not a major issue but since the configuration is named "retries" it's behavior is incorrect. 
