### PR TITLE
Fix produce mutex to allow variables to be updated in blocking condition

### DIFF
--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -472,7 +472,9 @@ func (cl *Client) produce(
 			p.mu.Lock()
 			calcNums()
 			for !quit && (overMaxRecs || overMaxBytes) {
+				p.mu.Unlock()
 				p.c.Wait()
+				p.mu.Lock()
 				calcNums()
 			}
 			p.blocked.Add(-1)
@@ -481,7 +483,7 @@ func (cl *Client) produce(
 
 		drainBuffered := func(err error) {
 			// The expected case here is that a context was
-			// canceled while we we waiting for space, so we are
+			// canceled while we waiting for space, so we are
 			// exiting and need to kill the goro above.
 			//
 			// However, it is possible that the goro above has

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -471,13 +471,13 @@ func (cl *Client) produce(
 			defer close(wait)
 			p.mu.Lock()
 			calcNums()
-
-			// Condition lock is required for wait semantics
-			p.c.L.Lock()
-			defer p.c.L.Unlock()
 			for !quit && (overMaxRecs || overMaxBytes) {
 				p.mu.Unlock()
+				// Condition lock is required for wait semantics
+				p.c.L.Lock()
 				p.c.Wait()
+				p.c.L.Unlock()
+				// Re-acquire log to keep the lock on exit
 				p.mu.Lock()
 				calcNums()
 			}

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -471,6 +471,10 @@ func (cl *Client) produce(
 			defer close(wait)
 			p.mu.Lock()
 			calcNums()
+
+			// Condition lock is required for wait semantics
+			p.c.L.Lock()
+			defer p.c.L.Unlock()
 			for !quit && (overMaxRecs || overMaxBytes) {
 				p.mu.Unlock()
 				p.c.Wait()


### PR DESCRIPTION
We have hit this bug franz-go leaking whole lot of goroutines where we call produce without cancel from a spawned goroutine for each. Looking through the code, having mutex open prevents other goroutines to update variables the wait condition is reading on. Cause both `quit, overMaxRecs, overBytes` all depends on `p.mu`. Also looks like condition Wait also missing locks required by its semantics. 

```
func (c *Cond) Wait() {
	c.checker.check()
	t := runtime_notifyListAdd(&c.notify)
	c.L.Unlock()
	runtime_notifyListWait(&c.notify, t)
	c.L.Lock()
}
```

However, now this concurrency code looks fairly unnatural, might be better to re-write it eventually. It's likely hard to make a test to reproduce it in github actions environment that might have very limited actual cpu parallelism, I tried setting a high GOMAXPROCS but it still is passing with/without changes.

Issue https://github.com/twmb/franz-go/issues/918

