### PR TITLE
Fix regression introduced in plugin/kprom/v1.2.0 that causes the prometheus.Registerer to be removed from the config OnClientClosed()

### DIFF
--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -400,7 +400,6 @@ func (m *Metrics) OnClientClosed(*kgo.Client) {
 			m.cfg.reg.Unregister(c)
 		}
 	}
-	m.cfg.reg = nil
 }
 
 // OnBrokerConnect implements the HookBrokerConnect interface for metrics


### PR DESCRIPTION
In Mimir we noticed that some metrics "disappeared" when we upgraded to `plugin/kprom/v1.2.0`. It looks like to be a regression introduced in https://github.com/twmb/franz-go/pull/936, where the `prometheus.Registerer` is removed from the config on the first call to `OnClientClosed()`. In this PR I propose to revert that change, preserving the behaviour we had in `v1.1.0` and before.

### Additional thoughts

The `kprom` plugin implementation looks a bit weird to me. On one side it's a hook, and I would expect it to correctly work when used by multiple clients. In practice, it doesn't really work when it's used by multiple clients concurrently (e.g. `OnNewClient()` creates a new set of metrics each time and on each call to `OnClientClosed()` it removes all registered metrics, not just the ones that were created for the specific client that's going to be closed), so it's only safe to be used by 1 client at a time.

That being said, in Mimir we have an use case where we create and close clients sequentially (so create client A, then close client A, then create client B, then close client B, ...) and reusing the same `kprom.Metrics` instance for that use case looks working just fine, until `v1.2.0` where the regression was introduced.