### PR TITLE
kgo: add ConsumeStartOffset, expand offset docs, update readme KIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ generation.
 | [KIP-35](https://cwiki.apache.org/confluence/display/KAFKA/KIP-35+-+Retrieving+protocol+version) — ApiVersion | 0.10.0 | Supported |
 | [KIP-40](https://cwiki.apache.org/confluence/display/KAFKA/KIP-40%3A+ListGroups+and+DescribeGroup) — ListGroups and DescribeGroups | 0.9.0 | Supported |
 | [KIP-41](https://cwiki.apache.org/confluence/display/KAFKA/KIP-41%3A+KafkaConsumer+Max+Records) — max.poll.records | 0.10.0 | Supported (via PollRecords) |
-| [KIP-42](https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors) — Producer & consumer interceptors | 0.10.0 | Partial support (hooks) |
+| [KIP-42](https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors) — Producer & consumer interceptors | 0.10.0 | Supported via hooks |
 | [KIP-43](https://cwiki.apache.org/confluence/display/KAFKA/KIP-43%3A+Kafka+SASL+enhancements) — SASL PLAIN & handshake | 0.10.0 | Supported |
 | [KIP-48](https://cwiki.apache.org/confluence/display/KAFKA/KIP-48+Delegation+token+support+for+Kafka) — Delegation tokens | 1.1 | Supported |
 | [KIP-54](https://cwiki.apache.org/confluence/display/KAFKA/KIP-54+-+Sticky+Partition+Assignment+Strategy) — Sticky partitioning | 0.11.0 | Supported |
@@ -289,7 +289,7 @@ generation.
 | [KIP-74](https://cwiki.apache.org/confluence/display/KAFKA/KIP-74%3A+Add+Fetch+Response+Size+Limit+in+Bytes) — Fetch response size limits | 0.10.1 | Supported |
 | [KIP-78](https://cwiki.apache.org/confluence/display/KAFKA/KIP-78%3A+Cluster+Id) — ClusterID in Metadata | 0.10.1 | Supported |
 | [KIP-79](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65868090) — List offsets for times | 0.10.1 | Supported |
-| [KIP-81](https://cwiki.apache.org/confluence/display/KAFKA/KIP-81%3A+Bound+Fetch+memory+usage+in+the+consumer) — Bound fetch memory usage | WIP | Supported (through a combo of options) |
+| [KIP-81](https://cwiki.apache.org/confluence/display/KAFKA/KIP-81%3A+Bound+Fetch+memory+usage+in+the+consumer) — Bound fetch memory usage | WIP | Supported (through options) |
 | [KIP-82](https://cwiki.apache.org/confluence/display/KAFKA/KIP-82+-+Add+Record+Headers) — Record headers | 0.11.0 | Supported |
 | [KIP-84](https://cwiki.apache.org/confluence/display/KAFKA/KIP-84%3A+Support+SASL+SCRAM+mechanisms) — SASL SCRAM | 0.10.2 | Supported |
 | [KIP-86](https://cwiki.apache.org/confluence/display/KAFKA/KIP-86%3A+Configurable+SASL+callback+handlers) — SASL Callbacks | 0.10.2 | Supported (through callback fns) |
@@ -304,7 +304,7 @@ generation.
 | [KIP-110](https://cwiki.apache.org/confluence/display/KAFKA/KIP-110%3A+Add+Codec+for+ZStandard+Compression) — zstd | 2.1 | Supported |
 | [KIP-112](https://cwiki.apache.org/confluence/display/KAFKA/KIP-112%3A+Handle+disk+failure+for+JBOD) — Broker request protocol changes | 1.0 | Supported |
 | [KIP-113](https://cwiki.apache.org/confluence/display/KAFKA/KIP-113%3A+Support+replicas+movement+between+log+directories) — LogDir requests | 1.0 | Supported |
-| [KIP-117](https://cwiki.apache.org/confluence/display/KAFKA/KIP-117%3A+Add+a+public+AdminClient+API+for+Kafka+admin+operations) — Admin client | 0.11.0 | Supported (via kmsg) |
+| [KIP-117](https://cwiki.apache.org/confluence/display/KAFKA/KIP-117%3A+Add+a+public+AdminClient+API+for+Kafka+admin+operations) — Admin client | 0.11.0 | Supported |
 | [KIP-124](https://cwiki.apache.org/confluence/display/KAFKA/KIP-124+-+Request+rate+quotas) — Request rate quotas | 0.11.0 | Supported |
 | [KIP-126](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=68715855) — Ensure proper batch size after compression | 0.11.0 | Supported (avoided entirely) |
 | [KIP-133](https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs) — Describe & Alter configs | 0.11.0 | Supported |
@@ -362,7 +362,7 @@ generation.
 | [KIP-498](https://cwiki.apache.org/confluence/display/KAFKA/KIP-498%3A+Add+client-side+configuration+for+maximum+response+size+to+protect+against+OOM) — Max bound on reads | ? | Supported |
 | [KIP-511](https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers) — Client name/version in ApiVersions request | 2.4 | Supported |
 | [KIP-514](https://cwiki.apache.org/confluence/display/KAFKA/KIP-514%3A+Add+a+bounded+flush%28%29+API+to+Kafka+Producer) — Bounded Flush | 2.4 | Supported (via context) |
-| [KIP-516](https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers) — Topic IDs | ??? | Supported as it is implemented |
+| [KIP-516](https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers) — Topic IDs | 2.8 | Supported |
 | [KIP-518](https://cwiki.apache.org/confluence/display/KAFKA/KIP-518%3A+Allow+listing+consumer+groups+per+state) — List groups by state | 2.6 | Supported |
 | [KIP-519](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=128650952) — Configurable SSL "engine" | 2.6 | Supported (via dialer) |
 | [KIP-525](https://cwiki.apache.org/confluence/display/KAFKA/KIP-525+-+Return+topic+metadata+and+configs+in+CreateTopics+response) — CreateTopics v5 returns configs | 2.4 | Supported |
@@ -402,7 +402,7 @@ generation.
 | [KIP-827](https://cwiki.apache.org/confluence/display/KAFKA/KIP-827%3A+Expose+logdirs+total+and+usable+space+via+Kafka+API) — `DescribeLogDirs.{Total,Usable}Bytes` | 3.3 | Supported |
 | [KIP-836](https://cwiki.apache.org/confluence/display/KAFKA/KIP-836%3A+Addition+of+Information+in+DescribeQuorumResponse+about+Voter+Lag) — `DescribeQuorum` voter lag info | 3.3 | Supported |
 | [KIP-841](https://cwiki.apache.org/confluence/display/KAFKA/KIP-841%3A+Fenced+replicas+should+not+be+allowed+to+join+the+ISR+in+KRaft) — `AlterPartition.TopicID` | 3.3 | Supported |
-| [KIP-848](https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol) — Next gen consumer rebalance protocol | 3.7 | Unsupported (proto supported) |
+| [KIP-848](https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol) — Next gen consumer rebalance protocol | 3.7 | Supported |
 | [KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes) — Add replica directory ID for replica fetchers | 3.9 | Supported |
 | [KIP-858](https://cwiki.apache.org/confluence/display/KAFKA/KIP-858%3A+Handle+JBOD+broker+disk+failure+in+KRaft) — JBOD in KRaft (protocol) | 3.7 | Supported |
 | [KIP-866](https://cwiki.apache.org/confluence/display/KAFKA/KIP-866+ZooKeeper+to+KRaft+Migration) — ZK to Raft RPC changes | 3.4 | Supported |
@@ -415,11 +415,12 @@ generation.
 | [KIP-966](https://cwiki.apache.org/confluence/display/KAFKA/KIP-966%3A+Eligible+Leader+Replicas) — Eligible leader replicas (protocol) | 3.7 | Supported |
 | [KIP-994](https://cwiki.apache.org/confluence/display/KAFKA/KIP-994%3A+Minor+Enhancements+to+ListTransactions+and+DescribeTransactions+APIs) — List/Describe transactions enhancements | 3.8 (partial) | Supported |
 | [KIP-1000](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1000%3A+List+Client+Metrics+Configuration+Resources) — ListClientMetricsResources | 3.7 | Supported |
-| [KIP-1106](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1076%3A++Metrics+for+client+applications+KIP-714+extension) — User provided client metrics | 4.0 | Supported |
 | [KIP-1005](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1005%3A+Expose+EarliestLocalOffset+and+TieredOffset) — ListOffsets w. Timestamp -5 | 3.9 | Supported |
+| [KIP-1106](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1106%3A+Add+duration+based+offset+reset+option+for+consumer+clients) - Reset offset by duration | 4.0 | Skipped, unneeded |
 | [KIP-1043](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1043%3A+Administration+of+groups) — Administration of groups (protocol) | 4.0 | Supported |
 | [KIP-1073](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1073:+Return+fenced+brokers+in+DescribeCluster+response) — DescribeCluster.IsFenced | 4.0 | Supported |
 | [KIP-1075](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1075%3A+Introduce+delayed+remote+list+offsets+purgatory+to+make+LIST_OFFSETS+async) — TimeoutMillis on ListOffsets | 4.0 | Supported |
+| [KIP-1076](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1076%3A++Metrics+for+client+applications+KIP-714+extension) — User provided client metrics | 4.0 | Supported |
 | [KIP-1102](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1102%3A+Enable+clients+to+rebootstrap+based+on+timeout+or+error+code) — RebootstrapRequired | 4.0 | Supported |
 
 Missing from above but included in librdkafka is:

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -350,6 +350,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.decompressor}
 	case namefn(ConsumeRegex):
 		return []any{cfg.regex}
+	case namefn(ConsumeStartOffset):
+		return []any{cfg.startOffset}
 	case namefn(ConsumeResetOffset):
 		return []any{cfg.resetOffset}
 	case namefn(ConsumeTopics):
@@ -478,6 +480,12 @@ func NewClient(opts ...Opt) (*Client, error) {
 			}
 		}
 	}
+
+	if cfg.setResetOffset && !cfg.setStartOffset {
+		cfg.startOffset = cfg.resetOffset
+	} else if cfg.setStartOffset && !cfg.setResetOffset {
+		cfg.resetOffset = cfg.startOffset
+	} // else they are both set (keep) or both unset (defaults)
 
 	ctx := context.Background()
 

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -147,7 +147,10 @@ type cfg struct {
 	minBytes       int32
 	maxBytes       lazyI32
 	maxPartBytes   lazyI32
+	startOffset    Offset
 	resetOffset    Offset
+	setStartOffset bool
+	setResetOffset bool
 	isolationLevel int8
 	keepControl    bool
 	rack           string
@@ -558,6 +561,7 @@ func defaultCfg() cfg {
 		minBytes:       1,
 		maxBytes:       50 << 20,
 		maxPartBytes:   1 << 20,
+		startOffset:    NewOffset().AtStart(),
 		resetOffset:    NewOffset().AtStart(),
 		isolationLevel: 0,
 
@@ -1369,33 +1373,73 @@ func MaxConcurrentFetches(n int) ConsumerOpt {
 	return consumerOpt{func(cfg *cfg) { cfg.maxConcurrentFetches = n }}
 }
 
-// ConsumeResetOffset sets the offset to start consuming from, or if
-// OffsetOutOfRange is seen while fetching, to restart consuming from. The
-// default is NewOffset().AtStart(), i.e., the earliest offset.
+// ConsumeStartOffset sets the offset to start consuming from when consuming a
+// partition for the first time. If you do not set [ConsumeResetOffset], this
+// is also the offset to reset to if the client sees an OffsetOutOfRange error
+// while consuming a partition. The default is NewOffset().AtStart(), i.e.,
+// start processing a partition from the earliest offset. If using this option,
+// it is strongly recommended to also set ConsumeResetOffset.
 //
-// For direct consumers, this is the offset that partitions begin to consume
-// from. For group consumers, this is the offset that partitions begin to
-// consume from if a partition has no commits. If partitions have commits, the
-// commit offset is used. While fetching, if OffsetOutOfRange is encountered,
-// the partition resets to ConsumeResetOffset. Using [NoResetOffset] stops
-// consuming a partition if the client encounters OffsetOutOfRange. Using
-// [Offset.AtCommitted] prevents consuming a partition in a group if the
-// partition has no prior commits.
+// If you use an exact or relative offsets and the offset ends up out of range,
+// the client chooses the nearest of either the log start offset or the log end
+// offset. For example, using At(3) when the partition starts at 8 results in
+// the partition being consumed from offset 8.
 //
-// If you use an exact offset or relative offsets and the offset ends up out of
-// range, the client chooses the nearest of either the log start offset or the
-// high watermark: using At(3) when the partition starts at 8 results in the
-// partition being consumed from offset 8.
+// For group consuming, you can use [Offset.AtCommitted] to prevent starting
+// consuming a partition in a group if the partition has no prior commits.
 //
-// In short form, the following determines the offset for when a partition is
-// seen for the first time, or reset while fetching:
+// The following determines the offset for when a partition is seen for the
+// first time:
 //
-//	reset at start?                        => log start offset
-//	reset at end?                          => high watermark
-//	reset at exact?                        => this exact offset (3 means offset 3)
-//	reset relative?                        => the above, + / - the relative amount
-//	reset exact or relative out of bounds? => nearest boundary (start or end)
-//	reset after millisec?                  => high watermark, or first offset after millisec if one exists
+//	at start?                         => start at the log start offset
+//	at end?                           => start at the log end offset
+//	at exact?                         => start at the an exact offset (3 means offset 3)
+//	relative?                         => start at the the above, + / - the relative amount
+//	exact/relative are out of bounds? => start at the nearest boundary (start or end)
+//	after millisec?                   => start at first offset after millisec if one exists, else log end offset
+//
+// To match Kafka's auto.offset.reset which is used for both the start offset
+// and the reset offset,
+//
+//	NewOffset().AtStart()     == auto.offset.reset "earliest"
+//	NewOffset().AtEnd()       == auto.offset.reset "latest"
+//	NewOffset().AtCommitted() == auto.offset.reset "none"
+//
+// Be sure to check the documentation for [ConsumeResetOffset], especially if
+// you rely on this option as the reset offset as well.
+func ConsumeStartOffset(offset Offset) ConsumerOpt {
+	return consumerOpt{func(cfg *cfg) { cfg.startOffset, cfg.setStartOffset = offset, true }}
+}
+
+// ConsumeResetOffset sets the offset to reset to if the client ever sees
+// OffsetOutOfRange while fetching. If you do not set [ConsumeStartOffset],
+// this is also the offset to start consuming from when consuming a partition
+// for the first time. The default is NewOffset().AtStart(), i.e., reset to the
+// earliest offset. If using this option, it is strongly recommended to also
+// set ConsumeStartOffset.
+//
+// This option is *only* used if a consumer seeds OffsetOutOfRange on the
+// *first* fetch of a partition. If the consumer has consumed the partition at
+// all and sees the error, it will automatically reset to the first offset
+// after the timestamp of the last successfully consumed offset. If data loss
+// occurred such that even the last successfully consumed offset is lost, the
+// client automatically resets to the new current end offset. If you want to
+// disable offset resetting entirely, you can use [NoResetOffset].
+//
+// If you use an exact or relative offsets and the offset ends up out of range,
+// the client chooses the nearest of either the log start offset or the log end
+// offset. For example, using At(3) when the partition starts at 8 results in
+// the partition being consumed from offset 8.
+//
+// The following determines the offset for when a partition is seen for the
+// first time, or reset while fetching:
+//
+//	at start?                         => reset to the log start offset
+//	at end?                           => reset to the log end offset
+//	at exact?                         => reset to the an exact offset (3 means offset 3)
+//	relative?                         => reset to the the above, + / - the relative amount
+//	exact/relative are out of bounds? => reset to the nearest boundary (start or end)
+//	after millisec?                   => reset to the first offset after millisec if one exists, else the log end offset
 //
 // To match Kafka's auto.offset.reset,
 //
@@ -1403,11 +1447,14 @@ func MaxConcurrentFetches(n int) ConsumerOpt {
 //	NewOffset().AtEnd()       == auto.offset.reset "latest"
 //	NewOffset().AtCommitted() == auto.offset.reset "none"
 //
-// With the above, make sure to use NoResetOffset() if you want to stop
+// With the above, make sure to use [NoResetOffset] if you want to stop
 // consuming when you encounter OffsetOutOfRange. It is highly recommended
-// to read the docs for all Offset methods to see a few other alternatives.
+// to read the docs for all Offset methods.
+//
+// Be sure to check the documentation for [ConsumeStartOffset], especially if
+// you rely on this option as the start offset as well.
 func ConsumeResetOffset(offset Offset) ConsumerOpt {
-	return consumerOpt{func(cfg *cfg) { cfg.resetOffset = offset }}
+	return consumerOpt{func(cfg *cfg) { cfg.resetOffset, cfg.setResetOffset = offset, true }}
 }
 
 // Rack specifies where the client is physically located and changes fetch

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -147,9 +147,9 @@ func (o Offset) Relative(n int64) Offset {
 	return o
 }
 
-// WithEpoch copies 'o' and returns an offset with the given epoch.  to use the
-// given epoch. This epoch is used for truncation detection; the default of -1
-// implies no truncation detection.
+// WithEpoch copies 'o' and returns an offset with the given epoch. This epoch
+// is used for truncation detection; the default of -1 implies no truncation
+// detection.
 func (o Offset) WithEpoch(e int32) Offset {
 	o.afterMilli = false
 	if e < 0 {

--- a/pkg/kgo/consumer_direct.go
+++ b/pkg/kgo/consumer_direct.go
@@ -86,7 +86,7 @@ func (d *directConsumer) findNewAssignments() map[string]map[int32]Offset {
 			}
 			toUseTopic := make(map[int32]Offset, len(partitions.partitions))
 			for partition := range partitions.partitions {
-				toUseTopic[int32(partition)] = d.cfg.resetOffset
+				toUseTopic[int32(partition)] = d.cfg.startOffset
 			}
 			toUse[topic] = toUseTopic
 		}

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -1673,7 +1673,7 @@ start:
 				offset.epoch = rPartition.LeaderEpoch
 			}
 			if rPartition.Offset == -1 {
-				offset = g.cfg.resetOffset
+				offset = g.cfg.startOffset
 			}
 			topicOffsets[rPartition.Partition] = offset
 		}


### PR DESCRIPTION
ConsumeResetOffset has always been confusing when trying to figure out what exactly it does and when. The main point of confusion (for me) has always been trying to reason about where I want to start consuming new partitions vs. where to reset to when a problem is encountered.

Well, we can split the two into dedicated options to resolve the confusion.

This also hopefully cleans up and clarifies which offset is used when. As it turns out, there really is only one place where the reset offset is used, and it's used very rarely (a niche sub-case of when OffsetOutOfRange is encountered). It's likely best to just leave it as NewOffset().AtStart().

I've read through KIP-1106 a few times, and given that the client already tries to reset to the best offset (right after the last succesfully consumed offset, otherwise the end), there is not really a reason to add duration based offset resetting to this client. I've noted that the kip is skipped in the readme.