### PR TITLE
EventHub Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ This library attempts to provide an intuitive API while interacting with Kafka t
 - **Kafka**: the original Java project
 - **Confluent Platform**
 - **Microsoft Event Hubs**
+  - As of May 16, 2025, Event Hubs supports only Kafka version 3.8. You **must** set the `kgo.MaxVersions(kversion.V3_8_0())` 
+    option; otherwise, you'll encounter the following error:
+    ```
+    [DEBUG] connection opened to broker; addr: XXX.servicebus.windows.net:9093, broker: seed_0
+    [DEBUG] issuing api versions request; broker: seed_0, version: 4
+    [DEBUG] wrote ApiVersions v4; broker: seed_0, bytes_written: 31, write_wait: 45.291µs, time_to_write: 22.107µs, err: <nil>
+    [DEBUG] read ApiVersions v4; broker: seed_0, bytes_read: 0, read_wait: 29.877µs, time_to_read: 62.945813ms, err: read tcp 192.168.0.36:50812->X.X.X.X:9093: read: connection reset by peer
+    [DEBUG] connection initialization failed; addr: XXXX.servicebus.windows.net:9093, broker: seed_0, err: read tcp 192.168.0.36:50812->X.X.X.X:9093: read: connection reset by peer
+
   - Event Hubs does [not support][MSEH] producing with compression; be sure to use `kgo.ProducerBatchCompression(kgo.NoCompression)`.
 - **Amazon MSK**
 


### PR DESCRIPTION
After upgrading to the v1.19.x, I was no longer able to connect to EventHub with the default settings. The problem stems from the fact that MS doesn't support greater than 3.8. The problem appears to be support for the v4 API which was added in v3.9. Commented this out allows v3.9 to work as well:
```
// KAFKA-17011 ede289db93f
now.incmax(18, 4) // 4 api versions
```

The following error occurs when using v3.9 and later:
```
[DEBUG] connection opened to broker; addr: XXX.servicebus.windows.net:9093, broker: seed_0
[DEBUG] issuing api versions request; broker: seed_0, version: 4
[DEBUG] wrote ApiVersions v4; broker: seed_0, bytes_written: 31, write_wait: 44.391µs, time_to_write: 21.115µs, err: <nil>
[DEBUG] read ApiVersions v4; broker: seed_0, bytes_read: 0, read_wait: 25.502µs, time_to_read: 62.984188ms, err: read tcp 192.168.0.36:34240->X.X.X.X:9093: read: connection reset by peer
[DEBUG] connection initialization failed; addr: XXX.servicebus.windows.net:9093, broker: seed_0, err: read tcp 192.168.0.36:34240->X.X.X.X:9093: read: connection reset by peer