### PR TITLE
Use gotils strconv to convert between bytes to string efficiently and safe

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -419,7 +419,7 @@ func validateMaxVersions(top, on *Struct) {
 	}
 }
 
-//go:generate sh -c "go run . | gofumpt | gofumpt -lang 1.19 -extra > ../pkg/kmsg/generated.go"
+//go:generate sh -c "go run . | gofumpt | gofumpt -lang go1.19 -extra > ../pkg/kmsg/generated.go"
 func main() {
 	const dir = "definitions"
 	const enums = "enums"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.8
 require (
 	github.com/klauspost/compress v1.18.0
 	github.com/pierrec/lz4/v4 v4.1.22
+	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 	golang.org/x/crypto v0.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 h1:qIQ0tWF9vxGtkJa24bR+2i53WBCz1nW/Pc47oVYauC4=
+github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=

--- a/pkg/kbin/primitives.go
+++ b/pkg/kbin/primitives.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"math"
 	"math/bits"
-	"reflect"
-	"unsafe"
+
+	gotils_strconv "github.com/savsgio/gotils/strconv"
 )
 
 // This file contains primitive type encoding and decoding.
@@ -663,7 +663,7 @@ func (b *Reader) String() string {
 	return string(b.Span(int(l)))
 }
 
-// UnsafeCompactString returns a Kafka compact string from the reader without
+// œCompactString returns a Kafka compact string from the reader without
 // allocating using the unsafe package. This must be used with care; note the
 // string holds a reference to the original slice.
 func (b *Reader) UnsafeCompactString() string {
@@ -848,9 +848,5 @@ func (b *Reader) Ok() bool {
 
 // UnsafeString returns the slice as a string using unsafe rule (6).
 func UnsafeString(slice []byte) string {
-	var str string
-	strhdr := (*reflect.StringHeader)(unsafe.Pointer(&str))             //nolint:gosec // known way to convert slice to string
-	strhdr.Data = ((*reflect.SliceHeader)(unsafe.Pointer(&slice))).Data //nolint:gosec // known way to convert slice to string
-	strhdr.Len = len(slice)
-	return str
+	return gotils_strconv.B2S(slice)
 }

--- a/pkg/kbin/primitives.go
+++ b/pkg/kbin/primitives.go
@@ -663,7 +663,7 @@ func (b *Reader) String() string {
 	return string(b.Span(int(l)))
 }
 
-// œCompactString returns a Kafka compact string from the reader without
+// UnsafeCompactString returns a Kafka compact string from the reader without
 // allocating using the unsafe package. This must be used with care; note the
 // string holds a reference to the original slice.
 func (b *Reader) UnsafeCompactString() string {

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -3,9 +3,9 @@ package kgo
 import (
 	"context"
 	"errors"
-	"reflect"
 	"time"
-	"unsafe"
+
+	gotils_strconv "github.com/savsgio/gotils/strconv"
 )
 
 // RecordHeader contains extra information that can be sent with Records.
@@ -194,11 +194,7 @@ func (r *Record) AppendFormat(b []byte, layout string) ([]byte, error) {
 // be used if you only ever read record fields. This function can safely be used
 // for producing; the client never modifies a record's key nor value fields.
 func StringRecord(value string) *Record {
-	var slice []byte
-	slicehdr := (*reflect.SliceHeader)(unsafe.Pointer(&slice))             //nolint:gosec // known way to convert string to slice
-	slicehdr.Data = ((*reflect.StringHeader)(unsafe.Pointer(&value))).Data //nolint:gosec // known way to convert string to slice
-	slicehdr.Len = len(value)
-	slicehdr.Cap = len(value)
+	slice := gotils_strconv.S2B(value)
 
 	return &Record{Value: slice}
 }
@@ -215,10 +211,7 @@ func StringRecord(value string) *Record {
 func KeyStringRecord(key, value string) *Record {
 	r := StringRecord(value)
 
-	keyhdr := (*reflect.SliceHeader)(unsafe.Pointer(&r.Key))           //nolint:gosec // known way to convert string to slice
-	keyhdr.Data = ((*reflect.StringHeader)(unsafe.Pointer(&key))).Data //nolint:gosec // known way to convert string to slice
-	keyhdr.Len = len(key)
-	keyhdr.Cap = len(key)
+	r.Key = gotils_strconv.S2B(key)
 
 	return r
 }

--- a/pkg/kmsg/go.mod
+++ b/pkg/kmsg/go.mod
@@ -6,3 +6,5 @@ retract (
 	v1.11.0 // This version erroneously always encoded tagged uuid fields, which failed on any Kafka version that did not support the field
 	v1.10.0 // This version failed to compile; I must have accidentally git-broke my fixed commit before pushing & merging
 )
+
+require github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287

--- a/pkg/kmsg/go.sum
+++ b/pkg/kmsg/go.sum
@@ -1,0 +1,2 @@
+github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 h1:qIQ0tWF9vxGtkJa24bR+2i53WBCz1nW/Pc47oVYauC4=
+github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=

--- a/pkg/kmsg/internal/kbin/primitives.go
+++ b/pkg/kmsg/internal/kbin/primitives.go
@@ -663,7 +663,7 @@ func (b *Reader) String() string {
 	return string(b.Span(int(l)))
 }
 
-// œCompactString returns a Kafka compact string from the reader without
+// UnsafeCompactString returns a Kafka compact string from the reader without
 // allocating using the unsafe package. This must be used with care; note the
 // string holds a reference to the original slice.
 func (b *Reader) UnsafeCompactString() string {

--- a/pkg/kmsg/internal/kbin/primitives.go
+++ b/pkg/kmsg/internal/kbin/primitives.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"math"
 	"math/bits"
-	"reflect"
-	"unsafe"
+
+	gotils_strconv "github.com/savsgio/gotils/strconv"
 )
 
 // This file contains primitive type encoding and decoding.
@@ -86,6 +86,12 @@ func VarintLen(i int32) int {
 // UvarintLen returns how long u would be if it were uvarint encoded.
 func UvarintLen(u uint32) int {
 	return int(uvarintLens[byte(bits.Len32(u))])
+}
+
+// VarlongLen returns how long i would be if it were varlong encoded.
+func VarlongLen(i int64) int {
+	u := uint64(i)<<1 ^ uint64(i>>63)
+	return uvarlongLen(u)
 }
 
 func uvarlongLen(u uint64) int {
@@ -657,7 +663,7 @@ func (b *Reader) String() string {
 	return string(b.Span(int(l)))
 }
 
-// UnsafeCompactString returns a Kafka compact string from the reader without
+// œCompactString returns a Kafka compact string from the reader without
 // allocating using the unsafe package. This must be used with care; note the
 // string holds a reference to the original slice.
 func (b *Reader) UnsafeCompactString() string {
@@ -842,9 +848,5 @@ func (b *Reader) Ok() bool {
 
 // UnsafeString returns the slice as a string using unsafe rule (6).
 func UnsafeString(slice []byte) string {
-	var str string
-	strhdr := (*reflect.StringHeader)(unsafe.Pointer(&str))             //nolint:gosec // known way to convert slice to string
-	strhdr.Data = ((*reflect.SliceHeader)(unsafe.Pointer(&slice))).Data //nolint:gosec // known way to convert slice to string
-	strhdr.Len = len(slice)
-	return str
+	return gotils_strconv.B2S(slice)
 }

--- a/pkg/sr/go.mod
+++ b/pkg/sr/go.mod
@@ -1,4 +1,3 @@
 module github.com/twmb/franz-go/pkg/sr
 
 go 1.23.8
-


### PR DESCRIPTION
Hello

Both `reflect.StringHeader` and `reflect.SliceHeader` are considere deprecated see https://pkg.go.dev/reflect#StringHeader

the new way, since go 1.20 is to use `unsafe` package

https://pkg.go.dev/unsafe#StringData
https://pkg.go.dev/unsafe#SliceData

to be possible be backward compatible with go 1.19 (if needed) or if you want to keep the code updated for future changes, I advice to use the library `github.com/savsgio/gotils`:

https://github.com/savsgio/gotils/tree/master/strconv

as you can see it provides the two ways to convert between slice of bytes and string via build flags.

Another option is to `copy` the same code everywhere. however you may need to keep track on future updates and the purpose of this library is to be transparent.

based on this, I made this pull request and add this external dependency as suggestion. You dont need to use.