### PR TITLE
generate: enforce all tags must have defaulters; kmsg: fix bug

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -375,6 +375,19 @@ func (s Struct) GetTypeDefault() any {
 	return fmt.Sprintf("(func() %[1]s { var v %[1]s; v.Default(); return v })() ", s.Name)
 }
 
+func (u Uuid) SetDefault(string) Type {
+	die("cannot set default on a uuid")
+	return u
+}
+
+func (Uuid) GetDefault() (any, bool) {
+	return "", false // no GetDefault
+}
+
+func (Uuid) GetTypeDefault() any {
+	return "[16]byte{}"
+}
+
 type FlexibleSetter interface {
 	AsFromFlexible() Type
 }

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -4329,12 +4329,21 @@ func (v *FetchRequest) AppendTo(dst []byte) []byte {
 						dst = kbin.AppendInt32(dst, v)
 					}
 					if isFlexible {
-						dst = kbin.AppendUvarint(dst, 1+uint32(v.UnknownTags.Len()))
-						{
-							v := v.ReplicaDirectoryID
-							dst = kbin.AppendUvarint(dst, 0)
-							dst = kbin.AppendUvarint(dst, 16)
-							dst = kbin.AppendUuid(dst, v)
+						var toEncode []uint32
+						if v.ReplicaDirectoryID != [16]byte{} {
+							toEncode = append(toEncode, 0)
+						}
+						dst = kbin.AppendUvarint(dst, uint32(len(toEncode)+v.UnknownTags.Len()))
+						for _, tag := range toEncode {
+							switch tag {
+							case 0:
+								{
+									v := v.ReplicaDirectoryID
+									dst = kbin.AppendUvarint(dst, 0)
+									dst = kbin.AppendUvarint(dst, 16)
+									dst = kbin.AppendUuid(dst, v)
+								}
+							}
 						}
 						dst = v.UnknownTags.AppendEach(dst)
 					}
@@ -42175,12 +42184,21 @@ func (v *FetchSnapshotRequest) AppendTo(dst []byte) []byte {
 						dst = kbin.AppendInt64(dst, v)
 					}
 					if isFlexible {
-						dst = kbin.AppendUvarint(dst, 1+uint32(v.UnknownTags.Len()))
-						{
-							v := v.ReplicaDirectoryID
-							dst = kbin.AppendUvarint(dst, 0)
-							dst = kbin.AppendUvarint(dst, 16)
-							dst = kbin.AppendUuid(dst, v)
+						var toEncode []uint32
+						if v.ReplicaDirectoryID != [16]byte{} {
+							toEncode = append(toEncode, 0)
+						}
+						dst = kbin.AppendUvarint(dst, uint32(len(toEncode)+v.UnknownTags.Len()))
+						for _, tag := range toEncode {
+							switch tag {
+							case 0:
+								{
+									v := v.ReplicaDirectoryID
+									dst = kbin.AppendUvarint(dst, 0)
+									dst = kbin.AppendUvarint(dst, 16)
+									dst = kbin.AppendUuid(dst, v)
+								}
+							}
 						}
 						dst = v.UnknownTags.AppendEach(dst)
 					}

--- a/pkg/kmsg/go.mod
+++ b/pkg/kmsg/go.mod
@@ -3,3 +3,8 @@ module github.com/twmb/franz-go/pkg/kmsg
 go 1.21
 
 toolchain go1.22.0
+
+retract (
+	v1.11.0 // This version erroneously always encoded tagged uuid fields, which failed on any Kafka version that did not support the field
+	v1.10.0 // This version failed to compile; I must have accidentally git-broke my fixed commit before pushing & merging
+)


### PR DESCRIPTION
Tags should only be encoded if they are not the default for their type. kmsg v1.11.0 introduced a tagged uuid field on FetchRequest, which is meant to be set only by brokers for inter-broker communication.

The uuid type previously did not have a defaulter in the generator, and the resulting generated code *always* encoded the ReplicaDirectorID field. If you upgraded kmsg and used it against an old Kafka, Kafka would fail to parse the request.

This commit now enforces that all tagged types have defaulters defined (the generator will panic if that is not the case), adds a defaulter for the uuid type, and fixes the generated code.

Closes #961.