### PR TITLE
sr: check for nil for basicAuth in Client.OptValues

### DIFF
--- a/pkg/sr/client.go
+++ b/pkg/sr/client.go
@@ -203,7 +203,10 @@ func (cl *Client) OptValues(opt any) []any {
 	case namefn(DialTLSConfig):
 		return []any{cl.dialTLS}
 	case namefn(BasicAuth):
-		return []any{cl.basicAuth.user, cl.basicAuth.pass}
+		if cl.basicAuth != nil {
+			return []any{cl.basicAuth.user, cl.basicAuth.pass}
+		}
+		return []any{}
 	case namefn(BearerToken):
 		return []any{cl.bearerToken}
 	case namefn(PreReq):


### PR DESCRIPTION
This PR fixes a crash in `Client.OptValues` when no basic auth is configured (see linked issue for details).

Summary of changes:
* fixes segfault when no basic auth is configured
* also implement testing of default client values in TestOptValue
* also move testing of OptValues to own TestOptValues test

Fixes #1043