### PR TITLE
kgo bugfix: ApiVersions replies only with key 18, not all keys

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -69,6 +69,36 @@ jobs:
           KGO_SEEDS: kafka:9092
           KGO_TEST_STABLE_FETCH: true
 
+  integration-test-kafka-38:
+    if: github.repository == 'twmb/franz-go'
+    runs-on: ubuntu-latest
+    name: "integration test kafka 3.8"
+    container: golang:latest
+    services:
+      zookeeper:
+        image: bitnami/zookeeper:latest
+        ports:
+          - 2181:2181
+        env:
+          ALLOW_ANONYMOUS_LOGIN: yes
+      kafka:
+        image: bitnami/kafka:3.8
+        ports:
+          - 9092:9092
+        env:
+          KAFKA_BROKER_ID: 1
+          KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
+          KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+          ALLOW_PLAINTEXT_LISTENER: yes
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test -timeout 5m ./...
+        env:
+          KGO_TEST_RF: 1
+          KGO_SEEDS: kafka:9092
+          KGO_TEST_STABLE_FETCH: true
+
   integration-test-redpanda:
     if: github.repository == 'twmb/franz-go'
     runs-on: ubuntu-latest

--- a/pkg/kgo/client_test.go
+++ b/pkg/kgo/client_test.go
@@ -214,3 +214,17 @@ type intSliceHook []int
 func (*intSliceHook) OnNewClient(*Client) {
 	// ignore
 }
+
+func TestPing(t *testing.T) {
+	t.Parallel()
+
+	cl, _ := newTestClient()
+	defer cl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	err := cl.Ping(ctx)
+	if err != nil {
+		t.Errorf("unable to ping: %v", err)
+	}
+}


### PR DESCRIPTION
This fixes a bug that has existed in this codebase forever, and only now finally can occur.

In Kafka 2.4, Kafka introduced KIP-511, bumping ApiVersion to v3.

I misread the KIP and assumed that the broker would send ALL API keys when the broker did not understand the version of the ApiVersions request we were sending.

In franz-go, if the client detects an UNSUPPORTED_VERSION error,

* Brokers pre 2.4 would outright send nothing; we would downgrade our request to v0 and retry. This worked.

* Brokers post 2.4, I deserialized the response as v0 and assumed I had all keys.

As it turns out, the broker returns only _one_ key, which is the version of ApiVersions that the broker supports. This would allow the client to re-request ApiVersions with the highest version the broker supports.

This was never a problem until Kafka 4, which finally bumped ApiVersions to version 4. The client now sends v4. The client would get UNSUPPORTED_VERSIONS, unmarshal as v0, and only have one key set.

Now, we unmarshal as v0 and then re-request as whatever version the broker says it supports.

This also adds a github action to test against Kafka 3.8, which should prevent regressions as the library moves further and further into the future.

Closes #1009, #1010.