### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - wastedassign
@@ -54,7 +54,6 @@ linters-settings:
 
   # If we want to opt out of a lint, we require an explanation.
   nolintlint:
-    allow-leading-space: true
     allow-unused: false
     require-explanation: true
     require-specific: true
@@ -114,8 +113,6 @@ linters-settings:
     ignore-generated-header: true
     severity: warning
     confidence: 0.8
-    error-code: 0
-    warning-code: 0
     rules:
       - name: atomic
       - name: blank-imports

--- a/generate/gen.go
+++ b/generate/gen.go
@@ -625,7 +625,7 @@ func (s Struct) WriteDefault(l *LineWriter) {
 
 func (s Struct) WriteDefn(l *LineWriter) {
 	if s.Comment != "" {
-		l.Write(s.Comment) //nolint:govet // ...
+		l.Write(s.Comment)
 	}
 	l.Write("type %s struct {", s.Name)
 	if s.TopLevel {
@@ -822,7 +822,7 @@ func (s Struct) WriteNewPtrFunc(l *LineWriter) {
 
 func (e Enum) WriteDefn(l *LineWriter) {
 	if e.Comment != "" {
-		l.Write(e.Comment) //nolint:govet // ...
+		l.Write(e.Comment)
 		l.Write("// ")
 	}
 	l.Write("// Possible values and their meanings:")
@@ -830,7 +830,7 @@ func (e Enum) WriteDefn(l *LineWriter) {
 	for _, v := range e.Values {
 		l.Write("// * %d (%s)", v.Value, v.Word)
 		if len(v.Comment) > 0 {
-			l.Write(v.Comment) //nolint:govet // ...
+			l.Write(v.Comment)
 		}
 		l.Write("//")
 	}


### PR DESCRIPTION
Note: You can use `golangci-lint config verify` to check if the `.golangci.yml` config matches the published schema.

- `tenv` has been deprecated in favour of `usetesting`
- `allow-leading-space` has been removed from `nolintlint`: https://github.com/golangci/golangci-lint/issues/3063
- `revive` doesn't have `error-code` `warning-code` as config options (see https://golangci-lint.run/usage/linters/#revive). There's some discussion https://github.com/mgechev/revive/issues/241 about adding `set_exit_status` to `revive`, but it's not exposed via `golangci-lint`