### PR TITLE
sr: Add logger function to schema registry client

### DIFF
--- a/pkg/kgo/logger.go
+++ b/pkg/kgo/logger.go
@@ -124,3 +124,16 @@ func (w *wrappedLogger) Log(level LogLevel, msg string, keyvals ...any) {
 	}
 	w.inner.Log(level, msg, keyvals...)
 }
+
+// LoggerFn returns an anonymous function that can be used in other packages
+// that support their own anonymous logger functions.
+//
+// Notably, this was added so that you can easily use a kgo.Logger in the
+// sister 'sr' and 'kfake' packages. Both clients can be initialized with a
+// 'LogFn' option. This function makes it easy to use the same kgo.Logger
+// across the other packages.
+func LoggerFn(l Logger) func(int8, string, ...any) {
+	return func(lvl int8, msg string, keyvals ...any) {
+		l.Log(LogLevel(lvl), msg, keyvals...)
+	}
+}

--- a/pkg/sr/clientopt.go
+++ b/pkg/sr/clientopt.go
@@ -79,3 +79,32 @@ func DefaultParams(ps ...Param) ClientOpt {
 		cl.defParams = mergeParams(ps...)
 	}}
 }
+
+// LogFn sets the logger function to use.
+func LogFn(logFn func(int8, string, ...any)) ClientOpt {
+	return clientOpt{func(cl *Client) { cl.logFn = logFn }}
+}
+
+// LogLevelFn sets a function to return the log level dynamically.
+// See [LogLevel] for more information.
+func LogLevelFn(fn func() int8) ClientOpt {
+	return clientOpt{func(cl *Client) { cl.logLvlFn = fn }}
+}
+
+// LogLevel sets a static log level to use, overriding the default
+// "info" level.
+//
+// There are five levels:
+//   - None (0)
+//   - Error (1)
+//   - Warn (2)
+//   - Info (3)
+//   - Debug (4)
+//
+// This package defines int8 constants for convenience. The levels
+// (and log function) mirror kgo's Logger and LogLevel definitions,
+// making it easy to use any existing kgo logging functionality you
+// may already be using in this package as well.
+func LogLevel(lvl int8) ClientOpt {
+	return clientOpt{func(cl *Client) { cl.logLvlFn = func() int8 { return lvl } }}
+}

--- a/pkg/sr/logger.go
+++ b/pkg/sr/logger.go
@@ -1,0 +1,16 @@
+package sr
+
+// The log levels that can be used to control the verbosity of the
+// SR client. The levels are ordered to mirror the kgo leveling.
+const (
+	// LogLevelNone corresponds to no logging.
+	LogLevelNone int8 = iota
+	// LogLevelError opts into logging errors.
+	LogLevelError
+	// LogLevelWarn opts into logging warnings and errors.
+	LogLevelWarn
+	// LogLevelInfo opts into informational logging, warnings, and errors.
+	LogLevelInfo
+	// LogLevelDebug opts into all logs.
+	LogLevelDebug
+)


### PR DESCRIPTION
It includes 3 new client options to set the
logger function and the logger level.

It mirrors kgo's Logger and LogLevel definitions,
making it easy to use any existing kgo logging
functionality you may already be using in this
package as well.