### PR TITLE
kmsg: properly annotate DescribeGroups.Group.ErrorMessage as v6+

### DIFF
--- a/generate/definitions/15_describe_groups
+++ b/generate/definitions/15_describe_groups
@@ -30,7 +30,7 @@ DescribeGroupsResponse =>
     // GROUP_ID_NOT_FOUND is returned on v6+ if the group ID is not found (KIP-1043).
     ErrorCode: int16
     // ErrorMessage is an optional message with more detail for the error code.
-    ErrorMessage: nullable-string
+    ErrorMessage: nullable-string // v6+
     // Group is the id of this group.
     Group: string
     // State is the state this group is in.

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -15716,7 +15716,7 @@ type DescribeGroupsResponseGroup struct {
 	ErrorCode int16
 
 	// ErrorMessage is an optional message with more detail for the error code.
-	ErrorMessage *string
+	ErrorMessage *string // v6+
 
 	// Group is the id of this group.
 	Group string
@@ -15811,7 +15811,7 @@ func (v *DescribeGroupsResponse) AppendTo(dst []byte) []byte {
 				v := v.ErrorCode
 				dst = kbin.AppendInt16(dst, v)
 			}
-			{
+			if version >= 6 {
 				v := v.ErrorMessage
 				if isFlexible {
 					dst = kbin.AppendCompactNullableString(dst, v)
@@ -15975,7 +15975,7 @@ func (v *DescribeGroupsResponse) readFrom(src []byte, unsafe bool) error {
 				v := b.Int16()
 				s.ErrorCode = v
 			}
-			{
+			if version >= 6 {
 				var v *string
 				if isFlexible {
 					if unsafe {


### PR DESCRIPTION
Closes #972.