### PR TITLE
sr: add new `Client.RegisterSchema` function

### DIFF
--- a/pkg/sr/client_test.go
+++ b/pkg/sr/client_test.go
@@ -188,6 +188,18 @@ func TestSchemaRegistryAPI(t *testing.T) {
 			expected: `[{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}]`,
 		},
 		{
+			name:     "register schema",
+			fn:       func() (any, error) { return c.RegisterSchema(ctx, dummySchema.Subject, dummySchema.Schema, -1, -1) },
+			expected: `1`,
+		},
+		{
+			name: "register schema with ID and version",
+			fn: func() (any, error) {
+				return c.RegisterSchema(ctx, dummySchema.Subject, dummySchema.Schema, dummySchema.ID, dummySchema.Version)
+			},
+			expected: `1`,
+		},
+		{
 			name:     "create schema",
 			fn:       func() (any, error) { return c.CreateSchema(ctx, dummySchema.Subject, dummySchema.Schema) },
 			expected: `{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,


### PR DESCRIPTION
First of all, apologies for submitting a PR with a new feature without starting a discussion about it first.
I thought this feature is simple enough and justified to just submit it for inclusion.

We recently migrated our Kafka cluster from Confluent 6.2.x to 7.8.x. In our setup, we have the ACL authorizer plugin configured in the Schema Registry service for implementing security. Until version 6.2.x, the `sr` package worked like a charm, however in version 7.8.x we hit access denied issues without any code changes.

After deeper investigation, we discovered that the new Schema Registry version does not apply ACL authorization correctly for the `GET /schemas/ids/{id}/versions` endpoint. Therefore, when calling `Client.CreateSchema`, we get 403 errors when the function tries to obtain the subject/version data for the newly created schema after calling the `POST /subjects/{subject}/versions` endpoint.

This does not happen when using a "superuser" with access to everything. Also, after configuring more relaxed ACLs for the "regular user", the call to the `GET /schemas/ids/{id}/versions` endpoint succeeds but returns empty arrays. Therefore I believe the `sr` package is not doing anything wrong. This is 100% a bug in the Confluent Schema Registry implementation of the ACL authorizer.

Because getting Confluent to fix this in the Schema Registry can be tedious and long (we still will try to get them to fix it), I thought that a faster solution would be to decouple these two calls in `Client.CreateSchemaWithIDAndVersion`. For this, I propose to create a new `Client.RegisterSchema` function (~~not 100% convinced on the name but is the best I got after several minutes thinking about it~~) that only calls the `POST /subjects/{subject}/versions` endpoint and is re-used by `Client.CreateSchemaWithIDAndVersion`.

Our use case actually only requires the assigned ID of the schema anyway, so we can skip the call to the `GET /schemas/ids/{id}/versions` for now until Confluent some day fixes this bug.

I hope this feature is well received and hopefully a new version of the `sr` package can be released with it.
Thanks in advance for your consideration and very open to your comments.

~~EDIT: Another candidate for the function name was `Client.RegisterSchema`, but I thought it may be confusing for users to differentiate between that and `Client.CreateSchema`.~~