### PR TITLE
kgo: switch Ping to issue a broker-only metadata request

### DIFF
--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -545,7 +545,7 @@ func (g *groupConsumer) leave(ctx context.Context) {
 		// member ID, there's nothing we can do.
 		memberID := g.memberGen.memberID()
 		if memberID == "" {
-			g.cfg.logger.Log(LogLevelInfo, "tried to leave group but we have no member ID yet, returning early", g.cfg.group)
+			g.cfg.logger.Log(LogLevelInfo, "tried to leave group but we have no member ID yet, returning early", "group", g.cfg.group)
 			return
 		}
 


### PR DESCRIPTION
ApiVersions can succeed even if the broker requires SASL and you forgot it in the client. Metadata forces a full SASL flow.