### PR TITLE
kgo: minor improvements while attempting to work around a Kafka hanging transaction bug

### DIFF
--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -25,7 +25,7 @@ func TestGroupETL(t *testing.T) {
 	t.Parallel()
 
 	topic1, topic1Cleanup := tmpTopic(t)
-	defer topic1Cleanup()
+	t.Cleanup(topic1Cleanup)
 
 	errs := make(chan error)
 	body := []byte(randsha()) // a small body so we do not flood RAM

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -271,7 +271,7 @@ issue:
 	// If we run tests in a container _immediately_ after the container
 	// starts, we can receive dial errors for a bit if the container is not
 	// fully initialized. Handle this by retrying specifically dial errors.
-	if ne := (*net.OpError)(nil); errors.As(err, &ne) && ne.Op == "dial" && time.Since(start) < 5*time.Second {
+	if ne := (*net.OpError)(nil); errors.As(err, &ne) && ne.Op == "dial" && time.Since(start) < 15*time.Second {
 		time.Sleep(10 * time.Millisecond)
 		goto issue
 	}
@@ -515,14 +515,14 @@ func testChainETL(
 		)
 	)
 
-	defer func() {
+	t.Cleanup(func() {
 		groupCleanup1()
 		groupCleanup2()
 		groupCleanup3()
 		topic2Cleanup()
 		topic3Cleanup()
 		topic4Cleanup()
-	}()
+	})
 
 	////////////////////
 	// CONSUMER START //

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -547,7 +547,7 @@ func (s *sink) doTxnReq(
 	// similar to the warning we give in the txn.go file, but the
 	// difference there is the user knows explicitly at the function call
 	// that canceling the context will opt them into invalid state.
-	err = s.cl.doWithConcurrentTransactions(s.cl.ctx, "AddPartitionsToTxn", func() error {
+	err = s.cl.doWithConcurrentTransactions(s.cl.ctx, fmt.Sprintf("AddPartitionsToTxn-sink%d", s.nodeID), func() error {
 		stripped, err = s.issueTxnReq(req, txnReq)
 		return err
 	})

--- a/pkg/kgo/txn_test.go
+++ b/pkg/kgo/txn_test.go
@@ -17,7 +17,7 @@ func TestTxnEtl(t *testing.T) {
 	t.Parallel()
 
 	topic1, topic1Cleanup := tmpTopic(t)
-	defer topic1Cleanup()
+	t.Cleanup(topic1Cleanup)
 
 	errs := make(chan error)
 	body := []byte(randsha()) // a small body so we do not flood RAM


### PR DESCRIPTION
What this adds:
* After EndTxn, we send ListTransactions to verify the transaction has actually completed
* If the transaction hangs for 10s, we log and set internally to reinitialize the producer ID.
* We log a lot

Some logging changes will be kept; the ListTransactions verification will be deleted, as well as the hard-resetting of the producerID.