### PR TITLE
kadm: bump deps, new APIs to support better lag

### DIFF
--- a/pkg/kadm/go.mod
+++ b/pkg/kadm/go.mod
@@ -3,7 +3,7 @@ module github.com/twmb/franz-go/pkg/kadm
 go 1.23.8
 
 require (
-	github.com/twmb/franz-go v1.18.1
+	github.com/twmb/franz-go v1.19.4
 	github.com/twmb/franz-go/pkg/kmsg v1.11.2
 	golang.org/x/crypto v0.38.0
 )

--- a/pkg/kadm/go.sum
+++ b/pkg/kadm/go.sum
@@ -2,8 +2,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
-github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go v1.19.4 h1:0ktflzm5YU7+YYdie8RQWFcU9uDJ03xLefplO1iMwO4=
+github.com/twmb/franz-go v1.19.4/go.mod h1:4kFJ5tmbbl7asgwAGVuyG1ZMx0NNpYk7EqflvWfPCpM=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2 h1:hIw75FpwcAjgeyfIGFqivAvwC5uNIOWRGvQgZhH4mhg=
 github.com/twmb/franz-go/pkg/kmsg v1.11.2/go.mod h1:CFfkkLysDNmukPYhGzuUcDtf46gQSqCZHMW1T4Z+wDE=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=

--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -93,6 +93,27 @@ func (d *DescribedGroup) AssignedPartitions() TopicsSet {
 	return s
 }
 
+// JoinTopics returns the set of topics that all members are interested in
+// consuming.
+//
+// This function is only relevant for groups of time "consumer".
+func (d DescribedGroup) JoinTopics() []string {
+	s := make(map[string]struct{})
+	for _, m := range d.Members {
+		if c, ok := m.Join.AsConsumer(); ok {
+			for _, t := range c.Topics {
+				s[t] = struct{}{}
+			}
+		}
+	}
+	ks := make([]string, 0, len(s))
+	for k := range s {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
 // DescribedGroup contains data from a describe groups response for a single
 // group.
 type DescribedGroup struct {
@@ -130,6 +151,29 @@ func (ds DescribedGroups) AssignedPartitions() TopicsSet {
 		}
 	}
 	return s
+}
+
+// JoinTopics returns the set of topics that all members are interested in
+// consuming. This is the all-group analogue to DescribedGroup.JoinTopics.
+//
+// This function is only relevant for groups of time "consumer".
+func (ds DescribedGroups) JoinTopics() []string {
+	s := make(map[string]struct{})
+	for _, g := range ds {
+		for _, m := range g.Members {
+			if c, ok := m.Join.AsConsumer(); ok {
+				for _, t := range c.Topics {
+					s[t] = struct{}{}
+				}
+			}
+		}
+	}
+	ks := make([]string, 0, len(s))
+	for k := range s {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
 }
 
 // Sorted returns all groups sorted by group name.
@@ -1498,9 +1542,12 @@ func (cl *Client) Lag(ctx context.Context, groups ...string) (DescribedGroupLags
 	}
 
 	// We have to list the start & end offset for all assigned and
-	// committed partitions.
+	// committed partitions, as well as any topics that group members
+	// WANT to consume (maybe they have not yet been committed to and
+	// we are currently eagerly rebalancing).
 	var startOffsets, endOffsets ListedOffsets
 	listPartitions := described.AssignedPartitions()
+	listPartitions.MergeTopics(described.JoinTopics())
 	listPartitions.Merge(fetched.CommittedPartitions())
 	if topics := listPartitions.Topics(); len(topics) > 0 {
 		for _, list := range []struct {
@@ -1565,6 +1612,7 @@ func (cl *Client) Lag(ctx context.Context, groups ...string) (DescribedGroupLags
 //	commits := FetchManyOffsets(ctx, group)
 //	var endOffsets ListedOffsets
 //	listPartitions := described.AssignedPartitions()
+//	listPartitions.MergeTopics(described.JoinTopics())
 //	listPartitions.Merge(commits.CommittedPartitions()
 //	if topics := listPartitions.Topics(); len(topics) > 0 {
 //		endOffsets = ListEndOffsets(ctx, listPartitions.Topics())
@@ -1715,6 +1763,20 @@ func CalculateGroupLagWithStartOffsets(
 					Err:       perr,
 				}
 
+			}
+		}
+
+		// For all members, we prime the lag map with the topics the
+		// member is interested in. It is possible the group is
+		// rebalancing (no partitions assigned!) and that topics have
+		// not been committed to.
+		j, ok := m.Join.AsConsumer()
+		if !ok {
+			continue
+		}
+		for _, t := range j.Topics {
+			if _, ok := l[t]; !ok {
+				l[t] = make(map[int32]GroupMemberLag)
 			}
 		}
 	}

--- a/pkg/kadm/kadm.go
+++ b/pkg/kadm/kadm.go
@@ -500,6 +500,13 @@ func (s TopicsSet) Merge(other TopicsSet) {
 	}
 }
 
+// Merge topics merges topic names into this set.
+func (s TopicsSet) MergeTopics(ts []string) {
+	for _, t := range ts {
+		s.Add(t)
+	}
+}
+
 // IntoList returns this set as a list.
 func (s TopicsSet) IntoList() TopicsList {
 	l := make(TopicsList, 0, len(s))


### PR DESCRIPTION
If a group is actively rebalancing or cooperative but rebalancing for the first time, the group will not have assigned partitions. We can look at what each member WANTS to consume and use that as further input into lag calculations.

This adds a few helper APIs to make further lag calculation easy (JoinTopics alongside AssignedPartitions, and a MergeTopics API on TopicsSet).

When iterating over all members, after we iterate over their assigned partitions, we can iterate over their interested topics and prime the lag map. If the topic is not in the lag map, add it. The existing logic at the end of the function goes over all topics in the lag map and calcuates lag per partition for all missing partitions.