### PR TITLE
KIP-714 & KIP-1106

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.22"
+  go: "1.23"
   allow-parallel-runners: true
 linters:
   default: none

--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ generation.
 | [KIP-700](https://cwiki.apache.org/confluence/display/KAFKA/KIP-700%3A+Add+Describe+Cluster+API) — DescribeCluster | 2.8 | Supported |
 | [KIP-704](https://cwiki.apache.org/confluence/display/KAFKA/KIP-704%3A+Send+a+hint+to+the+partition+leader+to+recover+the+partition) — AlterISR => AlterPartition | 3.2 | Supported |
 | [KIP-709](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173084258) — Batch OffsetFetch | 3.0 | Supported |
+| [KIP-714](https://cwiki.apache.org/confluence/display/KAFKA/KIP-714%3A+Client+metrics+and+observability) - Client Metrics | 3.7 | Supported |
 | [KIP-730](https://cwiki.apache.org/confluence/display/KAFKA/KIP-730%3A+Producer+ID+generation+in+KRaft+mode) - AllocateProducerIDs | 3.0 | Supported |
 | [KIP-734](https://cwiki.apache.org/confluence/display/KAFKA/KIP-734:+Improve+AdminClient.listOffsets+to+return+timestamp+and+offset+for+the+record+with+the+largest+timestamp) — Support MaxTimestamp in ListOffsets | 3.0 | Supported (simple version bump) |
 | [KIP-735](https://cwiki.apache.org/confluence/display/KAFKA/KIP-735%3A+Increase+default+consumer+session+timeout) — Bump default session timeout | ? | Supported |
@@ -414,6 +415,7 @@ generation.
 | [KIP-966](https://cwiki.apache.org/confluence/display/KAFKA/KIP-966%3A+Eligible+Leader+Replicas) — Eligible leader replicas (protocol) | 3.7 | Supported |
 | [KIP-994](https://cwiki.apache.org/confluence/display/KAFKA/KIP-994%3A+Minor+Enhancements+to+ListTransactions+and+DescribeTransactions+APIs) — List/Describe transactions enhancements | 3.8 (partial) | Supported |
 | [KIP-1000](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1000%3A+List+Client+Metrics+Configuration+Resources) — ListClientMetricsResources | 3.7 | Supported |
+| [KIP-1106](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1076%3A++Metrics+for+client+applications+KIP-714+extension) — User provided client metrics | 4.0 | Supported |
 | [KIP-1005](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1005%3A+Expose+EarliestLocalOffset+and+TieredOffset) — ListOffsets w. Timestamp -5 | 3.9 | Supported |
 | [KIP-1043](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1043%3A+Administration+of+groups) — Administration of groups (protocol) | 4.0 | Supported |
 | [KIP-1073](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1073:+Return+fenced+brokers+in+DescribeCluster+response) — DescribeCluster.IsFenced | 4.0 | Supported |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/twmb/franz-go
 
-go 1.21
+go 1.23
 
 require (
 	github.com/klauspost/compress v1.17.11

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -511,7 +511,8 @@ func (p bufPool) put(b []byte) { p.p.Put(&b) }
 func (b *broker) loadConnection(ctx context.Context, req kmsg.Request) (*brokerCxn, error) {
 	var (
 		pcxn         = &b.cxnNormal
-		isProduceCxn bool // see docs on brokerCxn.discard for why we do this
+		isProduceCxn bool
+		isFetchCxn   bool
 		reqKey       = req.Key()
 		_, isTimeout = req.(kmsg.TimeoutRequest)
 	)
@@ -521,6 +522,7 @@ func (b *broker) loadConnection(ctx context.Context, req kmsg.Request) (*brokerC
 		isProduceCxn = true
 	case reqKey == 1:
 		pcxn = &b.cxnFetch
+		isFetchCxn = true
 	case reqKey == 11 || reqKey == 14: // join || sync
 		pcxn = &b.cxnGroup
 	case isTimeout:
@@ -550,6 +552,12 @@ func (b *broker) loadConnection(ctx context.Context, req kmsg.Request) (*brokerC
 		return nil, err
 	}
 	b.cl.cfg.logger.Log(LogLevelDebug, "connection initialized successfully", "addr", b.addr, "broker", logID(b.meta.NodeID))
+
+	if isProduceCxn {
+		b.cl.metrics.observeRate(&b.cl.metrics.pConnCreation)
+	} else if isFetchCxn {
+		b.cl.metrics.observeRate(&b.cl.metrics.cConnCreation)
+	}
 
 	b.reapMu.Lock()
 	defer b.reapMu.Unlock()
@@ -1245,6 +1253,16 @@ func (cxn *brokerCxn) readResponse(
 			})
 		}
 	})
+
+	if readErr == nil {
+		latencyMillis := (writeWait + timeToWrite + readWait + timeToRead).Milliseconds()
+		if key == 0 {
+			cxn.b.cl.metrics.observeNodeTime(cxn.b.meta.NodeID, &cxn.b.cl.metrics.pReqLatency, latencyMillis)
+		} else if key == 1 {
+			cxn.b.cl.metrics.observeNodeTime(cxn.b.meta.NodeID, &cxn.b.cl.metrics.cReqLatency, latencyMillis)
+		}
+	}
+
 	if logger := cxn.cl.cfg.logger; logger.Level() >= LogLevelDebug {
 		logger.Log(LogLevelDebug, fmt.Sprintf("read %s v%d", kmsg.NameForKey(key), version), "broker", logID(cxn.b.meta.NodeID), "bytes_read", bytesRead, "read_wait", readWait, "time_to_read", timeToRead, "err", readErr)
 	}
@@ -1502,6 +1520,9 @@ func (cxn *brokerCxn) handleResp(pr promisedResp) {
 		if throttleResponse, ok := pr.resp.(kmsg.ThrottleResponse); ok {
 			millis, throttlesAfterResp := throttleResponse.Throttle()
 			if millis > 0 {
+				if pr.resp.Key() == 0 {
+					cxn.b.cl.metrics.observeTime(&cxn.b.cl.metrics.pThrottle, int64(millis))
+				}
 				cxn.b.cl.cfg.logger.Log(LogLevelInfo, "broker is throttling us in response", "broker", logID(cxn.b.meta.NodeID), "req", kmsg.Key(pr.resp.Key()).Name(), "throttle_millis", millis, "throttles_after_resp", throttlesAfterResp)
 				if throttlesAfterResp {
 					throttleUntil := time.Now().Add(time.Millisecond * time.Duration(millis)).UnixNano()

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -1256,7 +1256,7 @@ func (cxn *brokerCxn) readResponse(
 
 	if readErr == nil {
 		latencyMillis := (writeWait + timeToWrite + readWait + timeToRead).Milliseconds()
-		if key == 0 {
+		if key == 0 { //nolint:staticcheck // tagged switch not needed for one case...
 			cxn.b.cl.metrics.observeNodeTime(cxn.b.meta.NodeID, &cxn.b.cl.metrics.pReqLatency, latencyMillis)
 		} else if key == 1 {
 			cxn.b.cl.metrics.observeNodeTime(cxn.b.meta.NodeID, &cxn.b.cl.metrics.cReqLatency, latencyMillis)

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -532,6 +532,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 	cl.producer.init(cl)
 	cl.consumer.init(cl)
 	cl.metawait.init()
+	cl.metrics.init(cl)
 
 	if cfg.id != nil {
 		cl.reqFormatter = kmsg.NewRequestFormatter(kmsg.FormatterClientID(*cfg.id))

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -81,6 +81,8 @@ type Client struct {
 	consumer consumer
 	id2t     atomic.Value // map[[16]byte]string
 
+	metrics metrics
+
 	coordinatorsMu sync.Mutex
 	coordinators   map[coordinatorKey]*coordinatorLoad
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -545,6 +545,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 	cl.seeds.Store(seedBrokers)
 	go cl.updateMetadataLoop()
 	go cl.reapConnectionsLoop()
+	go cl.pushMetrics()
 
 	return cl, nil
 }
@@ -863,6 +864,12 @@ func (cl *Client) supportsKIP848v1() bool {
 	return cl.supportsKeyVersion(int16(kmsg.ConsumerGroupHeartbeat), 1)
 }
 
+// Called after the first metric observed, which is always after a response.
+func (cl *Client) supportsClientMetrics() bool {
+	return cl.supportsKeyVersion(int16(kmsg.GetTelemetrySubscriptions), 0) &&
+		cl.supportsKeyVersion(int16(kmsg.PushTelemetry), 0)
+}
+
 // A broker may not support some requests we want to make. This function checks
 // support. This should only be used *after* at least one successful response.
 func (cl *Client) supportsKeyVersion(key, version int16) bool {
@@ -1103,8 +1110,21 @@ func (cl *Client) close(ctx context.Context) (rerr error) {
 
 	// Now we kill the client context and all brokers, ensuring all
 	// requests fail. This will finish all producer callbacks and
-	// stop the metadata loop.
+	// stop the metadata loop and metrics loop.
 	cl.ctxCancel()
+
+	// Before killing brokers, give metrics 1s to push any final
+	// terminating message. The client context cancelation awakens
+	// the push-period-wait loop.
+	after := time.NewTimer(time.Second)
+	select {
+	case <-cl.metrics.ctx.Done():
+	case <-after.C:
+		cl.metrics.ctxCancel()
+	case <-ctx.Done():
+		cl.metrics.ctxCancel()
+	}
+
 	cl.brokersMu.Lock()
 	cl.stopBrokers = true
 	for _, broker := range cl.brokers {

--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -79,11 +79,11 @@ func TestCompressDecompress(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for _, produceVersion := range []int16{
-		0, 7,
+	for _, flag := range []CompressFlag{
+		0, CompressDisableZstd,
 	} {
 		wg.Add(1)
-		go func(produceVersion int16) {
+		go func(flag CompressFlag) {
 			defer wg.Done()
 			for _, codecs := range [][]CompressionCodec{
 				{{codec: 0}},
@@ -109,7 +109,7 @@ func TestCompressDecompress(t *testing.T) {
 						for _, in := range inputs {
 							w.Reset()
 
-							got, used := c.Compress(w, in, produceVersion)
+							got, used := c.Compress(w, in, flag)
 							got, err := d.Decompress(got, used)
 							if err != nil {
 								t.Errorf("unexpected decompress err: %v", err)
@@ -122,7 +122,7 @@ func TestCompressDecompress(t *testing.T) {
 					}()
 				}
 			}
-		}(produceVersion)
+		}(flag)
 	}
 	wg.Wait()
 }

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -2903,11 +2903,13 @@ func (g *groupConsumer) commit(
 			}
 		}
 
+		start := time.Now()
 		resp, err := req.RequestWith(commitCtx, g.cl)
 		if err != nil {
 			onDone(g.cl, req, nil, err)
 			return
 		}
+		g.cl.metrics.observeTime(&g.cl.metrics.cCommitLatency, time.Since(start).Milliseconds())
 		g.updateCommitted(req, resp)
 		onDone(g.cl, req, resp, nil)
 	}()

--- a/pkg/kgo/metrics_714.go
+++ b/pkg/kgo/metrics_714.go
@@ -1,0 +1,746 @@
+package kgo
+
+import (
+	"encoding/binary"
+	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// MetricTypeSum is a sum type metric. Every time the metric is
+	// collected, the number you are returning is cumulative from the time
+	// the client / your application was initialized.
+	MetricTypeSum = 1 + iota
+
+	// MetricTypeGauge is a gauge type metric. It is a recording of a value
+	// at a point in time.
+	MetricTypeGauge
+)
+
+type (
+	// MetricType is the type of metric you are providing: Type is the type
+	// of metric this is: either a gauge or a sum type.
+	MetricType uint8
+
+	// Metric is a user-defined client side metric so that you can send
+	// user-defined client metrics to the broker and give your cluster
+	// operator insight into your client.
+	//
+	// This type exists to support KIP-1076, which is an extension to
+	// KIP-714. Read either of those for more detail.
+	Metric struct {
+		// Name is a user provided metric name.
+		//
+		// KIP-714 prescribes how to name metrics: lowercase with dots,
+		// no dashes, and interoperable with the OpenTelemetry
+		// ecosystem. It is recommended follow the KIP-714 guidance and
+		// to namespace your metrics ("my.specific.metric.1;
+		// my.specific.metric.2). This client does not attempt to
+		// further santize your user provided name.
+		Name string
+
+		// Type is the type of metric this is: either a gauge or a sum
+		// type.
+		//
+		// Note that for sum types, the client internally caches all
+		// sum types by name for one extra collection period so that
+		// the client can calculate "delta" metrics if the broker
+		// requests them. You must provide the sum type metric on every
+		// collection; skipping a cycle means the client will be unable
+		// to calculate the delta once you provide it again in the
+		// future.
+		Type MetricType
+
+		// ValueInt is the value to record. Only one of ValueInt or
+		// ValueFloat should be non-zero; if both are non-zero or if
+		// both are zero, the metric is ignored.
+		//
+		// Sum metrics only support ValueInt, and the number should
+		// never go down. If the value goes down or ValueFloat is
+		// used, the metric is skipped.
+		ValueInt int64
+
+		// ValueFloat is the value to record. Only one of ValueInt or
+		// ValueFloat should be non-zero; if both are non-zero or if
+		// both are zero, the metric is ignored.
+		//
+		// Sum metrics only support ValueInt, and the number should
+		// never go down. If the value goes down or ValueFloat is
+		// used, the metric is skipped.
+		ValueFloat float64
+
+		// Attrs are optional attributes to add to this metric, such as
+		// a node ID. The supported `any` types are strings, booleans,
+		// numbers, and byte slices. All other attributes are silently
+		// skipped. Attributes should be lowercase with underscores
+		// (see KIP-714).
+		Attrs map[string]any
+	}
+
+	// metricRate is a count per second and a total.
+	metricRate struct {
+		count   atomic.Int64 // Sum of events this period; rate == float64(count/time) at rollup
+		tot     atomic.Int64 // Total events over all time.
+		lastTot int64        // Updated when encoding; the last value for tot in case broker requests DELTA.
+	}
+
+	// metricTime reports average latency, max latency, and total latency.
+	// The unit is in milliseconds.
+	metricTime struct {
+		sum     atomic.Int64 // With count, avg = sum/count at rollup.
+		count   atomic.Int64
+		max     atomic.Int64 // Max latency seen during this window.
+		tot     atomic.Int64 // Total sum of all latencies seen over all time (only encoded if name has a .WITH_TOTAL suffix)
+		lastTot int64
+	}
+
+	metricGauge struct {
+		v atomic.Int64
+	}
+
+	// We skip:
+	// * producer.record.queue.time.{avg,max} : medium signal; requires more wiring in the producer
+	// * consumer.poll.idle.ratio.avg         : less relevant in this client
+	metrics struct {
+		cl *Client
+
+		// mu is grabbed when accessing the map fields.
+		mu sync.Mutex
+
+		pConnCreation metricRate
+		pReqLatency   map[int32]*metricTime
+		pThrottle     metricTime
+
+		cConnCreation       metricRate
+		cReqLatency         map[int32]*metricTime
+		cCommitLatency      metricTime
+		cRebalanceLatency   metricTime
+		cFetchLatency       metricTime
+		cAssignedPartitions metricGauge
+
+		initNano     int64
+		lastPushNano int64
+
+		userSumLast map[string]int64
+	}
+)
+
+func (m *metrics) init(cl *Client) {
+	m.cl = cl
+	m.initNano = time.Now().UnixNano()
+}
+
+func safeDiv[T ~int64 | ~float64](num, denom T) T {
+	if denom == 0 {
+		return 0
+	}
+	return num / denom
+}
+
+func (t *metricRate) observe() {
+	t.count.Add(1)
+	t.tot.Add(1)
+}
+
+func (t *metricRate) rollNums() (rate float64, tot, lastTot int64) {
+	count := t.count.Swap(0)
+	lastTot = t.lastTot
+	tot = t.tot.Load()
+	t.lastTot = tot
+
+	rate = safeDiv(float64(count), float64(tot-lastTot))
+	return rate, tot, lastTot
+}
+
+func (t *metricTime) observe(millis int64) {
+	t.sum.Add(millis)
+	t.count.Add(1)
+	t.tot.Add(millis)
+	for {
+		max := t.max.Load()
+		if millis < max {
+			return
+		}
+		if t.max.CompareAndSwap(max, millis) {
+			return
+		}
+	}
+}
+
+func (t *metricTime) rollNums() (avg float64, max, tot, lastTot int64) {
+	sum := t.sum.Swap(0)
+	count := t.count.Swap(0)
+	max = t.max.Swap(0)
+	lastTot = t.lastTot
+	tot = t.tot.Load()
+	t.lastTot = tot
+
+	avg = safeDiv(float64(sum), float64(count))
+	return avg, max, tot, lastTot
+}
+
+func (m *metrics) observeNodeLatency(node int32, field *map[int32]*metricTime, millis int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if *field == nil {
+		*field = make(map[int32]*metricTime)
+	}
+	t := (*field)[node]
+	if t == nil {
+		t = new(metricTime)
+		(*field)[node] = t
+	}
+	t.observe(millis)
+}
+
+// If labels is non-nil, we use that for the Resource.
+func (m *metrics) appendTo(
+	b []byte,
+	aggregateDur time.Duration,
+	useDeltaSums bool,
+) []byte {
+	////////////
+	// VARIABLE INITIALIZATION
+	////////////
+	var (
+		metricsData    otelMetricsData
+		resourceMetric = &metricsData.resourceMetric
+		resource       = &resourceMetric.resource
+		scopeMetric    = &resourceMetric.scopeMetric
+		scope          = &scopeMetric.scope
+		metrics        = &scopeMetric.metrics
+		labels         = make(map[string]any)
+	)
+
+	if m.cl.cfg.rack != "" {
+		labels["client_rack"] = m.cl.cfg.rack
+	}
+	if m.cl.cfg.group != "" {
+		labels["group_id"] = m.cl.cfg.group
+	}
+	if m.cl.cfg.instanceID != nil {
+		labels["group_instance_id"] = *m.cl.cfg.instanceID
+	}
+	if memberID, _ := m.cl.GroupMetadata(); memberID != "" {
+		labels["group_member_id"] = memberID
+	}
+	if m.cl.cfg.txnID != nil {
+		labels["transactional_id"] = *m.cl.cfg.txnID
+	}
+	if len(labels) > 0 {
+		resource.attributes = labels
+	}
+	scope.name = "kgo"
+	scope.version = softwareVersion()
+
+	now := time.Now().UnixNano()
+	lastPush := m.lastPushNano
+	m.lastPushNano = now
+
+	////////////
+	// FUNCTIONS THAT APPEND TO `metrics`.
+	////////////
+
+	appendGauge := func(name string, vi64 int64, vf64 float64, attrs map[string]any) {
+		if vi64 == 0 && vf64 == 0 || vi64 != 0 && vf64 != 0 {
+			return
+		}
+		*metrics = append(*metrics, otelMetric{
+			name: name,
+			gauge: otelGauge{
+				otelNumDataPoint{
+					attributes: attrs,
+					vInt:       vi64,
+					vDouble:    vf64,
+					startNano:  lastPush,
+					timeNano:   now,
+				},
+			},
+		})
+	}
+	appendSum := func(name string, tot, lastTot int64, attrs map[string]any) {
+		if tot-lastTot == 0 {
+			return
+		}
+		if useDeltaSums {
+			*metrics = append(*metrics, otelMetric{
+				name: name,
+				sum: otelSum{
+					dataPoint: otelNumDataPoint{
+						attributes: attrs,
+						vInt:       tot - lastTot,
+						startNano:  lastPush,
+						timeNano:   now,
+					},
+					aggregationTemporality: otelTempDelta,
+				},
+			})
+		} else {
+			*metrics = append(*metrics, otelMetric{
+				name: name,
+				sum: otelSum{
+					dataPoint: otelNumDataPoint{
+						attributes: attrs,
+						vInt:       tot,
+						startNano:  m.initNano,
+						timeNano:   now,
+					},
+					aggregationTemporality: otelTempCumulative,
+				},
+			})
+		}
+	}
+
+	////////////
+	// COLLECTING ALL METRICS TO SEND
+	////////////
+
+	m.mu.Lock()
+	for _, s := range []struct {
+		name string
+		v    any
+	}{
+		{"producer.connection.creation", &m.pConnCreation},
+		{"producer.node.request.latency", &m.pReqLatency},
+		{"producer.produce.throttle.time", &m.pThrottle},
+		{"consumer.connection.creation", &m.cConnCreation},
+		{"consumer.node.request.latency", &m.cReqLatency},
+		{"consumer.coordinator.commit.latency", &m.cCommitLatency},
+		{"consumer.coordinator.rebalance.latency.WITH_TOTAL", &m.cRebalanceLatency},
+		{"consumer.fetch.manager.fetch.latency", &m.cFetchLatency},
+		{"consumer.coordinator.assigned.partitions", &m.cAssignedPartitions},
+	} {
+		switch t := s.v.(type) {
+		case *metricRate:
+			rate, tot, lastTot := t.rollNums()
+			appendGauge(s.name+".rate", 0, rate, nil)
+			appendSum(s.name+".total", tot, lastTot, nil)
+
+		case *metricTime:
+			// One metric in particular includes a `.total`
+			// measurement of latency. We special case this with a
+			// .WITH_TOTAL suffix on the name.
+			name, includeTotal := strings.CutSuffix(s.name, ".WITH_TOTAL")
+			avg, max, tot, lastTot := t.rollNums()
+			appendGauge(name+".avg", 0, avg, nil)
+			appendGauge(name+".max", max, 0, nil)
+			if includeTotal {
+				appendSum(name+".total", tot, lastTot, nil)
+			}
+
+		case map[int32]*metricTime:
+			for broker, m := range t {
+				avg, max, _, _ := m.rollNums()
+				attrs := map[string]any{"node_id": broker}
+				appendGauge(s.name+".avg", 0, avg, attrs)
+				appendGauge(s.name+".max", max, 0, attrs)
+				// By-node metrics do not write the forever-total-latency.
+				// We only have per-push increments, so we can safely delete
+				// the node every round (i.e., clean up if a broker goes away).
+				if avg == 0 && max == 0 {
+					delete(t, broker)
+				}
+			}
+
+		case *metricGauge:
+			appendGauge(s.name, t.v.Load(), 0, nil)
+
+		default:
+			m.mu.Unlock()
+			panic("unsupported type")
+		}
+	}
+	m.mu.Unlock()
+
+	if m.cl.cfg.userMetrics != nil {
+		var userSkipped []string
+		last := m.userSumLast
+		if last == nil {
+			last = make(map[string]int64)
+		}
+		m.userSumLast = make(map[string]int64)
+		for um := range m.cl.cfg.userMetrics() {
+			if um.ValueInt != 0 && um.ValueFloat != 0 || um.ValueInt == 0 && um.ValueFloat == 0 {
+				userSkipped = append(userSkipped, um.Name)
+				continue
+			}
+
+			switch um.Type {
+			case MetricTypeSum:
+				lastTot := last[um.Name]
+				if um.ValueFloat != 0 || um.ValueInt < 0 || lastTot > um.ValueInt {
+					userSkipped = append(userSkipped, um.Name)
+					continue
+				}
+				appendSum(um.Name, um.ValueInt, lastTot, um.Attrs)
+				m.userSumLast[um.Name] = um.ValueInt
+
+			case MetricTypeGauge:
+				appendGauge(um.Name, um.ValueInt, um.ValueFloat, um.Attrs)
+			}
+		}
+		if len(userSkipped) > 0 {
+			m.cl.cfg.logger.Log(LogLevelWarn, "skipped serialization of some user provided metrics", "skipped", userSkipped)
+		}
+	}
+
+	////////////
+	// SERIALIZING - finally append metricsData to b
+	////////////
+
+	return metricsData.appendTo(nil)
+}
+
+// The types below are encoded in protobuf format; canonical
+// definitions can be found at:
+// https://github.com/open-telemetry/opentelemetry-proto/blob/f24da8deeb50118271c9435972791ef05ec003b1/opentelemetry/proto/metrics/v1/metrics.proto
+type (
+	otelMetricsData struct {
+		// resourceMetrics is repeated, but we always use one element.
+		resourceMetric otelResourceMetric // = 1
+	}
+
+	otelResourceMetric struct {
+		// We do not encode resource if resource.attributes is empty;
+		// eliding resource just means it is not known.
+		resource otelResource // = 1
+
+		// scopeMetric is repeated, but we always use one element.
+		scopeMetric otelScopeMetric // = 2
+	}
+
+	// From a separate file:
+	// https://github.com/open-telemetry/opentelemetry-proto/blob/f24da8deeb50118271c9435972791ef05ec003b1/opentelemetry/proto/resource/v1/resource.proto
+	// We only use attributes, and only if any exist.
+	otelResource struct {
+		attributes map[string]any // = 1
+	}
+
+	otelScopeMetric struct {
+		scope   otelInstrumentationScope // = 1
+		metrics []otelMetric             // = 2
+	}
+
+	// From a separate file:
+	// https://github.com/open-telemetry/opentelemetry-proto/blob/f24da8deeb50118271c9435972791ef05ec003b1/opentelemetry/proto/common/v1/common.proto
+	// We use "kgo" and our released version (via the `softwareVersion()` func).
+	otelInstrumentationScope struct {
+		name    string // = 1
+		version string // = 2
+	}
+
+	otelMetric struct {
+		name string // = 1
+
+		// The metric data can be oneOf the following two:
+		gauge otelGauge // = 5
+		sum   otelSum   // = 7
+		// We use the non-empty struct; one must be non-empty.
+	}
+
+	otelGauge struct {
+		// The .proto defines this as `repeated`, but we always use
+		// only one data point.
+		dataPoint otelNumDataPoint // = 1
+	}
+
+	otelSum struct {
+		// Same as otelGauge, the .proto defines this as `repeated`
+		// but we only use one data point.
+		dataPoint otelNumDataPoint // = 1
+
+		// aggregationTemporality is an enum;
+		// 0 is unspecified
+		// 1 is delta
+		// 2 is cumulative
+		aggregationTemporality uint8 // = 2
+
+		// We always set isMonotonic to true.
+		isMonotonic bool // = 3
+	}
+
+	otelNumDataPoint struct {
+		// Encoded as key/value attributes; we currently only use int32
+		// broker IDs. This will need to change if other types are
+		// needed.
+		attributes map[string]any // = 7
+
+		startNano int64 // = 2
+		timeNano  int64 // = 3
+
+		// Only one of vDouble or vInt is non-zero, only
+		// one is used (this is oneof).
+		vDouble float64 // = 4
+		vInt    int64   // = 6
+	}
+)
+
+const (
+	otelTempDelta      = 1
+	otelTempCumulative = 2
+)
+
+////////////
+// SERIALIZATION
+////////////
+
+const (
+	protoTypeVarint = 0
+	protoType64bit  = 1
+	protoTypeLength = 2
+	protoType32bit  = 5
+)
+
+// appendProtoTag adds a Protocol Buffer tag (field number + proto type)
+func appendProtoTag(b []byte, fieldNumber int, protoType int) []byte {
+	return binary.AppendUvarint(b, uint64((fieldNumber<<3)|protoType))
+}
+
+// appendProtoString appends a string as length-prefixed bytes
+func appendProtoString(b []byte, s string) []byte {
+	b = binary.AppendUvarint(b, uint64(len(s)))
+	return append(b, s...)
+}
+
+func (d *otelMetricsData) appendTo(b []byte) []byte {
+	// Field 1: resourceMetric (message)
+	b = appendProtoTag(b, 1, protoTypeLength)
+	resourceBytes := d.resourceMetric.appendTo(nil)
+	b = binary.AppendUvarint(b, uint64(len(resourceBytes)))
+	b = append(b, resourceBytes...)
+
+	return b
+}
+
+func (m *otelResourceMetric) appendTo(b []byte) []byte {
+	// Field 1: resource (message) - only if attributes are present
+	if len(m.resource.attributes) > 0 {
+		b = appendProtoTag(b, 1, protoTypeLength)
+		resourceBytes := m.resource.appendTo(nil)
+		b = binary.AppendUvarint(b, uint64(len(resourceBytes)))
+		b = append(b, resourceBytes...)
+	}
+
+	// Field 2: scopeMetric (message)
+	b = appendProtoTag(b, 2, protoTypeLength)
+	scopeBytes := m.scopeMetric.appendTo(nil)
+	b = binary.AppendUvarint(b, uint64(len(scopeBytes)))
+	b = append(b, scopeBytes...)
+
+	return b
+}
+
+func (r *otelResource) appendTo(b []byte) []byte {
+	// Field 1: attributes (repeated KeyValue)
+	return appendOtelAttributesTo(b, 1, r.attributes)
+}
+
+func (s *otelScopeMetric) appendTo(b []byte) []byte {
+	// Field 1: scope (message)
+	b = appendProtoTag(b, 1, protoTypeLength)
+	scopeBytes := s.scope.appendTo(nil)
+	b = binary.AppendUvarint(b, uint64(len(scopeBytes)))
+	b = append(b, scopeBytes...)
+
+	// Field 2: metrics (repeated message)
+	for _, m := range s.metrics {
+		b = appendProtoTag(b, 2, protoTypeLength)
+		metricBytes := m.appendTo(nil)
+		b = binary.AppendUvarint(b, uint64(len(metricBytes)))
+		b = append(b, metricBytes...)
+	}
+
+	return b
+}
+
+func (s *otelInstrumentationScope) appendTo(b []byte) []byte {
+	// Field 1: name (string)
+	if s.name != "" {
+		b = appendProtoTag(b, 1, protoTypeLength)
+		b = appendProtoString(b, s.name)
+	}
+	// Field 2: version (string)
+	if s.version != "" {
+		b = appendProtoTag(b, 2, protoTypeLength)
+		b = appendProtoString(b, s.version)
+	}
+	return b
+}
+
+func (m *otelMetric) appendTo(b []byte) []byte {
+	// Field 1: name (string)
+	if m.name != "" {
+		b = appendProtoTag(b, 1, protoTypeLength)
+		b = appendProtoString(b, m.name)
+	}
+
+	// Field 5: gauge (message) - if used
+	if m.gauge.dataPoint.timeNano != 0 {
+		b = appendProtoTag(b, 5, protoTypeLength)
+		gaugeBytes := m.gauge.appendTo(nil)
+		b = binary.AppendUvarint(b, uint64(len(gaugeBytes)))
+		b = append(b, gaugeBytes...)
+	}
+
+	// Field 7: sum (message) - if used
+	if m.sum.dataPoint.timeNano != 0 {
+		b = appendProtoTag(b, 7, protoTypeLength)
+		sumBytes := m.sum.appendTo(nil)
+		b = binary.AppendUvarint(b, uint64(len(sumBytes)))
+		b = append(b, sumBytes...)
+	}
+	return b
+}
+
+func (g *otelGauge) appendTo(b []byte) []byte {
+	// Field 1: dataPoints (repeated message)
+	b = appendProtoTag(b, 1, protoTypeLength)
+	dataPointBytes := g.dataPoint.appendTo(nil)
+	b = binary.AppendUvarint(b, uint64(len(dataPointBytes)))
+	b = append(b, dataPointBytes...)
+
+	return b
+}
+
+func (s *otelSum) appendTo(b []byte) []byte {
+	// Field 1: dataPoints (repeated message)
+	b = appendProtoTag(b, 1, protoTypeLength)
+	dataPointBytes := s.dataPoint.appendTo(nil)
+	b = binary.AppendUvarint(b, uint64(len(dataPointBytes)))
+	b = append(b, dataPointBytes...)
+
+	// Field 2: aggregationTemporality (enum)
+	if s.aggregationTemporality != 0 {
+		b = appendProtoTag(b, 2, protoTypeVarint)
+		b = binary.AppendUvarint(b, uint64(s.aggregationTemporality))
+	}
+
+	// Field 3: isMonotonic (bool)
+	if s.isMonotonic {
+		b = appendProtoTag(b, 3, protoTypeVarint)
+		b = binary.AppendUvarint(b, 1) // true
+	}
+
+	return b
+}
+
+func (d *otelNumDataPoint) appendTo(b []byte) []byte {
+	// Field 2: startTimeUnixNano (fixed64)
+	if d.startNano != 0 {
+		b = appendProtoTag(b, 2, protoType64bit)
+		b = binary.LittleEndian.AppendUint64(b, uint64(d.startNano))
+	}
+
+	// Field 3: timeUnixNano (fixed64)
+	b = appendProtoTag(b, 3, protoType64bit)
+	b = binary.LittleEndian.AppendUint64(b, uint64(d.timeNano))
+
+	// Field 4: asDouble (double)
+	if d.vDouble != 0 {
+		b = appendProtoTag(b, 4, protoType64bit)
+		b = binary.LittleEndian.AppendUint64(b, math.Float64bits(d.vDouble))
+	}
+
+	// Field 6: asInt (int64)
+	if d.vInt != 0 {
+		b = appendProtoTag(b, 6, protoTypeVarint)
+		b = binary.AppendUvarint(b, uint64(d.vInt))
+	}
+
+	// Field 7: attributes
+	b = appendOtelAttributesTo(b, 7, d.attributes)
+
+	return b
+}
+
+func appendOtelAttributesTo(b []byte, fieldNumber int, attrs map[string]any) []byte {
+outer:
+	for key, value := range attrs {
+		b = appendProtoTag(b, fieldNumber, protoTypeLength)
+
+		kvBytes := []byte{}
+		// Field 1: key (string)
+		kvBytes = appendProtoTag(kvBytes, 1, protoTypeLength)
+		kvBytes = appendProtoString(kvBytes, key)
+
+		// Field 2: value (AnyValue)
+		kvBytes = appendProtoTag(kvBytes, 2, protoTypeLength)
+
+		var anyValueBytes []byte
+		switch t := value.(type) {
+		case *string, string:
+			var v string
+			switch t := t.(type) {
+			case string:
+				v = t
+			case *string:
+				if t != nil {
+					v = *t
+				}
+			}
+			anyValueBytes = appendProtoTag(anyValueBytes, 1, protoTypeLength) // string_value = 1
+			anyValueBytes = appendProtoString(anyValueBytes, v)
+		case bool:
+			anyValueBytes = appendProtoTag(anyValueBytes, 2, protoTypeVarint) // bool_value = 2
+			if t {
+				anyValueBytes = binary.AppendUvarint(anyValueBytes, 1)
+			} else {
+				anyValueBytes = binary.AppendUvarint(anyValueBytes, 0)
+			}
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr:
+			anyValueBytes = appendProtoTag(anyValueBytes, 3, protoTypeVarint) // int_value = 3
+			var v uint64
+			switch t := t.(type) {
+			case int:
+				v = uint64(t)
+			case int8:
+				v = uint64(t)
+			case int16:
+				v = uint64(t)
+			case int32:
+				v = uint64(t)
+			case int64:
+				v = uint64(t)
+			case uint:
+				v = uint64(t)
+			case uint8:
+				v = uint64(t)
+			case uint16:
+				v = uint64(t)
+			case uint32:
+				v = uint64(t)
+			case uint64:
+				v = uint64(t)
+			case uintptr:
+				v = uint64(t)
+			}
+			anyValueBytes = binary.AppendUvarint(anyValueBytes, v)
+		case float32, float64:
+			var v float64
+			switch t := t.(type) {
+			case float32:
+				v = float64(t)
+			case float64:
+				v = t
+			}
+			anyValueBytes = appendProtoTag(anyValueBytes, 4, protoType64bit) // double_value = 4
+			anyValueBytes = binary.LittleEndian.AppendUint64(anyValueBytes, math.Float64bits(v))
+		case []byte:
+			anyValueBytes = appendProtoTag(anyValueBytes, 7, protoTypeLength) // bytes_value = 7
+			anyValueBytes = binary.AppendUvarint(anyValueBytes, uint64(len(t)))
+			anyValueBytes = append(anyValueBytes, t...)
+		default:
+			continue outer
+		}
+
+		kvBytes = binary.AppendUvarint(kvBytes, uint64(len(anyValueBytes)))
+		kvBytes = append(kvBytes, anyValueBytes...)
+
+		b = binary.AppendUvarint(b, uint64(len(kvBytes)))
+		b = append(b, kvBytes...)
+	}
+	return b
+}

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -388,7 +388,7 @@ func TestRecBatchAppendTo(t *testing.T) {
 		kbatch.Attributes |= 0x0002 // snappy
 		w := byteBuffers.Get().(*bytes.Buffer)
 		w.Reset()
-		kbatch.Records, _ = compressor.Compress(w, kbatch.Records, version)
+		kbatch.Records, _ = compressor.Compress(w, kbatch.Records)
 	}
 
 	fixFields()

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -2313,7 +2313,7 @@ func (b seqRecBatch) appendTo(
 		defer byteBuffers.Put(w)
 		w.Reset()
 
-		compressed, codec := compressor.Compress(w, toCompress, version)
+		compressed, codec := compressor.Compress(w, toCompress, mkCompressFlags(version)...)
 		if compressed != nil && // nil would be from an error
 			len(compressed) < len(toCompress) {
 			// our compressed was shorter: copy over
@@ -2395,7 +2395,7 @@ func (b seqRecBatch) appendToAsMessageSet(dst []byte, version uint8, compressor 
 		defer byteBuffers.Put(w)
 		w.Reset()
 
-		compressed, codec := compressor.Compress(w, toCompress, int16(version))
+		compressed, codec := compressor.Compress(w, toCompress, mkCompressFlags(int16(version))...)
 		inner := &Record{Value: compressed}
 		wrappedLength := messageSet0Length(inner)
 		if version == 2 {


### PR DESCRIPTION
This supports 12 of the recommended 21 metrics; all 6 of the required ones.

KIP-1106 is supported by adding a client option, `UserMetricsFn`, allowing you to provide user metrics at every metric aggregation interval. Client metrics can be disabled with `DisableClientMetrics`. `UserMetricsFn` returns an `iter.Seq[Metric]`, requiring the minimum Go version for franz-go to be bumped to 1.23.

The compression API was simplified (hopefully) a bit by now not leaking an internal implementation detail.

This has been manually tested in two ways,
* Actual serialization was printed to a file and then validated with `protoc`.

This was done with:
```
git clone git@github.com:open-telemetry/opentelemetry-proto

protoc --proto_path=./opentelemetry-proto \
       --decode opentelemetry.proto.metrics.v1.MetricsData \
       ./opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto \
       < SERIALIZED
```

* I cloned this repo: https://github.com/riferrei/kafka-client-metrics-to-cloudwatch-with-kip-714 and ran the containers locally without AWS Cloudwatch setup. The broker is configured to enable client metrics; the client actually did generate and send metrics every second.

I did _not_ test viewing the metrics at the end, since I don't want to further figure out how to set up 3rd party systems. It would be beneficial for Confluent to provide a KIP-714 enabled broker and local server / log message to check correctness, but alas, a lot of KIP-714 leaves it for the implementor to figure out 👍 .

Unit tests are gated on introducing more third party libraries, which I'd like to avoid.

Closes #848.
