### PR TITLE
Fix misused variable from 1.19.3's pinReq removal

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - durationcheck
     - exhaustive
     - exptostd
+    - fatcontext
     - gocheckcompilerdirectives
     - gochecksumtype
     - gocritic

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -2451,7 +2451,7 @@ func (cl *Client) handleShardedReq(ctx context.Context, req kmsg.Request) ([]Res
 				} else if issue.any {
 					brokerAnys = append(brokerAnys, "any")
 				} else {
-					brokerAnys = append(brokerAnys, fmt.Sprintf("%d", issue.broker))
+					brokerAnys = append(brokerAnys, strconv.Itoa(int(issue.broker)))
 				}
 			}
 			l.Log(LogLevelDebug, "sharded request", "req", kmsg.Key(key).Name(), "destinations", brokerAnys)
@@ -2460,6 +2460,7 @@ func (cl *Client) handleShardedReq(ctx context.Context, req kmsg.Request) ([]Res
 		for i := range issues {
 			myIssue := issues[i]
 			var isPinned bool
+			ctx := ctx // loop local context, in case we override by pinning
 			if isPinned = myIssue.pin != nil; isPinned {
 				ctx = context.WithValue(ctx, ctxPinReq, myIssue.pin)
 			}

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -3227,7 +3227,7 @@ func (*findCoordinatorSharder) shard(_ context.Context, kreq kmsg.Request, lastE
 		sreq.CoordinatorType = req.CoordinatorType
 		sreq.CoordinatorKey = key
 		issues = append(issues, issueShard{
-			req: req,
+			req: sreq,
 			pin: &pinReq{pinMax: true, max: 3},
 			any: true,
 		})

--- a/pkg/kgo/internal/sticky/sticky_test.go
+++ b/pkg/kgo/internal/sticky/sticky_test.go
@@ -1303,6 +1303,7 @@ func TestMultiGenerational(t *testing.T) {
 		//
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			plan := Balance(test.members, test.topics)
 			testStickyResult(t, plan, test.members, test.nsticky, test.balance)
 			testPlanUsage(t, plan, test.topics, nil)

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -127,7 +127,7 @@ func (s *sink) createReq(id int64, epoch int16) (*produceRequest, *kmsg.AddParti
 
 		if s.cl.cfg.disableIdempotency {
 			if cctx := batch.records[0].cancelingCtx(); cctx != nil && req.firstCancelingCtx == nil {
-				req.firstCancelingCtx = cctx
+				req.firstCancelingCtx = cctx //nolint:fatcontext // we are only here if firstCancelingCtx is currently nil
 			}
 		}
 
@@ -339,7 +339,9 @@ func (s *sink) produce(sem <-chan struct{}) bool {
 	ctxFn := func() context.Context {
 		holCtxMu.Lock()
 		defer holCtxMu.Unlock()
-		holCtx = s.anyCtx()
+		if holCtx == nil {
+			holCtx = s.anyCtx() //nolint:fatcontext // not sure why this is flagged
+		}
 		return holCtx
 	}
 	isHolCtxDone := func() bool {

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1693,7 +1693,7 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 			&krecords[i],
 			record,
 		)
-		record.Context = poolsCtx
+		record.Context = poolsCtx   //nolint:fatcontext // not a nested context
 		krecords[i] = kmsg.Record{} // prevent the kmsg.Record from hanging onto anything
 		if kept := o.maybeKeepRecord(fp, record, abortBatch); kept {
 			nkept++

--- a/pkg/kversion/requests.go
+++ b/pkg/kversion/requests.go
@@ -1056,7 +1056,7 @@ func c28() *release {
 	return &release{
 		major: 2,
 		minor: 8,
-		kind:  kindBroker,
+		kind:  kindController,
 		reqs: map[int16]req{
 			1:  {key: 1, vmax: 12}, // fetch
 			3:  {key: 3, vmax: 11}, // metadata


### PR DESCRIPTION
Copying the second commit,

All credit to @douglasbouttell for the excellent find here.

Batched FindCoordinator requests against brokers that do not support
batched requests no longer worked at of 1.19.3. The problem was the
removal of pinReq, and well, a bug in the full removal.

This fixes the problem and adds a test test that fails without the fix.

I checked all linters I know of (opting into all revive, staticcheck,
gocritic, golangci-lint linters) and none of them catch this, for valid
reasons. It's hard to check.

I then went back and forth with Claude to generate some code that would
check it, and surprisingly came up with something. However, since it
generates a _few_ false positives and I don't want to learn enough of
the ast code to fully maintain the linter, I'm going to comment the code
on https://github.com/twmb/franz-go/issues/1034 and this PR and if anybody wants to take it and run with it,
feel free. The one other variable the lint flagged was a false positive.

Closes https://github.com/twmb/franz-go/issues/1034.