### PR TITLE
kgo: fix off-by-one with retries accounting

### DIFF
--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -1019,7 +1019,7 @@ func (cl *Client) waitUnknownTopic(
 			}
 			cl.cfg.logger.Log(LogLevelInfo, "new topic metadata wait failed, retrying wait", "topic", topic, "err", retryableErr)
 			tries++
-			if int64(tries) >= cl.cfg.recordRetries {
+			if int64(tries) > cl.cfg.recordRetries {
 				err = fmt.Errorf("no partitions available after attempting to refresh metadata %d times, last err: %w", tries, retryableErr)
 			}
 			if cl.cfg.maxUnknownFailures >= 0 && errors.Is(retryableErr, kerr.UnknownTopicOrPartition) {


### PR DESCRIPTION
Previously, if our tries was equal to the max retries, we would not retry. Instead, we should try again -- the number of tries is one less than the number of retries. We tried once, we retried 0 times.

Now, when we try twice, we have retried once, and we can fail properly. This also means that failing once will cause a metadata reload, rather than immediately failing the record and doing nothing.

This also switches freezing a batch to a dedicated bool field rather than relying on a secondary effect of counting how many times a batch has been tried. This allows us to move accounting of when a batch is actually tried to where it is actually being written, avoiding double counting of tries if the batch actually ends up not being sent after being selected to be sent (due to add partitions to txn failure or something).

Closes #937.