### PR TITLE
kgo: periodically redirect back to the leader & add config option

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -373,6 +373,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.keepRetryableFetchErrors}
 	case namefn(DisableFetchCRCValidation):
 		return []any{cfg.disableFetchCRCValidation}
+	case namefn(RecheckPreferredReplicaInterval):
+		return []any{cfg.recheckPreferredReplicaInterval}
 
 	case namefn(AdjustFetchOffsetsFn):
 		return []any{cfg.adjustOffsetsBeforeAssign}


### PR DESCRIPTION
The cluster may occasionally pick a new preferred replica. If the client is consuming from a preferred replica returned a long time ago, the client will never know of it *unless* the client periodically redirects back to the leader.

The Java client redirects back to the leader every MetadataMaxAge, but that seems a bit frequent (every 5min). This client defaults to 30min and adds a configuration option to raise or lower that.

A separate kfake integration test has been written and tested against this; it will remain in branch until the kgo 1.19 release (since currently, the kfake tests depend on released kgo versions).

Closes #905.