### PR TITLE
Add position function for consumer

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -2727,6 +2727,10 @@ func (cl *Client) storeCachedMappedMetadata(meta *kmsg.MetadataResponse, intoMap
 	}
 }
 
+func (cl *Client) Position(topic string, partition int32) (int64, error) {
+	return cl.consumer.position(topic, partition)
+}
+
 func unknownOrCode(exists bool, code int16) error {
 	if !exists {
 		return kerr.UnknownTopicOrPartition

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1752,6 +1752,15 @@ func (c *consumer) startNewSession(tps *topicsPartitions) *consumerSession {
 	return session
 }
 
+func (c *consumer) position(topic string, partition int32) (int64, error) {
+	for usedCursor := range c.usingCursors {
+		if usedCursor.topic == topic && usedCursor.partition == partition {
+			return usedCursor.offset, nil
+		}
+	}
+	return -1, fmt.Errorf("no assignment for topics %s partition %d", topic, partition)
+}
+
 // This function is responsible for issuing ListOffsets or
 // OffsetForLeaderEpoch. These requests's responses  are only handled within
 // the context of a consumer session.


### PR DESCRIPTION
I have a use-case where I want to know when I've reached a certain offset of a partition while consuming. That offset is not always guaranteed to be a committed record though.

As a concrete example I'm calling `cl.ListEndOffsets` to get the log end offset at some timestamp, then later consuming up to that point. So it's possible the LEO for the partition was 100, but the last valid record was at 98 with offset 99 being the commit message. If I just consume normally and track the "last seen" offset (`for lastSeen < leo - 1`), then this is workable assuming that something else gets produced to the partition. However if there is no traffic on that partition I'd spin forever since the consumer will never see offset 99.

What I am doing currently is something like:
```golang
consecutiveEmptyFetches := 0
for {
  tc, cancel := context.WithTimeout(ctx, time.Second)
  fetches := cl.PollFetches(tc)
  cancel()
  if err := fetches.Err(); errors.Is(err, context.DeadlineExceeded) {
    consecutiveEmptyFetches++
    if consecutiveEmptyFetches >= 2 {
      break
    }
  }
  consecutiveEmptyFetches = 0
  // process records
}
```
This just infers that I'm done because it polled a couple of times and got nothing, which isn't exactly a strong guarantee. In the previous implementation of this code using the Java client I did this by leveraging the [position](https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#position(org.apache.kafka.common.TopicPartition)) method on the consumer. I didn't see any equivalent in this library, but it looked like I could just simply expose the underlying cursor value to get the information I needed.

Obviously this PR could use documentation and better error handling, but what do you think about adding a function like this?