### PR TITLE
sr: refactor DialTLSConfig option so it is stored in client

### DIFF
--- a/pkg/sr/clientopt.go
+++ b/pkg/sr/clientopt.go
@@ -2,10 +2,8 @@ package sr
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
 	"strings"
-	"time"
 )
 
 type (
@@ -44,27 +42,10 @@ func URLs(urls ...string) ClientOpt {
 	}}
 }
 
-// DialTLSConfig sets a tls.Config to use in the default http client.
+// DialTLSConfig sets a tls.Config to use in the http client, either the default client or a client previously
+// set with the HTTPClient option. When setting this option, HTTP/2 support may not be enabled by default.
 func DialTLSConfig(c *tls.Config) ClientOpt {
-	return clientOpt{func(cl *Client) {
-		cl.httpcl = &http.Client{
-			Timeout: 5 * time.Second,
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-				TLSClientConfig:       c,
-				ForceAttemptHTTP2:     true,
-				MaxIdleConns:          100,
-				MaxIdleConnsPerHost:   100,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			},
-		}
-	}}
+	return clientOpt{func(cl *Client) { cl.dialTLS = c }}
 }
 
 // BasicAuth sets basic authorization to use for every request.

--- a/pkg/sr/clientopt_test.go
+++ b/pkg/sr/clientopt_test.go
@@ -7,83 +7,84 @@ import (
 	"testing"
 )
 
-func TestDialTLSConfig(t *testing.T) {
-	tlscfg := &tls.Config{}
+func TestDialTLSConfigOpt(t *testing.T) {
+	t.Run("Defaults", func(t *testing.T) {
+		tlscfg := &tls.Config{}
 
-	rcl, err := NewClient(DialTLSConfig(tlscfg))
-	if err != nil {
-		t.Fatalf("unable to create client: %s", err)
-	}
+		rcl, err := NewClient(DialTLSConfig(tlscfg))
+		if err != nil {
+			t.Fatalf("unable to create client: %s", err)
+		}
 
-	if rcl.dialTLS != tlscfg {
-		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
-	}
+		if rcl.dialTLS != tlscfg {
+			t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+		}
 
-	tr := rcl.httpcl.Transport.(*http.Transport)
-	if tr.TLSClientConfig != tlscfg {
-		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
-	}
-}
+		tr := rcl.httpcl.Transport.(*http.Transport)
+		if tr.TLSClientConfig != tlscfg {
+			t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+		}
+	})
 
-func TestDialTLSConfigWithHTTPClient(t *testing.T) {
-	httpcl := &http.Client{}
-	tlscfg := &tls.Config{}
+	t.Run("CustomHTTPClient", func(t *testing.T) {
+		httpcl := &http.Client{}
+		tlscfg := &tls.Config{}
 
-	rcl, err := NewClient(
-		HTTPClient(httpcl),
-		DialTLSConfig(tlscfg),
-	)
-	if err != nil {
-		t.Fatalf("unable to create client: %s", err)
-	}
+		rcl, err := NewClient(
+			HTTPClient(httpcl),
+			DialTLSConfig(tlscfg),
+		)
+		if err != nil {
+			t.Fatalf("unable to create client: %s", err)
+		}
 
-	if rcl.dialTLS != tlscfg {
-		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
-	}
+		if rcl.dialTLS != tlscfg {
+			t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+		}
 
-	tr := rcl.httpcl.Transport.(*http.Transport)
-	if tr.TLSClientConfig != tlscfg {
-		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
-	}
-}
+		tr := rcl.httpcl.Transport.(*http.Transport)
+		if tr.TLSClientConfig != tlscfg {
+			t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+		}
+	})
 
-func TestDialTLSConfigWithHTTPClientAndTransport(t *testing.T) {
-	httptr := &http.Transport{}
-	httpcl := &http.Client{Transport: httptr}
-	tlscfg := &tls.Config{}
+	t.Run("CustomHTTPTransport", func(t *testing.T) {
+		httptr := &http.Transport{}
+		httpcl := &http.Client{Transport: httptr}
+		tlscfg := &tls.Config{}
 
-	rcl, err := NewClient(
-		HTTPClient(httpcl),
-		DialTLSConfig(tlscfg),
-	)
-	if err != nil {
-		t.Fatalf("unable to create client: %s", err)
-	}
+		rcl, err := NewClient(
+			HTTPClient(httpcl),
+			DialTLSConfig(tlscfg),
+		)
+		if err != nil {
+			t.Fatalf("unable to create client: %s", err)
+		}
 
-	if rcl.dialTLS != tlscfg {
-		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
-	}
+		if rcl.dialTLS != tlscfg {
+			t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+		}
 
-	tr := rcl.httpcl.Transport.(*http.Transport)
-	if tr.TLSClientConfig != tlscfg {
-		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
-	}
-}
+		tr := rcl.httpcl.Transport.(*http.Transport)
+		if tr.TLSClientConfig != tlscfg {
+			t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+		}
+	})
 
-func TestDialTLSConfigWithIncompatibleHTTPClient(t *testing.T) {
-	dialFn := func(network, addr string) (net.Conn, error) { return nil, nil }
-	httptr := &http.Transport{Dial: dialFn}
-	httpcl := &http.Client{Transport: httptr}
-	tlscfg := &tls.Config{}
+	t.Run("IncompatibleHTTPClient", func(t *testing.T) {
+		dialFn := func(network, addr string) (net.Conn, error) { return nil, nil }
+		httptr := &http.Transport{Dial: dialFn}
+		httpcl := &http.Client{Transport: httptr}
+		tlscfg := &tls.Config{}
 
-	_, err := NewClient(
-		HTTPClient(httpcl),
-		DialTLSConfig(tlscfg),
-	)
+		_, err := NewClient(
+			HTTPClient(httpcl),
+			DialTLSConfig(tlscfg),
+		)
 
-	expected := "unable to use DialTLSConfig with an http.Client that has a custom dial function"
-	if err.Error() != expected {
-		t.Errorf("new client error: expected %q, got %q", expected, err.Error())
-	}
-
+		expected := "unable to use DialTLSConfig with an http.Client that has a custom dial function"
+		if err.Error() != expected {
+			t.Errorf("new client error: expected %q, got %q", expected, err.Error())
+		}
+	})
 }

--- a/pkg/sr/clientopt_test.go
+++ b/pkg/sr/clientopt_test.go
@@ -83,8 +83,8 @@ func TestDialTLSConfigOpt(t *testing.T) {
 		)
 
 		expected := "unable to use DialTLSConfig with an http.Client that has a custom dial function"
-		if err.Error() != expected {
-			t.Errorf("new client error: expected %q, got %q", expected, err.Error())
+		if err == nil || err.Error() != expected {
+			t.Errorf("new client error: expected %q, got %q", expected, err)
 		}
 	})
 }

--- a/pkg/sr/clientopt_test.go
+++ b/pkg/sr/clientopt_test.go
@@ -70,27 +70,6 @@ func TestDialTLSConfigWithHTTPClientAndTransport(t *testing.T) {
 	}
 }
 
-func TestDialTLSConfigWithNilHTTPClient(t *testing.T) {
-	tlscfg := &tls.Config{}
-
-	rcl, err := NewClient(
-		HTTPClient(nil),
-		DialTLSConfig(tlscfg),
-	)
-	if err != nil {
-		t.Fatalf("unable to create client: %s", err)
-	}
-
-	if rcl.dialTLS != tlscfg {
-		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
-	}
-
-	tr := rcl.httpcl.Transport.(*http.Transport)
-	if tr.TLSClientConfig != tlscfg {
-		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
-	}
-}
-
 func TestDialTLSConfigWithIncompatibleHTTPClient(t *testing.T) {
 	dialFn := func(network, addr string) (net.Conn, error) { return nil, nil }
 	httptr := &http.Transport{Dial: dialFn}

--- a/pkg/sr/clientopt_test.go
+++ b/pkg/sr/clientopt_test.go
@@ -1,0 +1,110 @@
+package sr
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestDialTLSConfig(t *testing.T) {
+	tlscfg := &tls.Config{}
+
+	rcl, err := NewClient(DialTLSConfig(tlscfg))
+	if err != nil {
+		t.Fatalf("unable to create client: %s", err)
+	}
+
+	if rcl.dialTLS != tlscfg {
+		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+	}
+
+	tr := rcl.httpcl.Transport.(*http.Transport)
+	if tr.TLSClientConfig != tlscfg {
+		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+	}
+}
+
+func TestDialTLSConfigWithHTTPClient(t *testing.T) {
+	httpcl := &http.Client{}
+	tlscfg := &tls.Config{}
+
+	rcl, err := NewClient(
+		HTTPClient(httpcl),
+		DialTLSConfig(tlscfg),
+	)
+	if err != nil {
+		t.Fatalf("unable to create client: %s", err)
+	}
+
+	if rcl.dialTLS != tlscfg {
+		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+	}
+
+	tr := rcl.httpcl.Transport.(*http.Transport)
+	if tr.TLSClientConfig != tlscfg {
+		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+	}
+}
+
+func TestDialTLSConfigWithHTTPClientAndTransport(t *testing.T) {
+	httptr := &http.Transport{}
+	httpcl := &http.Client{Transport: httptr}
+	tlscfg := &tls.Config{}
+
+	rcl, err := NewClient(
+		HTTPClient(httpcl),
+		DialTLSConfig(tlscfg),
+	)
+	if err != nil {
+		t.Fatalf("unable to create client: %s", err)
+	}
+
+	if rcl.dialTLS != tlscfg {
+		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+	}
+
+	tr := rcl.httpcl.Transport.(*http.Transport)
+	if tr.TLSClientConfig != tlscfg {
+		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+	}
+}
+
+func TestDialTLSConfigWithNilHTTPClient(t *testing.T) {
+	tlscfg := &tls.Config{}
+
+	rcl, err := NewClient(
+		HTTPClient(nil),
+		DialTLSConfig(tlscfg),
+	)
+	if err != nil {
+		t.Fatalf("unable to create client: %s", err)
+	}
+
+	if rcl.dialTLS != tlscfg {
+		t.Errorf("TLS config: expected %+v, got %+v", tlscfg, rcl.dialTLS)
+	}
+
+	tr := rcl.httpcl.Transport.(*http.Transport)
+	if tr.TLSClientConfig != tlscfg {
+		t.Errorf("TLS config in transport: expected %+v, got %+v", tlscfg, tr.TLSClientConfig)
+	}
+}
+
+func TestDialTLSConfigWithIncompatibleHTTPClient(t *testing.T) {
+	dialFn := func(network, addr string) (net.Conn, error) { return nil, nil }
+	httptr := &http.Transport{Dial: dialFn}
+	httpcl := &http.Client{Transport: httptr}
+	tlscfg := &tls.Config{}
+
+	_, err := NewClient(
+		HTTPClient(httpcl),
+		DialTLSConfig(tlscfg),
+	)
+
+	expected := "unable to use DialTLSConfig with an http.Client that has a custom dial function"
+	if err.Error() != expected {
+		t.Errorf("new client error: expected %q, got %q", expected, err.Error())
+	}
+
+}

--- a/pkg/sr/clientopt_test.go
+++ b/pkg/sr/clientopt_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDialTLSConfigOpt(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
-		tlscfg := &tls.Config{}
+		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
 
 		rcl, err := NewClient(DialTLSConfig(tlscfg))
 		if err != nil {
@@ -28,7 +28,7 @@ func TestDialTLSConfigOpt(t *testing.T) {
 
 	t.Run("CustomHTTPClient", func(t *testing.T) {
 		httpcl := &http.Client{}
-		tlscfg := &tls.Config{}
+		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
 
 		rcl, err := NewClient(
 			HTTPClient(httpcl),
@@ -51,7 +51,7 @@ func TestDialTLSConfigOpt(t *testing.T) {
 	t.Run("CustomHTTPTransport", func(t *testing.T) {
 		httptr := &http.Transport{}
 		httpcl := &http.Client{Transport: httptr}
-		tlscfg := &tls.Config{}
+		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
 
 		rcl, err := NewClient(
 			HTTPClient(httpcl),
@@ -72,10 +72,10 @@ func TestDialTLSConfigOpt(t *testing.T) {
 	})
 
 	t.Run("IncompatibleHTTPClient", func(t *testing.T) {
-		dialFn := func(network, addr string) (net.Conn, error) { return nil, nil }
+		dialFn := func(_, _ string) (net.Conn, error) { return nil, nil }
 		httptr := &http.Transport{Dial: dialFn}
 		httpcl := &http.Client{Transport: httptr}
-		tlscfg := &tls.Config{}
+		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
 
 		_, err := NewClient(
 			HTTPClient(httpcl),


### PR DESCRIPTION
This PR refactors the `DialTLSConfig` option setter so the TLS config is stored in `sr.Client` and applied in `sr.NewClient` instead of the option setter.

Note that using `DialTLSConfig()` overrides any client set with `HTTPClient()`. This is the same behaviour as before.

After this PR is merged, I will add the missing `OptValues` case for the `DialTLSConfig` option to #963.

Fixes #971 
