### PR TITLE
kgo: expose IsRetryableBrokerErr

### DIFF
--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -11,6 +11,18 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 )
 
+// IsRetryableBrokerErr returns whether the client considers an error from a
+// broker retrayble. This returns true specifically if the client thinks it can
+// retry whatever it was just trying to do with a broker. It returns false in
+// all other cases.
+//
+// This can used external to the library to help filter errors if use kgo
+// hooks: errors may be sent to hooks before the client retries whatever it was
+// just attempting.
+func IsRetryableBrokerErr(err error) bool {
+	return isRetryableBrokerErr(err)
+}
+
 func isRetryableBrokerErr(err error) bool {
 	// The error could be nil if we are evaluating multiple errors at once,
 	// and only one is non-nil. The intent of this function is to evaluate


### PR DESCRIPTION
It is a smaller delta to expose a public func wrapping a private func than to make the private func public and change all usages of it.

I'm switching to Retryable rather than the currently exposed
kerr.Retriable or Broker.RetriableRequest. This is an inconsistency, but
Retryable feels more correct and what I've moved to for the past years:

    https://english.stackexchange.com/a/305274

Closes #877.