### PR TITLE
Add buffered fetch/produce bytes to prometheus metrics

### DIFF
--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -12,7 +12,9 @@
 //	#{ns}_produce_bytes_total{node_id="#{node}",topic="#{topic}"}
 //	#{ns}_fetch_bytes_total{node_id="#{node}",topic="#{topic}"}
 //	#{ns}_buffered_produce_records_total
+//	#{ns}_buffered_produce_bytes_total
 //	#{ns}_buffered_fetch_records_total
+//	#{ns}_buffered_fetch_bytes_total
 //
 // The above metrics can be expanded considerably with options in this package,
 // allowing timings, uncompressed and compressed bytes, and different labels.
@@ -98,7 +100,9 @@ type Metrics struct {
 
 	// Buffered
 	bufferedFetchRecords   prometheus.GaugeFunc
+	bufferedFetchBytes     prometheus.GaugeFunc
 	bufferedProduceRecords prometheus.GaugeFunc
+	bufferedProduceBytes   prometheus.GaugeFunc
 
 	// Holds references to all metric collectors
 	allMetricCollectors []prometheus.Collector
@@ -355,6 +359,17 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		func() float64 { return float64(client.BufferedProduceRecords()) },
 	)
 
+	m.bufferedProduceBytes = factory.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			ConstLabels: constLabels,
+			Name:        "buffered_produce_bytes_total",
+			Help:        "Total number of bytes buffered within the client ready to be produced",
+		},
+		func() float64 { return float64(client.BufferedProduceBytes()) },
+	)
+
 	m.bufferedFetchRecords = factory.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace:   namespace,
@@ -364,6 +379,17 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 			Help:        "Total number of records buffered within the client ready to be consumed",
 		},
 		func() float64 { return float64(client.BufferedFetchRecords()) },
+	)
+
+	m.bufferedFetchBytes = factory.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			ConstLabels: constLabels,
+			Name:        "buffered_fetch_bytes_total",
+			Help:        "Total number of bytes buffered within the client ready to be consumed",
+		},
+		func() float64 { return float64(client.BufferedFetchBytes()) },
 	)
 
 	m.allMetricCollectors = append(m.allMetricCollectors,
@@ -389,7 +415,9 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		m.fetchBatchesTotal,
 		m.fetchRecordsTotal,
 		m.bufferedFetchRecords,
+		m.bufferedFetchBytes,
 		m.bufferedProduceRecords,
+		m.bufferedProduceBytes,
 	)
 }
 


### PR DESCRIPTION
I noticed `buffered_fetch_bytes_total` and `buffered_produce_bytes_total` were not exported by the kprom metrics plugin so I've added them in this PR.

The [kvictoria](https://github.com/twmb/franz-go/blob/master/plugin/kvictoria/kvictoria.go#L126-L128) plugin already exports these metrics.  However, I noticed these metrics are not exported by kotel and kgmetrics and I'm not sure whether they should be or not.  

In any case, I think adding these metrics to kprom would be really useful so I decided to start with that.  Thanks!