### PR TITLE
kgo: fix cancellation of a fetch in manageFetchConcurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ dev
 origin
 TESTING
 generate/generate
+.idea
 go.work
 go.work.sum

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1541,9 +1541,9 @@ func (s *consumerSession) manageFetchConcurrency() {
 			var found bool
 			for i, want := range wantFetch {
 				if want == cancel {
-					_ = append(wantFetch[i:], wantFetch[i+1:]...)
-					wantFetch = wantFetch[:len(wantFetch)-1]
+					wantFetch = append(wantFetch[:i], wantFetch[i+1:]...)
 					found = true
+					break
 				}
 			}
 			// If we did not find the channel, then we have already


### PR DESCRIPTION
I discovered a "bug" in the code responsible for handling the cancellation of a fetch request. Fortunately, it doesn’t seem to cause any immediate issues (if I’ve correctly understood the relationship between `manageFetchConcurrency` and `fetchLoop`). However I think it’s better to fix it now to prevent potential problems in the future when changes are made.

In this snippet, instead of deleting the `i`-th element, the last element is being removed:
```go
_ = append(wantFetch[i:], wantFetch[i+1:]...)
wantFetch = wantFetch[:len(wantFetch)-1]
```

I also attempted to write a test to cover this case, but it would require a significant redesign of `manageFetchConcurrency` so I’ve set this idea aside.
