### PR TITLE
kgo: add ctx field to client cfg

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -454,7 +454,13 @@ func NewClient(opts ...Opt) (*Client, error) {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
+
+	if cfg.ctx != nil {
+		ctx = cfg.ctx
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
 
 	cl := &Client{
 		cfg:       cfg,

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -398,6 +398,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.requireStable}
 	case namefn(SessionTimeout):
 		return []any{cfg.sessionTimeout}
+	case namefn(WithContext):
+		return []any{cfg.ctx}
 	default:
 		return nil
 	}

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -537,6 +537,10 @@ func (cl *Client) Opts() []Opt {
 	return cl.opts
 }
 
+func (cl *Client) Context() context.Context {
+	return cl.ctx
+}
+
 func (cl *Client) loadSeeds() []*broker {
 	return cl.seeds.Load().([]*broker)
 }

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -537,6 +537,10 @@ func (cl *Client) Opts() []Opt {
 	return cl.opts
 }
 
+// Context returns the internal context used wherever possible in the client.
+// By default this is context.WithCancel(context.Background()). You may
+// override the background context with your own via [WithContext].
+// The context is occasionally wrapped further internally in client subsystems.
 func (cl *Client) Context() context.Context {
 	return cl.ctx
 }

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -569,9 +569,9 @@ func WithLogger(l Logger) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.logger = &wrappedLogger{l} }}
 }
 
-// WithContext sets the client to use the a custom context.
+// WithContext sets the client to use a custom context.
 //
-// By default the client uses context.Background.
+// By default, the client uses context.Background.
 func WithContext(ctx context.Context) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.ctx = ctx }}
 }

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -69,6 +69,7 @@ type cfg struct {
 	/////////////////////
 
 	id                     *string // client ID
+	ctx                    context.Context
 	dialFn                 func(context.Context, string, string) (net.Conn, error)
 	dialTimeout            time.Duration
 	dialTLS                *tls.Config
@@ -566,6 +567,13 @@ func SoftwareNameAndVersion(name, version string) Opt {
 // It is invalid to use a nil logger; doing so will cause panics.
 func WithLogger(l Logger) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.logger = &wrappedLogger{l} }}
+}
+
+// WithContext sets the client to use the a custom context.
+//
+// By default the client uses context.Background.
+func WithContext(ctx context.Context) Opt {
+	return clientOpt{func(cfg *cfg) { cfg.ctx = ctx }}
 }
 
 // RequestTimeoutOverhead uses the given time as overhead while deadlining


### PR DESCRIPTION
Adds `ctx` field to allow custom contexts to be used by the client
For example, it allows the custom `onAssigned` func, added using `OnPartitionsAssigned` opt, to access a custom context and any propagated value inside (like tracers)