### PR TITLE
kgo: fix data race in consumer code path

### DIFF
--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1109,6 +1109,18 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 
 	c.cl.cfg.logger.Log(LogLevelDebug, "assign requires loading offsets")
 
+	// We could have a prior handleListOrEpochResults finishing concurrent
+	// with a new assignment. We need to guard below, because list/epoch
+	// results can set offsets for loaded cursors.
+	//
+	// Example: I was just cooperatively assigned p1o10e3, and I issued an
+	// epoch request to validate data loss. I was then assigned p2o4e-1:
+	// there is no epoch to validate, so we immediately begin consuming
+	// at the offset. The epoch request returns and tries also using the
+	// cursor concurrently. We need to guard it.
+	session.listOrEpochMu.Lock()
+	defer session.listOrEpochMu.Unlock()
+
 	topics := tps.load()
 	for topic, partitions := range assignments {
 		topicPartitions := topics.loadTopic(topic) // should be non-nil
@@ -1486,6 +1498,9 @@ type consumerSession struct {
 	workersCond *sync.Cond
 	workers     int
 
+	// listOrEpochMu largely guards the below. It is a sub-mutex of the
+	// consumer mutex to guard one concurrent data access (see below in
+	// assignPartitions).
 	listOrEpochMu           sync.Mutex
 	listOrEpochLoadsWaiting listOrEpochLoads
 	listOrEpochMetaCh       chan struct{} // non-nil if Loads is non-nil, signalled on meta update


### PR DESCRIPTION
To happen,
* A client must be consuming cooperatively and must be assigned new partitions after a rebalance
* The client must have just fetched offsets -- after which the client is internally in assignPartitions
* The client must have previously a running ListOffsets or OffsetForLeaderEpoch concurrently finishing (this is why we must be cooperatively consuming -- eager consumers kill everything in flight)

The second and third bullet points will concurrently try to update the map of using "cursors" (pointers in a partiiton).

The fix is to use an existing mutex -- the one already used by in list or epoch requests and responses -- in assignPartitions.

Closes #982.