### PR TITLE
Fix go generate

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -419,7 +419,7 @@ func validateMaxVersions(top, on *Struct) {
 	}
 }
 
-//go:generate sh -c "go run . | gofumpt | gofumpt -lang 1.19 -extra > ../pkg/kmsg/generated.go"
+//go:generate sh -c "go run . | gofumpt | gofumpt -lang go1.19 -extra > ../pkg/kmsg/generated.go"
 func main() {
 	const dir = "definitions"
 	const enums = "enums"

--- a/pkg/kmsg/internal/kbin/primitives.go
+++ b/pkg/kmsg/internal/kbin/primitives.go
@@ -88,6 +88,12 @@ func UvarintLen(u uint32) int {
 	return int(uvarintLens[byte(bits.Len32(u))])
 }
 
+// VarlongLen returns how long i would be if it were varlong encoded.
+func VarlongLen(i int64) int {
+	u := uint64(i)<<1 ^ uint64(i>>63)
+	return uvarlongLen(u)
+}
+
 func uvarlongLen(u uint64) int {
 	return int(uvarintLens[byte(bits.Len64(u))])
 }

--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -3,10 +3,11 @@ package kprom
 import (
 	"reflect"
 
+	"maps"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"maps"
 )
 
 type cfg struct {
@@ -166,7 +167,7 @@ type HistogramOpts struct {
 //	 		Buckets: prometheus.LinearBuckets(10, 10, 8),
 //	 	},
 //	 	kprom.HistogramOpts{
-//	 		Enable: kprom.ReadeTime,
+//	 		Enable: kprom.ReadTime,
 //	 		// kprom default bucket will be used
 //	 	},
 //	 ),


### PR DESCRIPTION
I note that go generate ./... fails with latest gofumpt

```console
$ go generate ./...
panic: invalid Go version: "1.19"

goroutine 18 [running]:
mvdan.cc/gofumpt/format.File(0xc000012080, 0xc0001920a0, {{0x7ffe3a2a4da4, 0x4}, {0x0, 0x0}, 0x1})
	/home/tiago/work/go/pkg/mod/mvdan.cc/gofumpt@v0.8.0/format/format.go:99 +0x27c
main.processFile({0x63bbc5, 0x10}, {0x0, 0x0}, {0x68a398?, 0xc000186028?}, 0xc0001962b0, 0x1)
	/home/tiago/work/go/pkg/mod/mvdan.cc/gofumpt@v0.8.0/gofmt.go:327 +0x38d
main.gofmtMain.func2(0x0?)
	/home/tiago/work/go/pkg/mod/mvdan.cc/gofumpt@v0.8.0/gofmt.go:508 +0x3a
main.(*sequencer).Add.func2()
	/home/tiago/work/go/pkg/mod/mvdan.cc/gofumpt@v0.8.0/gofmt.go:191 +0x42
created by main.(*sequencer).Add in goroutine 1
	/home/tiago/work/go/pkg/mod/mvdan.cc/gofumpt@v0.8.0/gofmt.go:190 +0x19b
generate/main.go:422: running "sh": exit status 2
```

The fix is easy, and I renegerate everything to keep the project updated.

part of this was done on #1016 and the fix in go doc kprom was new

Enjoy