### PR TITLE
Produce with ctx

### DIFF
--- a/examples/produce_with_ctx/README.md
+++ b/examples/produce_with_ctx/README.md
@@ -1,0 +1,96 @@
+# Produce with ctx
+
+This small example demonstrates a per message context with a timeout.
+
+We _do_ expect franz-go kgo.Client to fully support context deadlines.
+
+## Examples
+
+```
+$ docker run --rm -it --name=source -p 8081:8081 -p 9092:9092 -p 9644:9644 redpandadata/redpanda redpanda start --node-id 0 --mode dev-container --set "rpk.additional_start_flags=[--reactor-backend=epoll]" --set redpanda.auto_create_topics_enabled=true --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr host.docker.internal:9092 --schema-registry-addr 0.0.0.0:8081
+```
+
+```
+$ go run .
+$ rpk topic consume foobar -o ':end' -X brokers=localhost:9092
+{
+  "topic": "foobar",
+  "key": "0",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 0,
+  "partition": 0,
+  "offset": 0
+}
+{
+  "topic": "foobar",
+  "key": "1",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 1,
+  "partition": 0,
+  "offset": 1
+}
+{
+  "topic": "foobar",
+  "key": "2",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 2,
+  "partition": 0,
+  "offset": 2
+}
+{
+  "topic": "foobar",
+  "key": "3",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 3,
+  "partition": 0,
+  "offset": 3
+}
+{
+  "topic": "foobar",
+  "key": "4",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 4,
+  "partition": 0,
+  "offset": 4
+}
+{
+  "topic": "foobar",
+  "key": "5",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 5,
+  "partition": 0,
+  "offset": 5
+}
+{
+  "topic": "foobar",
+  "key": "6",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 6,
+  "partition": 0,
+  "offset": 6
+}
+{
+  "topic": "foobar",
+  "key": "7",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 7,
+  "partition": 0,
+  "offset": 7
+}
+{
+  "topic": "foobar",
+  "key": "8",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 8,
+  "partition": 0,
+  "offset": 8
+}
+{
+  "topic": "foobar",
+  "key": "9",
+  "value": "{\"test\":\"foo\"}",
+  "timestamp": 9,
+  "partition": 0,
+  "offset": 9
+}
+```

--- a/examples/produce_with_ctx/go.mod
+++ b/examples/produce_with_ctx/go.mod
@@ -1,0 +1,17 @@
+module produce_with_ctx
+
+go 1.24
+
+toolchain go1.24.1
+
+require (
+	github.com/twmb/franz-go v1.18.0
+	github.com/twmb/franz-go/pkg/kadm v1.14.0
+)
+
+require (
+	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
+)

--- a/examples/produce_with_ctx/go.sum
+++ b/examples/produce_with_ctx/go.sum
@@ -1,0 +1,12 @@
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
+github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/twmb/franz-go v1.18.0 h1:25FjMZfdozBywVX+5xrWC2W+W76i0xykKjTdEeD2ejw=
+github.com/twmb/franz-go v1.18.0/go.mod h1:zXCGy74M0p5FbXsLeASdyvfLFsBvTubVqctIaa5wQ+I=
+github.com/twmb/franz-go/pkg/kadm v1.14.0 h1:nAn1co1lXzJQocpzyIyOFOjUBf4WHWs5/fTprXy2IZs=
+github.com/twmb/franz-go/pkg/kadm v1.14.0/go.mod h1:XjOPz6ZaXXjrW2jVCfLuucP8H1w2TvD6y3PT2M+aAM4=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
+golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
+golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=

--- a/examples/produce_with_ctx/main.go
+++ b/examples/produce_with_ctx/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func main() {
+	ctx := context.Background()
+
+	seeds := []string{"localhost:9092"}
+
+	client, err := kgo.NewClient(kgo.SeedBrokers(seeds...))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	topic := "foobar"
+	_, err = kadm.NewClient(client).CreateTopic(context.Background(), 1, -1, nil, topic)
+	if err != nil {
+		panic(err)
+	}
+
+	count := 10
+	wg := sync.WaitGroup{}
+	wg.Add(count)
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	//ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	defer cancel()
+	for i := range count {
+		r := &kgo.Record{
+			Key:       []byte(strconv.Itoa(i)),
+			Topic:     topic,
+			Timestamp: time.UnixMilli(int64(i)),
+			Value:     []byte(`{"test":"foo"}`),
+		}
+
+		client.Produce(ctx, r, func(_ *kgo.Record, err error) {
+			if err != nil {
+				panic(err)
+			}
+			wg.Done()
+		})
+
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
This small example demonstrates a per message context with a timeout.

We _do_ expect franz-go kgo.Client to fully support context deadlines.

Clarifying: https://github.com/twmb/franz-go/issues/953