### PR TITLE
kgo: allow compressor & decompressors to be entirely user driven; allow users to inject memory pools

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,163 +1,173 @@
-# We may as well allow multiple golangci-lint invocations at once.
+version: "2"
 run:
-  allow-parallel-runners: true
   go: "1.22"
-
-# golangci-lint by default ignores some staticcheck and vet raised issues that
-# are actually important to catch. The following ensures that we do not ignore
-# those tools ever.
-issues:
-  exclude-use-default: false
-  max-same-issues: 0 # print all failures
-
+  allow-parallel-runners: true
 linters:
-  disable-all: true
+  default: none
   enable:
-    # Enabled by default linters: we want all except errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
-    # Not enabled by default: we want a good chunk
+
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose
     - copyloopvar
+    - decorder
+    - durationcheck
     - durationcheck
     - exhaustive
+    - exptostd
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - gocritic
-    - gofmt
-    - gofumpt
-    - goimports
     - goprintffuncname
     - gosec
+    - gosmopolitan
+    - grouper
+    - iface
+    - importas
+    - makezero
+    - mirror
     - misspell
     - nilerr
     - noctx
     - nolintlint
     - revive
     - rowserrcheck
+    - spancheck
     - sqlclosecheck
-    - usetesting
     - unconvert
     - unparam
+    - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
 
-linters-settings:
-  # A default case ensures we have checked everything. We should not require
-  # every enum to be checked if we want to default.
-  exhaustive:
-    default-signifies-exhaustive: true
+  settings:
 
-  # If we want to opt out of a lint, we require an explanation.
-  nolintlint:
-    allow-unused: false
-    require-explanation: true
-    require-specific: true
+    errorlint:
+      errorf: false
 
-  # We do not want every usage of fmt.Errorf to use %w.
-  errorlint:
-    errorf: false
+    exhaustive:
+      default-signifies-exhaustive: true
 
-  # If gofumpt is run outside of a module, it assumes Go 1.0 rather than the
-  # latest Go. We always want the latest formatting.
-  #
-  # https://github.com/mvdan/gofumpt/issues/137
-  gofumpt:
-    extra-rules: true
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - builtinShadow
+        - commentedOutCode
+        - emptyStringTest
+        - evalOrder
+        - ifElseChain
+        - importShadow
+        - ptrToRefParam
+        - sloppyReassign
+        - tooManyResultsChecker
+        - typeDefFirst
+        - unnamedResult
+        - unnecessaryBlock
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      settings:
+        hugeParam:
+          sizeThreshold: 256
+        rangeValCopy:
+          sizeThreshold: 256
 
-  gosec:
-    excludes:
-      - G104 # unhandled errors, we exclude for the same reason we do not use errcheck
-      - G404 # we want math/rand
-      - G115 # irrelevant flags in this repo
+    gosec:
+      excludes:
+        - G104
+        - G404
+        - G115
 
-  # Gocritic is a meta linter that has very good lints, and most of the
-  # experimental ones are very good too. We opt into everything, which helps
-  # us when we upgrade golangci-lint, and we specifically opt out of a batch.
-  #
-  # You can see what the opt-outs would flag by deleting them.
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - appendAssign
-      - builtinShadow
-      - commentedOutCode
-      - emptyStringTest
-      - evalOrder
-      - ifElseChain
-      - importShadow
-      - ptrToRefParam
-      - sloppyReassign
-      - tooManyResultsChecker
-      - typeDefFirst
-      - unnamedResult
-      - unnecessaryBlock
-    settings:
-      hugeParam:
-        sizeThreshold: 256
-      rangeValCopy:
-        sizeThreshold: 256
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
 
-  # Revive is yet another metalinter with a bunch of useful lints. The below
-  # opts in to all of the ones we would like to use.
-  revive:
-    ignore-generated-header: true
-    severity: warning
-    confidence: 0.8
-    rules:
-      - name: atomic
-      - name: blank-imports
-      - name: bool-literal-in-expr
-      - name: call-to-gc
-      - name: constant-logical-expr
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: defer
-      - name: dot-imports
-      - name: duplicated-imports
-      - name: early-return
-      - name: empty-block
-      - name: empty-lines
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: get-return
-      - name: identical-branches
-      - name: if-return
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: optimize-operands-order
-      - name: range
-      - name: range-val-in-closure
-      - name: receiver-naming
-      - name: string-of-int
-      - name: struct-tag
-      - name: superfluous-else
-      - name: time-equal
-      - name: time-naming
-      - name: var-declaration
-      - name: unconditional-recursion
-      - name: unexported-naming
-      - name: unexported-return
-      - name: unnecessary-stmt
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: unused-receiver
-      - name: useless-break
-      - name: waitgroup-by-value
+    revive:
+      confidence: 0.8
+      severity: warning
+      rules:
+        - name: atomic
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: empty-lines
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: optimize-operands-order
+        - name: range
+        - name: range-val-in-closure
+        - name: receiver-naming
+        - name: string-of-int
+        - name: struct-tag
+        - name: superfluous-else
+        - name: time-equal
+        - name: time-naming
+        - name: var-declaration
+        - name: unconditional-recursion
+        - name: unexported-naming
+        - name: unexported-return
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: unused-receiver
+        - name: useless-break
+        - name: waitgroup-by-value
 
-  # We disable the nil ctx check, because we deliberately internally use nil
-  # contexts for beneficial reasons, and we disable the SSLv3 deprecation
-  # warning because this is solely for a debug log.
-  staticcheck:
-    checks: ["all", "-SA1012", "-SA1019"]
+    staticcheck:
+      checks:
+        - all
+        - -SA1012
+        - -SA1019
+        - -ST1003
+        - -ST1016
+        - -QF1001
+
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+issues:
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -442,7 +442,7 @@ outer:
 // Control is a function to call on any client request the cluster handles.
 //
 // If the control function returns true, then either the response is written
-// back to the client or, if there the control function returns an error, the
+// back to the client or, if the control function returns an error, the
 // client connection is closed. If both returns are nil, then the cluster will
 // loop continuing to read from the client and the client will likely have a
 // read timeout at some point.
@@ -467,7 +467,7 @@ func (c *Cluster) Control(fn func(kmsg.Request) (kmsg.Response, error, bool)) {
 // handles.
 //
 // If the control function returns true, then either the response is written
-// back to the client or, if there the control function returns an error, the
+// back to the client or, if the control function returns an error, the
 // client connection is closed. If both returns are nil, then the cluster will
 // loop continuing to read from the client and the client will likely have a
 // read timeout at some point.

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -154,7 +154,7 @@ func validateCfg(opts ...Opt) (cfg, []hostport, error) {
 		}
 	}
 	if cfg.decompressor == nil {
-		cfg.decompressor = DefaultDecompressor()
+		cfg.decompressor = DefaultDecompressor(cfg.pools...)
 	}
 
 	return cfg, seeds, nil
@@ -284,6 +284,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.sasls}
 	case namefn(WithHooks):
 		return []any{cfg.hooks}
+	case namefn(WithPools):
+		return []any{cfg.pools}
 	case namefn(ConcurrentTransactionsBackoff):
 		return []any{cfg.txnBackoff}
 	case namefn(ConsiderMissingTopicDeletedAfter):

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -572,7 +572,7 @@ func (cl *Client) Ping(ctx context.Context) error {
 }
 
 // PurgeTopicsFromClient internally removes all internal information about the
-// input topics. If you you want to purge information for only consuming or
+// input topics. If you want to purge information for only consuming or
 // only producing, see the related functions [PurgeTopicsFromConsuming] and
 // [PurgeTopicsFromProducing].
 //
@@ -995,7 +995,7 @@ func (cl *Client) updateBrokers(brokers []kmsg.MetadataResponseBroker) {
 // will hang if you polled, did not allow rebalances, and want to close. Close
 // does not automatically allow rebalances because leaving a group causes a
 // revoke, and the client does not assume that the final revoke is concurrency
-// safe. The CloseAllowingRebalance function exists a a shortcut to opt into
+// safe. The CloseAllowingRebalance function exists a shortcut to opt into
 // allowing rebalance while closing.
 //
 // If you are using static membership, CloseAllowingRebalance will NOT send a
@@ -2046,7 +2046,7 @@ func (cl *Client) handleReqWithCoordinator(
 
 // Broker returns a handle to a specific broker to directly issue requests to.
 // Note that there is no guarantee that this broker exists; if it does not,
-// requests will fail with with an unknown broker error.
+// requests will fail with an unknown broker error.
 func (cl *Client) Broker(id int) *Broker {
 	return &Broker{
 		id: int32(id),

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -80,9 +80,6 @@ type Client struct {
 	producer producer
 	consumer consumer
 
-	compressor   Compressor
-	decompressor Decompressor
-
 	coordinatorsMu sync.Mutex
 	coordinators   map[coordinatorKey]*coordinatorLoad
 
@@ -119,7 +116,7 @@ type hostport struct {
 
 // ValidateOpts returns an error if the options are invalid.
 func ValidateOpts(opts ...Opt) error {
-	_, _, _, err := validateCfg(opts...)
+	_, _, err := validateCfg(opts...)
 	return err
 }
 
@@ -138,23 +135,29 @@ func parseSeeds(addrs []string) ([]hostport, error) {
 // This function validates the configuration and returns a few things that we
 // initialize while validating. The difference between this and NewClient
 // initialization is all NewClient initialization is infallible.
-func validateCfg(opts ...Opt) (cfg, []hostport, Compressor, error) {
+func validateCfg(opts ...Opt) (cfg, []hostport, error) {
 	cfg := defaultCfg()
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
 	if err := cfg.validate(); err != nil {
-		return cfg, nil, nil, err
+		return cfg, nil, err
 	}
 	seeds, err := parseSeeds(cfg.seedBrokers)
 	if err != nil {
-		return cfg, nil, nil, err
+		return cfg, nil, err
 	}
-	compressor, err := DefaultCompressor(cfg.compression...)
-	if err != nil {
-		return cfg, nil, nil, err
+	if cfg.compressor == nil {
+		cfg.compressor, err = DefaultCompressor(cfg.compression...)
+		if err != nil {
+			return cfg, nil, err
+		}
 	}
-	return cfg, seeds, compressor, nil
+	if cfg.decompressor == nil {
+		cfg.decompressor = DefaultDecompressor()
+	}
+
+	return cfg, seeds, nil
 }
 
 func namefn(fn any) string {
@@ -298,6 +301,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.maxProduceInflight}
 	case namefn(ProducerBatchCompression):
 		return []any{cfg.compression}
+	case namefn(WithCompressor):
+		return []any{cfg.compressor}
 	case namefn(ProducerBatchMaxBytes):
 		return []any{cfg.maxRecordBatchBytes}
 	case namefn(MaxBufferedRecords):
@@ -334,6 +339,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.partitions}
 	case namefn(ConsumePreferringLagFn):
 		return []any{cfg.preferLagFn}
+	case namefn(WithDecompressor):
+		return []any{cfg.decompressor}
 	case namefn(ConsumeRegex):
 		return []any{cfg.regex}
 	case namefn(ConsumeResetOffset):
@@ -420,7 +427,7 @@ func (cl *Client) OptValues(opt any) []any {
 // NewClient also launches a goroutine which periodically updates the cached
 // topic metadata.
 func NewClient(opts ...Opt) (*Client, error) {
-	cfg, seeds, compressor, err := validateCfg(opts...)
+	cfg, seeds, err := validateCfg(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -485,9 +492,6 @@ func NewClient(opts ...Opt) (*Client, error) {
 
 		bufPool: newBufPool(),
 		prsPool: newPrsPool(),
-
-		compressor:   compressor,
-		decompressor: DefaultDecompressor(),
 
 		coordinators: make(map[coordinatorKey]*coordinatorLoad),
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -80,8 +80,8 @@ type Client struct {
 	producer producer
 	consumer consumer
 
-	compressor   *compressor
-	decompressor *decompressor
+	compressor   Compressor
+	decompressor Decompressor
 
 	coordinatorsMu sync.Mutex
 	coordinators   map[coordinatorKey]*coordinatorLoad
@@ -138,7 +138,7 @@ func parseSeeds(addrs []string) ([]hostport, error) {
 // This function validates the configuration and returns a few things that we
 // initialize while validating. The difference between this and NewClient
 // initialization is all NewClient initialization is infallible.
-func validateCfg(opts ...Opt) (cfg, []hostport, *compressor, error) {
+func validateCfg(opts ...Opt) (cfg, []hostport, Compressor, error) {
 	cfg := defaultCfg()
 	for _, opt := range opts {
 		opt.apply(&cfg)
@@ -150,7 +150,7 @@ func validateCfg(opts ...Opt) (cfg, []hostport, *compressor, error) {
 	if err != nil {
 		return cfg, nil, nil, err
 	}
-	compressor, err := newCompressor(cfg.compression...)
+	compressor, err := DefaultCompressor(cfg.compression...)
 	if err != nil {
 		return cfg, nil, nil, err
 	}
@@ -487,7 +487,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 		prsPool: newPrsPool(),
 
 		compressor:   compressor,
-		decompressor: newDecompressor(),
+		decompressor: DefaultDecompressor(),
 
 		coordinators: make(map[coordinatorKey]*coordinatorLoad),
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -369,6 +369,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.rack}
 	case namefn(KeepRetryableFetchErrors):
 		return []any{cfg.keepRetryableFetchErrors}
+	case namefn(DisableFetchCRCValidation):
+		return []any{cfg.disableFetchCRCValidation}
 
 	case namefn(AdjustFetchOffsetsFn):
 		return []any{cfg.adjustOffsetsBeforeAssign}

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -16,14 +16,27 @@ import (
 
 var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, 8<<10)) }}
 
-type codecType int8
+// CompressionCodecType is a bitfield specifying a Kafka-defined compression
+// codec. Per spec, only four compression codecs are supported. However, if
+// you control both the producer and consumer, you can technically override the
+// codec to anything.
+type CompressionCodecType int8
 
 const (
-	codecNone codecType = iota
-	codecGzip
-	codecSnappy
-	codecLZ4
-	codecZstd
+	// CodecNone is a compression codec signifying no compression is used.
+	CodecNone CompressionCodecType = iota
+	// CodecGzip is a compression codec signifying gzip compression.
+	CodecGzip
+	// CodecSnappy is a compression codec signifying snappy compression.
+	CodecSnappy
+	// CodecLz4 is a compression codec signifying lz4 compression.
+	CodecLz4
+	// CodecZstd is a compression codec signifying zstd compression.
+	CodecZstd
+
+	// CodecError is returned from compressing or decompressing if an error
+	// occurred.
+	CodecError = -1
 )
 
 // CompressionCodec configures how records are compressed before being sent.
@@ -32,25 +45,52 @@ const (
 // RecordBatch. All records in a RecordBatch are compressed into one record
 // for that batch.
 type CompressionCodec struct {
-	codec codecType
+	codec CompressionCodecType
 	level int
 }
 
 // NoCompression is a compression option that avoids compression. This can
 // always be used as a fallback compression.
-func NoCompression() CompressionCodec { return CompressionCodec{codecNone, 0} }
+func NoCompression() CompressionCodec { return CompressionCodec{CodecNone, 0} }
 
 // GzipCompression enables gzip compression with the default compression level.
-func GzipCompression() CompressionCodec { return CompressionCodec{codecGzip, gzip.DefaultCompression} }
+func GzipCompression() CompressionCodec { return CompressionCodec{CodecGzip, gzip.DefaultCompression} }
 
 // SnappyCompression enables snappy compression.
-func SnappyCompression() CompressionCodec { return CompressionCodec{codecSnappy, 0} }
+func SnappyCompression() CompressionCodec { return CompressionCodec{CodecSnappy, 0} }
 
 // Lz4Compression enables lz4 compression with the fastest compression level.
-func Lz4Compression() CompressionCodec { return CompressionCodec{codecLZ4, 0} }
+func Lz4Compression() CompressionCodec { return CompressionCodec{CodecLz4, 0} }
 
 // ZstdCompression enables zstd compression with the default compression level.
-func ZstdCompression() CompressionCodec { return CompressionCodec{codecZstd, 0} }
+func ZstdCompression() CompressionCodec { return CompressionCodec{CodecZstd, 0} }
+
+// Compressor is an interface that defines how produce batches are compressed.
+// You can override the default client internal compressor for more control
+// over what compressors to use, level, and memory reuse.
+type Compressor interface {
+	// Compress compresses src and returns the compressed data as well as
+	// the codec type that was used. The 'dst' [bytes.Buffer] argument is
+	// pooled within the client and reused across calls to Compress. You
+	// can use 'dst' to save memory and return 'dst.Bytes()'. The returned
+	// slice is fully used *before* 'dst' is put back into the internal
+	// pool. As an example, you can look at the franz-go internal
+	// implementation of the default compressor in compression.go.
+	//
+	// Note that old brokers do not support zstd compression. If the
+	// produce request version is less than 7, zstd compression should
+	// not be used.
+	Compress(dst *bytes.Buffer, src []byte, produceRequestVersion int16) ([]byte, CompressionCodecType)
+}
+
+// Decompressor is an interface that defines how fetch batches are
+// decompressed. You can override the default client internal decompressor for
+// more control over what decompressors to use and memory reuse.
+type Decompressor interface {
+	// Decompress decompresses src, which is compressed with codecType,
+	// and returns the decompressed data or an error.
+	Decompress(src []byte, codecType CompressionCodecType) ([]byte, error)
+}
 
 // WithLevel changes the compression codec's "level", effectively allowing for
 // higher or lower compression ratios at the expense of CPU speed.
@@ -65,18 +105,25 @@ func (c CompressionCodec) WithLevel(level int) CompressionCodec {
 }
 
 type compressor struct {
-	options  []codecType
+	options  []CompressionCodecType
 	gzPool   sync.Pool
 	lz4Pool  sync.Pool
 	zstdPool sync.Pool
 }
 
-func newCompressor(codecs ...CompressionCodec) (*compressor, error) {
+// DefaultCompressor returns the default client compressor. The returned
+// compressor will compress produce batches in preference-order of the
+// specified codecs. Usually, you only need to specify one codec. If you are
+// speaking to an old broker that may not support zstd, you may need to specify
+// a second compressor as fallback (old Kafka did not support zstd).  If no
+// codecs are specified, or the specified codec is CodecNone, this returns
+// 'nil, nil'. A compressor is only used within the client if it is non-nil.
+func DefaultCompressor(codecs ...CompressionCodec) (Compressor, error) {
 	if len(codecs) == 0 {
 		return nil, nil
 	}
 
-	used := make(map[codecType]bool) // we keep one type of codec per CompressionCodec
+	used := make(map[CompressionCodecType]bool) // we keep one type of codec per CompressionCodec
 	var keepIdx int
 	for _, codec := range codecs {
 		if _, exists := used[codec.codec]; exists {
@@ -100,9 +147,9 @@ out:
 	for _, codec := range codecs {
 		c.options = append(c.options, codec.codec)
 		switch codec.codec {
-		case codecNone:
+		case CodecNone:
 			break out
-		case codecGzip:
+		case CodecGzip:
 			level := gzip.DefaultCompression
 			if codec.level != 0 {
 				if _, err := gzip.NewWriterLevel(nil, codec.level); err != nil {
@@ -110,8 +157,8 @@ out:
 				}
 			}
 			c.gzPool = sync.Pool{New: func() any { c, _ := gzip.NewWriterLevel(nil, level); return c }}
-		case codecSnappy: // (no pool needed for snappy)
-		case codecLZ4:
+		case CodecSnappy: // (no pool needed for snappy)
+		case CodecLz4:
 			level := codec.level
 			if level < 0 {
 				level = 0 // 0 == lz4.Fast
@@ -127,7 +174,7 @@ out:
 			}
 			w.Close()
 			c.lz4Pool = sync.Pool{New: fn}
-		case codecZstd:
+		case CodecZstd:
 			opts := []zstd.EOption{
 				zstd.WithWindowSize(64 << 10),
 				zstd.WithEncoderConcurrency(1),
@@ -148,7 +195,7 @@ out:
 		}
 	}
 
-	if c.options[0] == codecNone {
+	if c.options[0] == CodecNone {
 		return nil, nil // first codec was passthrough
 	}
 
@@ -159,15 +206,10 @@ type zstdEncoder struct {
 	inner *zstd.Encoder
 }
 
-// Compress compresses src to buf, returning buf's inner slice once done or nil
-// if an error is encountered.
-//
-// The writer should be put back to its pool after the returned slice is done
-// being used.
-func (c *compressor) compress(dst *bytes.Buffer, src []byte, produceRequestVersion int16) ([]byte, codecType) {
-	var use codecType
+func (c *compressor) Compress(dst *bytes.Buffer, src []byte, produceRequestVersion int16) ([]byte, CompressionCodecType) {
+	var use CompressionCodecType
 	for _, option := range c.options {
-		if option == codecZstd && produceRequestVersion < 7 {
+		if option == CodecZstd && produceRequestVersion < 7 {
 			continue
 		}
 		use = option
@@ -176,31 +218,31 @@ func (c *compressor) compress(dst *bytes.Buffer, src []byte, produceRequestVersi
 
 	var out []byte
 	switch use {
-	case codecNone:
+	case CodecNone:
 		return src, 0
-	case codecGzip:
+	case CodecGzip:
 		gz := c.gzPool.Get().(*gzip.Writer)
 		defer c.gzPool.Put(gz)
 		gz.Reset(dst)
 		if _, err := gz.Write(src); err != nil {
-			return nil, -1
+			return nil, CodecError
 		}
 		if err := gz.Close(); err != nil {
-			return nil, -1
+			return nil, CodecError
 		}
 		out = dst.Bytes()
-	case codecLZ4:
+	case CodecLz4:
 		lz := c.lz4Pool.Get().(*lz4.Writer)
 		defer c.lz4Pool.Put(lz)
 		lz.Reset(dst)
 		if _, err := lz.Write(src); err != nil {
-			return nil, -1
+			return nil, CodecError
 		}
 		if err := lz.Close(); err != nil {
-			return nil, -1
+			return nil, CodecError
 		}
 		out = dst.Bytes()
-	case codecSnappy:
+	case CodecSnappy:
 		// Because the Snappy and Zstd codecs do not accept an io.Writer interface
 		// and directly take a []byte slice, here, the underlying []byte slice (`dst`)
 		// obtained from the bytes.Buffer{} from the pool is passed.
@@ -209,7 +251,7 @@ func (c *compressor) compress(dst *bytes.Buffer, src []byte, produceRequestVersi
 		// reading and writing via it's (eg: accessing via `Byte()`). For subsequent
 		// reads, the underlying slice has to be used directly.
 		//
-		// In this particular context, it is acceptable as there there are no subsequent
+		// In this particular context, it is acceptable as there are no subsequent
 		// operations performed on the buffer and it is immediately returned to the
 		// pool and `Reset()` the next time it is obtained and used where `compress()`
 		// is called.
@@ -217,7 +259,7 @@ func (c *compressor) compress(dst *bytes.Buffer, src []byte, produceRequestVersi
 			dst.Grow(l)
 		}
 		out = s2.EncodeSnappy(dst.Bytes(), src)
-	case codecZstd:
+	case CodecZstd:
 		zstdEnc := c.zstdPool.Get().(*zstdEncoder)
 		defer c.zstdPool.Put(zstdEnc)
 		if l := zstdEnc.inner.MaxEncodedSize(len(src)); l > dst.Cap() {
@@ -235,7 +277,8 @@ type decompressor struct {
 	unzstdPool sync.Pool
 }
 
-func newDecompressor() *decompressor {
+// DefaultDecompressor returns the default decompressor used by clients.
+func DefaultDecompressor() Decompressor {
 	d := &decompressor{
 		ungzPool: sync.Pool{
 			New: func() any { return new(gzip.Reader) },
@@ -264,18 +307,16 @@ type zstdDecoder struct {
 	inner *zstd.Decoder
 }
 
-func (d *decompressor) decompress(src []byte, codec byte) ([]byte, error) {
-	// Early return in case there is no compression
-	compCodec := codecType(codec)
-	if compCodec == codecNone {
+func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([]byte, error) {
+	if codecType == CodecNone {
 		return src, nil
 	}
 	out := byteBuffers.Get().(*bytes.Buffer)
 	out.Reset()
 	defer byteBuffers.Put(out)
 
-	switch compCodec {
-	case codecGzip:
+	switch codecType {
+	case CodecGzip:
 		ungz := d.ungzPool.Get().(*gzip.Reader)
 		defer d.ungzPool.Put(ungz)
 		if err := ungz.Reset(bytes.NewReader(src)); err != nil {
@@ -285,7 +326,7 @@ func (d *decompressor) decompress(src []byte, codec byte) ([]byte, error) {
 			return nil, err
 		}
 		return append([]byte(nil), out.Bytes()...), nil
-	case codecSnappy:
+	case CodecSnappy:
 		if len(src) > 16 && bytes.HasPrefix(src, xerialPfx) {
 			return xerialDecode(src)
 		}
@@ -294,7 +335,7 @@ func (d *decompressor) decompress(src []byte, codec byte) ([]byte, error) {
 			return nil, err
 		}
 		return append([]byte(nil), decoded...), nil
-	case codecLZ4:
+	case CodecLz4:
 		unlz4 := d.unlz4Pool.Get().(*lz4.Reader)
 		defer d.unlz4Pool.Put(unlz4)
 		unlz4.Reset(bytes.NewReader(src))
@@ -302,7 +343,7 @@ func (d *decompressor) decompress(src []byte, codec byte) ([]byte, error) {
 			return nil, err
 		}
 		return append([]byte(nil), out.Bytes()...), nil
-	case codecZstd:
+	case CodecZstd:
 		unzstd := d.unzstdPool.Get().(*zstdDecoder)
 		defer d.unzstdPool.Put(unzstd)
 		decoded, err := unzstd.inner.DecodeAll(src, out.Bytes())

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -282,8 +282,8 @@ type decompressor struct {
 }
 
 // DefaultDecompressor returns the default decompressor used by clients.
-// The first pool provided, if any, that implements PoolDecompressBytes
-// will be used.
+// The first pool provided that implements PoolDecompressBytes will be
+// used where possible.
 func DefaultDecompressor(pools ...Pool) Decompressor {
 	d := &decompressor{
 		ungzPool: sync.Pool{
@@ -371,9 +371,8 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		}
 		if userPooled {
 			return decoded, nil
-		} else {
-			return append([]byte(nil), decoded...), nil
 		}
+		return append([]byte(nil), decoded...), nil
 	case CodecLz4:
 		unlz4 := d.unlz4Pool.Get().(*lz4.Reader)
 		defer d.unlz4Pool.Put(unlz4)
@@ -391,9 +390,8 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		}
 		if userPooled {
 			return decoded, nil
-		} else {
-			return append([]byte(nil), decoded...), nil
 		}
+		return append([]byte(nil), decoded...), nil
 	default:
 		return nil, errors.New("unknown compression codec")
 	}

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -148,9 +148,10 @@ type cfg struct {
 	preferLagFn    PreferLagFn
 	decompressor   Decompressor
 
-	maxConcurrentFetches     int
-	disableFetchSessions     bool
-	keepRetryableFetchErrors bool
+	maxConcurrentFetches      int
+	disableFetchSessions      bool
+	keepRetryableFetchErrors  bool
+	disableFetchCRCValidation bool
 
 	topics     map[string]*regexp.Regexp   // topics to consume; if regex is true, values are compiled regular expressions
 	partitions map[string]map[int32]Offset // partitions to directly consume from
@@ -1498,6 +1499,13 @@ func WithDecompressor(decompressor Decompressor) ConsumerOpt {
 // errors being returned in fetches (and ignore the other errors).
 func KeepRetryableFetchErrors() ConsumerOpt {
 	return consumerOpt{func(cfg *cfg) { cfg.keepRetryableFetchErrors = true }}
+}
+
+// DisableFetchCRCValidation disables crc32 checksum validation when fetching.
+// This should only be used if you are working with a broker that does not
+// properly support CRCs in record batches.
+func DisableFetchCRCValidation() ConsumerOpt {
+	return consumerOpt{func(cfg *cfg) { cfg.disableFetchCRCValidation = true }}
 }
 
 //////////////////////////////////

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1023,7 +1023,7 @@ func WithCompressor(compressor Compressor) ProducerOpt {
 // many record batches for many topics.
 //
 // If a single record encodes larger than this number (before compression), it
-// will will not be written and a callback will have the appropriate error.
+// will not be written and a callback will have the appropriate error.
 //
 // Note that this is the maximum size of a record batch before compression. If
 // a batch compresses poorly and actually grows the batch, the uncompressed
@@ -1180,7 +1180,7 @@ func ManualFlushing() ProducerOpt {
 // only to produce a later one successfully. This also allows for easier
 // sequence number ordering internally.
 //
-// The timeout is only evaluated evaluated before writing a request or after a
+// The timeout is only evaluated before writing a request or after a
 // produce response. Thus, a sink backoff may delay record timeout slightly.
 //
 // This option is roughly equivalent to delivery.timeout.ms.
@@ -1430,7 +1430,7 @@ func ConsumeRegex() ConsumerOpt {
 
 // DisableFetchSessions sets the client to not use fetch sessions (Kafka 1.0+).
 //
-// A "fetch session" is is a way to reduce bandwidth for fetch requests &
+// A "fetch session" is a way to reduce bandwidth for fetch requests &
 // responses, and to potentially reduce the amount of work that brokers have to
 // do to handle fetch requests. A fetch session opts into the broker tracking
 // some state of what the client is interested in. For example, say that you

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -208,7 +208,7 @@ func (cl *Client) LeaveGroup() {
 	cl.LeaveGroupContext(cl.ctx)
 }
 
-// LeaveGroup leaves a group. Close automatically leaves the group, so this is
+// LeaveGroupContext leaves a group. Close automatically leaves the group, so this is
 // only necessary to call if you plan to leave the group but continue to use
 // the client. If a rebalance is in progress, this function waits for the
 // rebalance to complete before the group can be left. This is necessary to
@@ -864,7 +864,7 @@ func (g *groupConsumer) setupAssignedAndHeartbeat() (string, error) {
 	// Before we fetch offsets, we wait for the user's onAssign callback to
 	// be done. This ensures a few things:
 	//
-	// * that we wait for for prerevoking to be done, which updates the
+	// * that we wait for prerevoking to be done, which updates the
 	// uncommitted field. Waiting for that ensures that a rejoin and poll
 	// does not have weird concurrent interaction.
 	//
@@ -1799,7 +1799,7 @@ type uncommit struct {
 type EpochOffset struct {
 	// Epoch is the leader epoch of the record being committed. Truncation
 	// detection relies on the epoch of the CURRENT record. For truncation
-	// detection, the client asks "what is the the end of this epoch?",
+	// detection, the client asks "what is the end of this epoch?",
 	// which returns one after the end offset (see the next field, and
 	// check the docs on kmsg.OffsetForLeaderEpochRequest).
 	Epoch int32

--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -238,6 +238,7 @@ func (c *testConsumer) etl(etlsBeforeQuit int) {
 					}
 				},
 			)
+			r.Recycle() // should be a no-op since we are not using pooling
 		}
 	}
 }

--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -13,7 +13,7 @@ import (
 
 // Hook is a hook to be called when something happens in kgo.
 //
-// The base Hook interface is useless, but wherever a hook can occur in kgo,
+// The base Hook interface is meaningless, but wherever a hook can occur in kgo,
 // the client checks if your hook implements an appropriate interface. If so,
 // your hook is called.
 //

--- a/pkg/kgo/pools.go
+++ b/pkg/kgo/pools.go
@@ -1,0 +1,193 @@
+package kgo
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+////////////////////////////////////////////////////////////////
+// NOTE:                                                      //
+// NOTE: Make sure new hooks are checked in implementsAnyPool //
+// NOTE:                                                      //
+////////////////////////////////////////////////////////////////
+
+// Pool is a memory pool to be used where relevant.
+//
+// The base Pool interface is meaningless, but wherever a type can be pooled in
+// kgo, the client checks if your pool implements an appropriate pool interface.
+// If so, the pool is received from (Get), and when the data is done being used,
+// the pool is put back into (Put).
+//
+// All pool interfaces in this package have Pool in the name. Pools must be safe
+// for concurrent use.
+type Pool any
+
+type pools []Pool
+
+func (ps pools) each(fn func(Pool) bool) {
+	for _, p := range ps {
+		found := fn(p)
+		if found {
+			return
+		}
+	}
+}
+
+// PoolDecompressBytes is a pool that returns a slice that decompressed data
+// will be decoded into.
+type PoolDecompressBytes interface {
+	// GetDecompressBytes returns a slice to decompress into. This
+	// interface is given the compressed data and the codec that will be
+	// used for decompressing.
+	//
+	// For many decompression algorithms, it is not possible to accurately
+	// know the size that data will be once decompressed. You can guess a
+	// multiplier, or you can use rolling statistics via FetchBatchMetrics.
+	// If the slice is not large enough, it is grown and the grown slice is
+	// put back into the pool (not the original slice, since decompression
+	// libraries often internally discard the original slice).
+	//
+	// NOTE: If you provide your own Decompressor, this function will not
+	// be called. However, PutDecompressBytes will still be called with the
+	// slice that is returned from Decompress if Decompress was called. It
+	// is expected that you use your own GetDecompressBytes in your own
+	// Decompress if you provide this pool, however, if you do not, you'll
+	// just have extra data slices put back into your pool that you never
+	// created.
+	GetDecompressBytes(compressed []byte, codec CompressionCodecType) []byte
+	// PutDecompressBytes puts a slice of that was used for decompression
+	// back into the pool. The slice is zeroed before it is put back.
+	PutDecompressBytes([]byte)
+}
+
+// PoolKRecords is a pool that returns a slice that raw kmsg.Record's are
+// decoded into.
+type PoolKRecords interface {
+	// GetKRecords returns a slice with capacity n.
+	GetKRecords(n int) []kmsg.Record
+	// PutKRecords puts a slice back into the pool.
+	PutKRecords([]kmsg.Record)
+}
+
+// PoolRecords is a pool that returns a slice of Record's.
+type PoolRecords interface {
+	// GetRecords returns a slice with capacity n.
+	GetRecords(n int) []Record
+	// PutRecords puts a slice back into the pool.
+	PutRecords([]Record)
+}
+
+func strp(s string) *string { return &s }
+
+var ctxRecRecycle = strp("rec-recycle")
+
+const recSize = unsafe.Sizeof(Record{})
+
+func recordPoolsCtx(pools []Pool, decompressBytes []byte, recs []Record) (*recordPools, context.Context) {
+	if len(recs) == 0 { // ...just in case
+		return nil, nil
+	}
+	p := &recordPools{
+		pools:           pools,
+		decompressBytes: decompressBytes,
+		recs:            recs,
+	}
+	return p, context.WithValue(context.Background(), ctxRecRecycle, p)
+}
+
+// Recycle "recycles" this record if it was taken from a pool, and frees its
+// attachment to any underlying pooled slices. If the pooled slice no longer
+// has any records attached, the slices are put back into their pools.
+//
+// This method is only relevant if you are using the [WithPools] option.
+//
+// NOTE: It is invalid to continue using the record after calling recycle;
+// doing so may result in corruption and data races. If you use
+// PoolDecompressBytes, you cannot continue to use a shallow copy of any
+// fields, you must clone them!
+func (r *Record) Recycle() {
+	if r.Context == nil {
+		return
+	}
+	v := r.Context.Value(ctxRecRecycle)
+	if v == nil {
+		return
+	}
+	*r = Record{} // prevent the Record from hanging onto anything; *kmsg.Record is already cleared during processing
+	ps := v.(*recordPools)
+
+	r0 := &ps.recs[0]
+
+	idx := int((uintptr(unsafe.Pointer(r)) - uintptr(unsafe.Pointer(r0))) / recSize) //nolint:gosec // unsafe rule (3) roughly (we don't need to convert back)
+	if idx < 0 || idx >= len(ps.recs) {
+		panic(fmt.Sprintf("recycling a record and the index %v is invalid (max pool len %v)", idx, len(ps.recs)))
+	}
+	if &ps.recs[idx] != r {
+		panic("sanity check pointer comparison index for recycling record is not the same!")
+	}
+
+	rem := ps.n.Add(-1)
+	if rem > 0 {
+		return
+	}
+
+	// Reset the length of slices to max to ensure we zero things and so
+	// that users can avoid this resetting.
+	ps.decompressBytes = ps.decompressBytes[:cap(ps.decompressBytes)]
+	ps.recs = ps.recs[:cap(ps.recs)]
+
+	for i := range ps.decompressBytes {
+		ps.decompressBytes[i] = 0 // this loop is optimized in the compiler to a memclr: https://go.dev/wiki/CompilerOptimizations#optimized-memclr
+	}
+
+	// We use len checks below because we should NOT put empty slices back
+	// into the pool (especially since the decompressBytes may never have
+	// been created!).
+	pools(ps.pools).each(func(p Pool) bool {
+		if pdecom, ok := p.(PoolDecompressBytes); ok {
+			if len(ps.decompressBytes) > 0 {
+				pdecom.PutDecompressBytes(ps.decompressBytes)
+				ps.decompressBytes = nil
+			}
+		}
+		if precs, ok := p.(PoolRecords); ok {
+			if len(ps.recs) > 0 {
+				precs.PutRecords(ps.recs)
+				ps.recs = nil
+			}
+		}
+		return false // always loop through all pools; we put each slice into a max of one pool
+	})
+}
+
+type recordPools struct {
+	pools []Pool
+	n     atomic.Int64
+
+	decompressBytes []byte
+	recs            []Record
+}
+
+// implementsAnyPool will check the incoming Pool for any Pool implementation
+func implementsAnyPool(p Pool) bool {
+	switch p.(type) {
+	case /*PoolRequestBuffer,*/
+		PoolDecompressBytes,
+		PoolKRecords,
+		PoolRecords:
+		return true
+	}
+	return false
+}
+
+func ensureLen[S ~[]E, E any](s S, n int) S {
+	s = s[:cap(s)]
+	if len(s) >= n {
+		return s[:n]
+	}
+	return append(s, make([]E, n-len(s))...)
+}

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -481,7 +481,7 @@ func (cl *Client) produce(
 
 		drainBuffered := func(err error) {
 			// The expected case here is that a context was
-			// canceled while we we waiting for space, so we are
+			// canceled while we waiting for space, so we are
 			// exiting and need to kill the goro above.
 			//
 			// However, it is possible that the goro above has
@@ -968,7 +968,7 @@ func (cl *Client) addUnknownTopicRecord(pr promisedRec) {
 	}
 	unknown.buffered = append(unknown.buffered, pr)
 	if len(unknown.buffered) == 1 {
-		go cl.waitUnknownTopic(pr.ctx, pr.Record.Context, pr.Topic, unknown)
+		go cl.waitUnknownTopic(pr.ctx, pr.Context, pr.Topic, unknown)
 	}
 }
 

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -51,6 +51,7 @@ func (a RecordAttrs) TimestampType() int8 {
 // CompressionType signifies with which algorithm this record was compressed.
 //
 // 0 is no compression, 1 is gzip, 2 is snappy, 3 is lz4, and 4 is zstd.
+// The returned uint8 can be converted directly to a [CompressionCodecType].
 func (a RecordAttrs) CompressionType() uint8 {
 	return a.attrs & 0b0000_0111
 }

--- a/pkg/kgo/record_formatter.go
+++ b/pkg/kgo/record_formatter.go
@@ -1603,11 +1603,12 @@ func (*RecordReader) parseReadSize(layout string, dst *uint64, needBrace bool) (
 
 				switch state {
 				default: // stateUnknown
-					if b == 't' {
+					switch b {
+					case 't':
 						state = stateTrue
 						last = b
 						return 1
-					} else if b == 'f' {
+					case 'f':
 						state = stateFalse
 						last = b
 						return 1

--- a/pkg/kgo/record_formatter.go
+++ b/pkg/kgo/record_formatter.go
@@ -443,16 +443,16 @@ func NewRecordFormatter(layout string) (*RecordFormatter, error) {
 				layout = layout[len("compression}"):]
 				f.fns = append(f.fns, func(b []byte, _ *FetchPartition, r *Record) []byte {
 					return writeR(b, r, func(b []byte, r *Record) []byte {
-						switch codecType(r.Attrs.CompressionType()) {
-						case codecNone:
+						switch CompressionCodecType(r.Attrs.CompressionType()) {
+						case CodecNone:
 							return append(b, "none"...)
-						case codecGzip:
+						case CodecGzip:
 							return append(b, "gzip"...)
-						case codecSnappy:
+						case CodecSnappy:
 							return append(b, "snappy"...)
-						case codecLZ4:
+						case CodecLz4:
 							return append(b, "lz4"...)
-						case codecZstd:
+						case CodecZstd:
 							return append(b, "zstd"...)
 						default:
 							return append(b, "unknown"...)

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1680,6 +1680,9 @@ func (recBuf *recBuf) newRecordBatch() *recBatch {
 	}
 }
 
+// prsPool is the one pool we have internally that is hard to expose an
+// interface for. That said, ideally batch size is relatively consistent
+// over time and using our own internal pool is fine enough.
 type prsPool struct{ p *sync.Pool }
 
 func newPrsPool() prsPool {

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -85,7 +85,7 @@ func (s *sink) createReq(id int64, epoch int16) (*produceRequest, *kmsg.AddParti
 		producerEpoch: epoch,
 
 		hasHook:    s.cl.producer.hasHookBatchWritten,
-		compressor: s.cl.compressor,
+		compressor: s.cl.cfg.compressor,
 
 		wireLength:      s.cl.baseProduceRequestLength(), // start length with no topics
 		wireLengthLimit: s.cl.cfg.maxBrokerWriteBytes,

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -881,7 +881,7 @@ func (s *sink) handleReqRespBatch(
 		// in flight). With KIP-890, we still just disregard whatever
 		// supposedly non-retryable / actually-is-retryable error is
 		// returned if the LogStartOffset is _after_ what we previously
-		// produced. Specifically, this is step (4) in in wiki link
+		// produced. Specifically, this is step (4) in wiki link
 		// within KAFKA-5793.
 		//
 		// InvalidMapping is similar to UnknownProducerID, but occurs

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1098,7 +1098,7 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				continue
 			}
 
-			fp := partOffset.processRespPartition(br, rp, s.cl.decompressor, s.cl.cfg.hooks)
+			fp := partOffset.processRespPartition(br, rp, s.cl.cfg.decompressor, s.cl.cfg.hooks)
 			if fp.Err != nil {
 				if moving := kmove.maybeAddFetchPartition(resp, rp, partOffset.from); moving {
 					strip(topic, partition, fp.Err)


### PR DESCRIPTION
* Exports the internal Compressor and Decompressor
* Adds WithCompressor and WithDecompressor options to allow end-user overrides
* Improves # of allocs when reading fetch responses by performing slab allocations
* Exports the function that processes fetch response partitions, allowing end-users to manually process fetch responses
* Adds a WithPools option and exposes three pools a user can provide to reuse memory while processing fetch responses
* Adds a DisableFetchCRCValidation consumer option, for if you really need this escape hatch (for #909)
