### PR TITLE
Fix issues detected by gopls modernize

### DIFF
--- a/examples/bench/main.go
+++ b/examples/bench/main.go
@@ -14,8 +14,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/twmb/franz-go/plugin/kprom"
 	"github.com/twmb/tlscfg"
+
+	"github.com/twmb/franz-go/plugin/kprom"
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/aws"

--- a/examples/hooks_and_logging/plugin_go-metrics/main.go
+++ b/examples/hooks_and_logging/plugin_go-metrics/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/rcrowley/go-metrics"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kgmetrics"
 )

--- a/examples/hooks_and_logging/plugin_kotel/main.go
+++ b/examples/hooks_and_logging/plugin_kotel/main.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/plugin/kotel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
@@ -23,6 +21,9 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/plugin/kotel"
 )
 
 var (

--- a/examples/produce_with_ctx/main.go
+++ b/examples/produce_with_ctx/main.go
@@ -32,7 +32,7 @@ func main() {
 	wg.Add(count)
 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	//ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	// ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
 	defer cancel()
 	for i := range count {
 		r := &kgo.Record{

--- a/examples/schema_registry/schema_registry.go
+++ b/examples/schema_registry/schema_registry.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hamba/avro/v2"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sr"
 )

--- a/generate/gen.go
+++ b/generate/gen.go
@@ -190,7 +190,7 @@ func (s Struct) WriteAppend(l *LineWriter) {
 	l.Write("if isFlexible {")
 	defer l.Write("}")
 
-	for i := 0; i < len(tags); i++ {
+	for i := range len(tags) {
 		f, exists := tags[i]
 		if !exists {
 			die("saw %d tags, but did not see tag %d; expected monotonically increasing", len(tags), i)
@@ -204,7 +204,7 @@ func (s Struct) WriteAppend(l *LineWriter) {
 
 	if len(tags) > 0 {
 		l.Write("var toEncode []uint32")
-		for i := 0; i < len(tags); i++ {
+		for i := range len(tags) {
 			f := tags[i]
 			canDefault := false
 			if d, ok := f.Type.(Defaulter); ok {
@@ -249,7 +249,7 @@ func (s Struct) WriteAppend(l *LineWriter) {
 		l.Write("dst = kbin.AppendUvarint(dst, 0+uint32(v.UnknownTags.Len()))")
 	}
 
-	for i := 0; i < len(tags); i++ {
+	for i := range len(tags) {
 		l.Write("case %d:", i)
 		f := tags[i]
 
@@ -574,7 +574,7 @@ func (s Struct) WriteDecode(l *LineWriter) {
 	l.Write("default:")
 	l.Write("s.UnknownTags.Set(key, b.Span(int(b.Uvarint())))")
 
-	for i := 0; i < len(tags); i++ {
+	for i := range len(tags) {
 		f, exists := tags[i]
 		if !exists {
 			die("saw %d tags, but did not see tag %d; expected monotonically increasing", len(tags), i)

--- a/pkg/kfake/sasl.go
+++ b/pkg/kfake/sasl.go
@@ -11,8 +11,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/twmb/franz-go/pkg/kmsg"
 	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 // TODO server-error-value in serverFinal

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -1027,10 +1027,7 @@ func (cxn *brokerCxn) doSasl(authenticate bool) error {
 		// every second after, we add between 0.05s or 0.08s to our
 		// backoff. At 12hr, we reauth ~24 to 28min before the
 		// lifetime.
-		usePessimismMillis := maxPessimismMillis
-		if minPessimismMillis > maxPessimismMillis {
-			usePessimismMillis = minPessimismMillis
-		}
+		usePessimismMillis := max(minPessimismMillis, maxPessimismMillis)
 		useLifetimeMillis := lifetimeMillis - int64(usePessimismMillis)
 
 		// Subtracting our min pessimism may result in our connection

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,7 +29,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
-	"slices"
 )
 
 var crc32c = crc32.MakeTable(crc32.Castagnoli) // record crc's use Castagnoli table; for consuming/producing

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
+	"slices"
 )
 
 var crc32c = crc32.MakeTable(crc32.Castagnoli) // record crc's use Castagnoli table; for consuming/producing
@@ -596,7 +597,7 @@ func (cl *Client) Ping(ctx context.Context) error {
 	req.Topics = []kmsg.MetadataRequestTopic{}
 
 	cl.brokersMu.RLock()
-	brokers := append([]*broker(nil), cl.brokers...)
+	brokers := slices.Clone(cl.brokers)
 	cl.brokersMu.RUnlock()
 
 	var lastErr error
@@ -1316,9 +1317,9 @@ func (cl *Client) RequestCachedMetadata(ctx context.Context, req *kmsg.MetadataR
 	}
 	dupp := func(p kmsg.MetadataResponseTopicPartition) kmsg.MetadataResponseTopicPartition {
 		p2 := p
-		p2.Replicas = append([]int32(nil), p2.Replicas...)
-		p2.ISR = append([]int32(nil), p2.ISR...)
-		p2.OfflineReplicas = append([]int32(nil), p2.OfflineReplicas...)
+		p2.Replicas = slices.Clone(p2.Replicas)
+		p2.ISR = slices.Clone(p2.ISR)
+		p2.OfflineReplicas = slices.Clone(p2.OfflineReplicas)
 		p2.UnknownTags = kmsg.Tags{}
 		return p2
 	}
@@ -2780,7 +2781,7 @@ func (l *unknownErrShards) err(err error, topic string, partition any) {
 // partitions is a slice where each element has type of arg1 of l.fn.
 func (l *unknownErrShards) errs(err error, topic string, partitions any) {
 	v := reflect.ValueOf(partitions)
-	for i := 0; i < v.Len(); i++ {
+	for i := range v.Len() {
 		l.err(err, topic, v.Index(i).Interface())
 	}
 }

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -12,6 +12,7 @@ import (
 	"github.com/klauspost/compress/s2"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
+	"slices"
 )
 
 var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, 8<<10)) }}
@@ -182,10 +183,7 @@ out:
 			c.gzPool = sync.Pool{New: func() any { c, _ := gzip.NewWriterLevel(nil, level); return c }}
 		case CodecSnappy: // (no pool needed for snappy)
 		case CodecLz4:
-			level := codec.level
-			if level < 0 {
-				level = 0 // 0 == lz4.Fast
-			}
+			level := max(codec.level, 0)
 			fn := func() any { return lz4.NewWriter(new(bytes.Buffer)) }
 			w := lz4.NewWriter(new(bytes.Buffer))
 			if err := w.Apply(lz4.CompressionLevelOption(lz4.CompressionLevel(level))); err == nil {
@@ -374,7 +372,7 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		// reference to the slice. Thus, we can return the original
 		// slice from the user-provided pool: it is only recycled
 		// at the end when the user says they are done.
-		rfn = func() []byte { return append([]byte(nil), out.Bytes()...) }
+		rfn = func() []byte { return slices.Clone(out.Bytes()) }
 	}
 
 	switch codecType {
@@ -399,7 +397,7 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		if userPooled {
 			return decoded, nil
 		}
-		return append([]byte(nil), decoded...), nil
+		return slices.Clone(decoded), nil
 	case CodecLz4:
 		unlz4 := d.unlz4Pool.Get().(*lz4.Reader)
 		defer d.unlz4Pool.Put(unlz4)
@@ -418,7 +416,7 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		if userPooled {
 			return decoded, nil
 		}
-		return append([]byte(nil), decoded...), nil
+		return slices.Clone(decoded), nil
 	default:
 		return nil, errors.New("unknown compression codec")
 	}

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -7,12 +7,12 @@ import (
 	"errors"
 	"io"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/klauspost/compress/s2"
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
-	"slices"
 )
 
 var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, 8<<10)) }}

--- a/pkg/kgo/compression_test.go
+++ b/pkg/kgo/compression_test.go
@@ -100,7 +100,7 @@ func TestCompressDecompress(t *testing.T) {
 					}
 					t.Errorf("unexpected nil compressor from codecs %v", codecs)
 				}
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					wg.Add(1)
 					go func() {
 						w := byteBuffers.Get().(*bytes.Buffer)

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"slices"
 )
 
 // Offset is a message offset in a partition.

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"slices"
 )
 
 // Offset is a message offset in a partition.
@@ -33,9 +34,9 @@ const atCommitted = -999
 // MarshalJSON implements json.Marshaler.
 func (o Offset) MarshalJSON() ([]byte, error) {
 	if o.relative == 0 {
-		return []byte(fmt.Sprintf(`{"At":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.at, o.epoch, o.currentEpoch)), nil
+		return fmt.Appendf(nil, `{"At":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.at, o.epoch, o.currentEpoch), nil
 	}
-	return []byte(fmt.Sprintf(`{"At":%d,"Relative":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.at, o.relative, o.epoch, o.currentEpoch)), nil
+	return fmt.Appendf(nil, `{"At":%d,"Relative":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.at, o.relative, o.epoch, o.currentEpoch), nil
 }
 
 // String returns the offset as a string; the purpose of this is for logs.
@@ -1318,9 +1319,9 @@ func (o offsetLoad) MarshalJSON() ([]byte, error) {
 		return o.Offset.MarshalJSON()
 	}
 	if o.relative == 0 {
-		return []byte(fmt.Sprintf(`{"Replica":%d,"At":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.replica, o.at, o.epoch, o.currentEpoch)), nil
+		return fmt.Appendf(nil, `{"Replica":%d,"At":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.replica, o.at, o.epoch, o.currentEpoch), nil
 	}
-	return []byte(fmt.Sprintf(`{"Replica":%d,"At":%d,"Relative":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.replica, o.at, o.relative, o.epoch, o.currentEpoch)), nil
+	return fmt.Appendf(nil, `{"Replica":%d,"At":%d,"Relative":%d,"Epoch":%d,"CurrentEpoch":%d}`, o.replica, o.at, o.relative, o.epoch, o.currentEpoch), nil
 }
 
 func (o offsetLoadMap) errToLoaded(err error) []loadedOffset {
@@ -1569,7 +1570,7 @@ func (s *consumerSession) manageFetchConcurrency() {
 			var found bool
 			for i, want := range wantFetch {
 				if want == cancel {
-					wantFetch = append(wantFetch[:i], wantFetch[i+1:]...)
+					wantFetch = slices.Delete(wantFetch, i, i+1)
 					found = true
 					break
 				}
@@ -2380,12 +2381,12 @@ func (o offsetLoadMap) buildListReq(isolationLevel int8) (r1, r2 *kmsg.ListOffse
 	if createEnd {
 		r2 = kmsg.NewPtrListOffsetsRequest()
 		*r2 = *r1
-		r2.Topics = append([]kmsg.ListOffsetsRequestTopic(nil), r1.Topics...)
+		r2.Topics = slices.Clone(r1.Topics)
 		for i := range r1.Topics {
 			l := &r2.Topics[i]
 			r := &r1.Topics[i]
 			*l = *r
-			l.Partitions = append([]kmsg.ListOffsetsRequestTopicPartition(nil), r.Partitions...)
+			l.Partitions = slices.Clone(r.Partitions)
 			for i := range l.Partitions {
 				l.Partitions[i].Timestamp = -1
 			}

--- a/pkg/kgo/consumer_direct.go
+++ b/pkg/kgo/consumer_direct.go
@@ -1,5 +1,7 @@
 package kgo
 
+import "maps"
+
 type directConsumer struct {
 	cfg    *cfg
 	tps    *topicsPartitions           // data for topics that the user assigned
@@ -31,9 +33,7 @@ func (c *consumer) initDirect() {
 			d.m.add(topic, partition)
 		}
 		p := make(map[int32]Offset, len(partitions))
-		for partition, offset := range partitions {
-			p[partition] = offset
-		}
+		maps.Copy(p, partitions)
 		d.ps[topic] = p
 	}
 	for topic := range d.cfg.topics {

--- a/pkg/kgo/consumer_direct_test.go
+++ b/pkg/kgo/consumer_direct_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"sync"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"slices"
 )
 
 // Allow adding a topic to consume after the client is initialized with nothing

--- a/pkg/kgo/consumer_direct_test.go
+++ b/pkg/kgo/consumer_direct_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"slices"
 )
 
 // Allow adding a topic to consume after the client is initialized with nothing
@@ -72,13 +73,11 @@ func TestConsumeTopicRetrieval_Many(t *testing.T) {
 	if len(topics) != 0 {
 		t.Fatalf("expected no topics, got %v", topics)
 	}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		cl.AddConsumeTopics(fmt.Sprintf("%s_%d", topicName, i))
 	}
 	topics = cl.GetConsumeTopics()
-	sort.Slice(topics, func(i, j int) bool {
-		return topics[i] < topics[j]
-	})
+	slices.Sort(topics)
 	if len(topics) != 100 || topics[0] != fmt.Sprintf("%s_%d", topicName, 0) {
 		t.Fatalf("expected to see %v, got %v", topicName, topics)
 	}
@@ -355,7 +354,7 @@ func TestPauseIssue489(t *testing.T) {
 		{"fetches", func(ctx context.Context) Fetches { return cl.PollFetches(ctx) }},
 		{"records", func(ctx context.Context) Fetches { return cl.PollRecords(ctx, 1000) }},
 	} {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			var sawZero, sawOne, sawTwo bool
 			for (!sawZero || !sawOne || !sawTwo) && !closed(ctx.Done()) {
@@ -434,7 +433,7 @@ func TestPauseIssueOct2023(t *testing.T) {
 		{"fetches", func(ctx context.Context) Fetches { return cl.PollFetches(ctx) }},
 		{"records", func(ctx context.Context) Fetches { return cl.PollRecords(ctx, 1000) }},
 	} {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			var sawt1, sawt2, sawt3 bool
 			for (!sawt1 || !sawt2 || !sawt3) && !closed(ctx.Done()) {
@@ -644,7 +643,7 @@ func TestIssue865(t *testing.T) {
 	)
 
 	var wg sync.WaitGroup
-	for i := 0; i < nrecs; i++ {
+	for i := range nrecs {
 		r1 := StringRecord(strconv.Itoa(i))
 		r1.Topic = t1
 		wg.Add(1)
@@ -772,7 +771,7 @@ func TestPooling(t *testing.T) {
 	const nrecs = 10
 
 	var wg sync.WaitGroup
-	for i := 0; i < nrecs; i++ {
+	for range nrecs {
 		wg.Add(1)
 		cl.Produce(context.Background(), StringRecord("foobarfoobarfoobarfoobar"), func(_ *Record, err error) {
 			defer wg.Done()
@@ -822,7 +821,7 @@ func TestGroupSimple(t *testing.T) {
 	)
 	defer cl.Close()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := cl.ProduceSync(context.Background(), StringRecord("foo")).FirstErr(); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"maps"
 )
 
 type groupConsumer struct {

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"maps"
 )
 
 type groupConsumer struct {
@@ -359,7 +360,7 @@ func (c *consumer) initGroup() {
 			if user != nil {
 				dup := make(map[string][]int32)
 				for k, vs := range m {
-					dup[k] = append([]int32(nil), vs...)
+					dup[k] = slices.Clone(vs)
 				}
 				user(ctx, cl, dup)
 			}
@@ -1503,14 +1504,14 @@ func (g *groupConsumer) joinGroupProtocols() []kmsg.JoinGroupRequestProtocol {
 	}
 	lastDup := make(map[string][]int32, len(g.lastAssigned))
 	for t, ps := range g.lastAssigned {
-		lastDup[t] = append([]int32(nil), ps...) // deep copy to allow modifications
+		lastDup[t] = slices.Clone(ps) // deep copy to allow modifications
 	}
 
 	g.mu.Unlock()
 
 	sort.Strings(topics) // we guarantee to JoinGroupMetadata that the input strings are sorted
 	for _, partitions := range lastDup {
-		sort.Slice(partitions, func(i, j int) bool { return partitions[i] < partitions[j] }) // same for partitions
+		slices.Sort(partitions) // same for partitions
 	}
 
 	gen := g.memberGen.generation()
@@ -2832,9 +2833,7 @@ func (g *groupConsumer) commit(
 			}
 			dupPs := make(map[int32]EpochOffset, len(ps))
 			dup[t] = dupPs
-			for p, eo := range ps {
-				dupPs[p] = eo
-			}
+			maps.Copy(dupPs, ps)
 		}
 		uncommitted = dup
 	}

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -3,13 +3,13 @@ package kgo
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo/internal/sticky"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"slices"
 )
 
 // GroupBalancer balances topics and partitions among group members.

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo/internal/sticky"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"slices"
 )
 
 // GroupBalancer balances topics and partitions among group members.
@@ -295,7 +296,7 @@ func (p *BalancePlan) IntoSyncAssignment() []kmsg.SyncGroupRequestGroupAssignmen
 	for member, assignment := range p.plan {
 		var kassignment kmsg.ConsumerMemberAssignment
 		for topic, partitions := range assignment {
-			sort.Slice(partitions, func(i, j int) bool { return partitions[i] < partitions[j] })
+			slices.Sort(partitions)
 			assnTopic := kmsg.NewConsumerMemberAssignmentTopic()
 			assnTopic.Topic = topic
 			assnTopic.Partitions = partitions
@@ -432,7 +433,7 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 			interests.Reset()
 			fmt.Fprintf(interests, "interested topics: %v, previously owned: ", meta.Topics)
 			for _, owned := range meta.OwnedPartitions {
-				sort.Slice(owned.Partitions, func(i, j int) bool { return owned.Partitions[i] < owned.Partitions[j] })
+				slices.Sort(owned.Partitions)
 				fmt.Fprintf(interests, "%s%v, ", owned.Topic, owned.Partitions)
 			}
 			strInterests := interests.String()

--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -50,7 +50,7 @@ func TestGroupETL(t *testing.T) {
 				errs <- fmt.Errorf("unable to flush: %v", err)
 			}
 		}()
-		for i := 0; i < testRecordLimit; i++ {
+		for i := range testRecordLimit {
 			myKey := []byte(strconv.Itoa(i))
 			cl.Produce(
 				context.Background(),

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -528,7 +528,7 @@ func testChainETL(
 	// CONSUMER START //
 	////////////////////
 
-	for i := 0; i < 3; i++ { // three consumers start with standard poll&commit behavior
+	for range 3 { // three consumers start with standard poll&commit behavior
 		consumers1.goRun(transactional, -1)
 		consumers2.goRun(transactional, -1)
 		consumers3.goRun(transactional, -1)
@@ -539,7 +539,7 @@ func testChainETL(
 	consumers2.goRun(transactional, 2) // same
 
 	time.Sleep(5 * time.Second)
-	for i := 0; i < 3; i++ { // trigger rebalance after 5s with more consumers
+	for range 3 { // trigger rebalance after 5s with more consumers
 		consumers1.goRun(transactional, -1)
 		consumers2.goRun(transactional, -1)
 		consumers3.goRun(transactional, -1)
@@ -585,7 +585,7 @@ out:
 		}
 
 		sort.Ints(allKeys)
-		for i := 0; i < testRecordLimit; i++ {
+		for i := range testRecordLimit {
 			if allKeys[i] != i {
 				t.Errorf("consumers %d: got key %d != exp %d, first 100: %v", level, allKeys[i], i, allKeys[:100])
 			}

--- a/pkg/kgo/internal/sticky/sticky.go
+++ b/pkg/kgo/internal/sticky/sticky.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"slices"
 )
 
 // Sticky partitioning has two versions, the latter from KIP-341 preventing a
@@ -452,11 +453,8 @@ func (b *balancer) assignUnassignedAndInitGraph() {
 			}
 			memberTopics := b.members[memberNum].Topics
 			var memberStillWantsTopic bool
-			for _, memberTopic := range memberTopics {
-				if memberTopic == b.topicInfos[topicNum].topic {
-					memberStillWantsTopic = true
-					break
-				}
+			if slices.Contains(memberTopics, b.topicInfos[topicNum].topic) {
+				memberStillWantsTopic = true
 			}
 			if !memberStillWantsTopic {
 				partNums.remove(partNum)

--- a/pkg/kgo/internal/sticky/sticky.go
+++ b/pkg/kgo/internal/sticky/sticky.go
@@ -7,10 +7,10 @@ package sticky
 
 import (
 	"math"
+	"slices"
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"slices"
 )
 
 // Sticky partitioning has two versions, the latter from KIP-341 preventing a

--- a/pkg/kgo/internal/sticky/sticky_test.go
+++ b/pkg/kgo/internal/sticky/sticky_test.go
@@ -1660,7 +1660,7 @@ func makeLargeBalance(withImbalance bool) generatedInput {
 	var allTopics []string
 	topics := make(map[string]int32)
 	var totalPartitions int
-	for i := 0; i < topicNum; i++ {
+	for i := range topicNum {
 		n := rng.Intn(partitionNum * 5 / 2)
 		totalPartitions += n
 		topic := fmt.Sprintf("topic%d", i)
@@ -1669,7 +1669,7 @@ func makeLargeBalance(withImbalance bool) generatedInput {
 	}
 
 	var members []GroupMember
-	for i := 0; i < memberNum; i++ {
+	for i := range memberNum {
 		members = append(members, GroupMember{
 			ID:     fmt.Sprintf("consumer%d", i),
 			Topics: allTopics,
@@ -1694,7 +1694,7 @@ func makeLargeBalanceWithExisting(withImbalance bool) generatedInput {
 
 	oldMembers := input.members
 	input.members = input.members[:0]
-	for i := 0; i < topicNum; i++ {
+	for i := range topicNum {
 		consumer := fmt.Sprintf("consumer%d", i)
 		input.members = append(input.members, GroupMember{
 			ID:       consumer,
@@ -1752,14 +1752,14 @@ func makeJavaPlan(topicCount, partitionCount, consumerCount int, imbalanced bool
 	p := generatedInput{topics: make(map[string]int32)}
 	var allTopics []string
 
-	for i := 0; i < topicCount; i++ {
+	for i := range topicCount {
 		topic := fmt.Sprintf("t%d", i)
 		allTopics = append(allTopics, topic)
 		p.topics[topic] = int32(partitionCount)
 		p.totalPartitions += partitionCount
 	}
 
-	for i := 0; i < consumerCount; i++ {
+	for i := range consumerCount {
 		p.members = append(p.members, GroupMember{
 			ID:     fmt.Sprintf("c%d", i),
 			Topics: allTopics,

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
-	"slices"
 )
 
 type metawait struct {

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"slices"
 )
 
 type metawait struct {
@@ -252,10 +253,7 @@ loop:
 			// still fail we will fall into the slower update below
 			// which waits (default) 5s between tries.
 			if now && err == nil && nowTries < 8 {
-				wait := 250 * time.Millisecond
-				if cl.cfg.metadataMinAge < wait {
-					wait = cl.cfg.metadataMinAge
-				}
+				wait := min(cl.cfg.metadataMinAge, 250*time.Millisecond)
 				cl.cfg.logger.Log(LogLevelDebug, "immediate metadata update had inner errors, re-updating",
 					"errors", retryWhy.reason(""),
 					"update_after", wait,
@@ -1022,7 +1020,7 @@ func (m multiUpdateWhy) reason(reason string) string {
 				for p := range ps {
 					psSorted = append(psSorted, p)
 				}
-				sort.Slice(psSorted, func(i, j int) bool { return psSorted[i] < psSorted[j] })
+				slices.Sort(psSorted)
 				topicStrings = append(topicStrings, fmt.Sprintf("%s%v", t, psSorted))
 			}
 		}

--- a/pkg/kgo/metrics_714.go
+++ b/pkg/kgo/metrics_714.go
@@ -112,10 +112,7 @@ func (cl *Client) pushMetrics() {
 
 	push:
 		for i := 0; !terminating; i++ {
-			wait := time.Duration(gresp.PushIntervalMillis) * time.Millisecond
-			if wait < time.Second {
-				wait = time.Second
-			}
+			wait := max(time.Duration(gresp.PushIntervalMillis)*time.Millisecond, time.Second)
 			if i == 0 { // for the first request, jitter 0.5 <= wait <= 1.5
 				cl.rng(func(r *rand.Rand) {
 					wait = time.Duration(float64(wait) * (0.5 + r.Float64()))

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -42,7 +42,7 @@ func TestClient_Produce(t *testing.T) {
 	// Start N workers that will concurrently write to the same partition.
 	var recsWritten atomic.Int64
 	var fatal atomic.Bool
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		workers.Add(1)
 
 		go func() {
@@ -209,7 +209,7 @@ func TestIssue831(t *testing.T) {
 	defer cl.Close()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 500; i++ {
+	for range 500 {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -108,7 +108,7 @@ func (s *sink) createReq(id int64, epoch int16) (*produceRequest, *kmsg.AddParti
 	defer s.recBufsMu.Unlock()
 
 	recBufsIdx := s.recBufsStart
-	for i := 0; i < len(s.recBufs); i++ {
+	for range s.recBufs {
 		recBuf := s.recBufs[recBufsIdx]
 		recBufsIdx = (recBufsIdx + 1) % len(s.recBufs)
 

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -577,10 +577,7 @@ func (s *source) takeNBuffered(paused pausedTopics, n int) (Fetch, int, bool) {
 			rt.Partitions = append(rt.Partitions, *p)
 			rp := &rt.Partitions[len(rt.Partitions)-1]
 
-			take := n
-			if take > len(p.Records) {
-				take = len(p.Records)
-			}
+			take := min(n, len(p.Records))
 
 			rp.Records = p.Records[:take:take]
 			p.Records = p.Records[take:]
@@ -662,7 +659,7 @@ func (s *source) createReq() *fetchRequest {
 	defer s.cursorsMu.Unlock()
 
 	cursorIdx := s.cursorsStart
-	for i := 0; i < len(s.cursors); i++ {
+	for range s.cursors {
 		c := s.cursors[cursorIdx]
 		cursorIdx = (cursorIdx + 1) % len(s.cursors)
 		if !c.usable() || paused.has(c.topic, c.partition) {
@@ -849,7 +846,7 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 	}
 
 	var didBackoff bool
-	backoff := func(why interface{}) {
+	backoff := func(why any) {
 		// We preemptively allow more fetches (since we are not buffering)
 		// and reset our session because of the error (who knows if kafka
 		// processed the request but the client failed to receive it).
@@ -1561,7 +1558,7 @@ func (a aborter) trackAbortedPID(producerID int64) {
 // readRawRecordsInto reads records from in and returns them, returning early
 // if there were partial records.
 func readRawRecordsInto(rs []kmsg.Record, in []byte) []kmsg.Record {
-	for i := 0; i < len(rs); i++ {
+	for i := range rs {
 		length, used := kbin.Varint(in)
 		total := used + int(length)
 		if used == 0 || length < 0 || len(in) < total {
@@ -2214,7 +2211,7 @@ func (f *fetchRequest) adjustPreferringLag() {
 	}
 	pall := make(map[string][]int32, len(f.porder))
 	for t, ps := range f.porder {
-		pall[t] = append([]int32(nil), ps...)
+		pall[t] = slices.Clone(ps)
 	}
 
 	lag := make(map[string]map[int32]int64, len(f.torder))
@@ -2222,10 +2219,7 @@ func (f *fetchRequest) adjustPreferringLag() {
 		plag := make(map[int32]int64, len(ps))
 		lag[t] = plag
 		for p, c := range ps {
-			hwm := c.hwm
-			if c.hwm < 0 {
-				hwm = 0
-			}
+			hwm := max(c.hwm, 0)
 			lag := hwm - c.offset
 			if c.offset <= 0 {
 				lag = hwm
@@ -2251,7 +2245,7 @@ func (f *fetchRequest) adjustPreferringLag() {
 		for i := 0; i < len(torder); i++ {
 			t := torder[i]
 			if _, exists := tall[t]; !exists {
-				torder = append(torder[:i], torder[i+1:]...) // user gave topic we were not fetching
+				torder = slices.Delete(torder, i, i+1) // user gave topic we were not fetching
 				i--
 			}
 			delete(tall, t)
@@ -2282,7 +2276,7 @@ func (f *fetchRequest) adjustPreferringLag() {
 		for i := 0; i < len(order); i++ {
 			p := order[i]
 			if _, exists := pused[p]; !exists {
-				order = append(order[:i], order[i+1:]...)
+				order = slices.Delete(order, i, i+1)
 				i--
 			}
 			delete(pused, p)

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -3,6 +3,7 @@ package kgo
 import (
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"maps"
 )
 
 /////////////

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"maps"
 )
 
 /////////////
@@ -19,9 +20,7 @@ import (
 
 func dupmsi32(m map[string]int32) map[string]int32 {
 	d := make(map[string]int32, len(m))
-	for t, ps := range m {
-		d[t] = ps
-	}
+	maps.Copy(d, m)
 	return d
 }
 
@@ -98,7 +97,7 @@ func (m mtps) String() string {
 	sort.Strings(ts)
 	for _, t := range ts {
 		ps = append(ps[:0], m[t]...)
-		sort.Slice(ps, func(i, j int) bool { return ps[i] < ps[j] })
+		slices.Sort(ps)
 		topicsWritten++
 		fmt.Fprintf(&sb, "%s%v", t, ps)
 		if topicsWritten < len(m) {
@@ -327,9 +326,7 @@ func (t *topicsPartitions) storeTopics(topics []string)      { t.v.Store(t.ensur
 func (t *topicsPartitions) clone() topicsPartitionsData {
 	current := t.load()
 	clone := make(map[string]*topicPartitions, len(current))
-	for k, v := range current {
-		clone[k] = v
-	}
+	maps.Copy(clone, current)
 	return clone
 }
 
@@ -804,8 +801,8 @@ func (k *kip951move) doMove(cl *Client) {
 			}
 			dup := *l.load()
 			r := &dup
-			r.writablePartitions = append([]*topicPartition{}, r.writablePartitions...)
-			r.partitions = append([]*topicPartition{}, r.partitions...)
+			r.writablePartitions = slices.Clone(r.writablePartitions)
+			r.partitions = slices.Clone(r.partitions)
 			lr = oldNew{l, r}
 			topics[topic] = lr
 		}

--- a/pkg/kgo/txn_test.go
+++ b/pkg/kgo/txn_test.go
@@ -57,7 +57,7 @@ func TestTxnEtl(t *testing.T) {
 			}
 		}()
 		var safeUnsafe bool
-		for i := 0; i < testRecordLimit; i++ {
+		for i := range testRecordLimit {
 			// We start with a transaction, and every 10k records
 			// we commit and begin a new one.
 			if i > 0 && i%10000 == 0 {

--- a/pkg/sr/client_test.go
+++ b/pkg/sr/client_test.go
@@ -112,7 +112,6 @@ func TestSchemaRegistryAPI(t *testing.T) {
 				return
 			}
 			_, err = w.Write(b)
-
 			if err != nil {
 				http.Error(w, fmt.Sprintf("unable to write response: %s", err), http.StatusInternalServerError)
 				return

--- a/plugin/klogr/klogr.go
+++ b/plugin/klogr/klogr.go
@@ -3,6 +3,7 @@ package klogr
 
 import (
 	"github.com/go-logr/logr"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 

--- a/plugin/klogr/klogr_test.go
+++ b/plugin/klogr/klogr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr/funcr"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 

--- a/plugin/klogrus/klogrus.go
+++ b/plugin/klogrus/klogrus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 

--- a/plugin/kotel/carrier_test.go
+++ b/plugin/kotel/carrier_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 

--- a/plugin/kotel/carrier_test.go
+++ b/plugin/kotel/carrier_test.go
@@ -74,10 +74,11 @@ func TestRecordCarrier_Keys(t *testing.T) {
 		},
 		{
 			name: "Multiple",
-			record: &kgo.Record{Headers: []kgo.RecordHeader{
-				{Key: "key1", Value: []byte("value1")},
-				{Key: "key2", Value: []byte("value2")},
-			},
+			record: &kgo.Record{
+				Headers: []kgo.RecordHeader{
+					{Key: "key1", Value: []byte("value1")},
+					{Key: "key2", Value: []byte("value2")},
+				},
 			},
 			want: []string{"key1", "key2"},
 		},

--- a/plugin/kotel/meter.go
+++ b/plugin/kotel/meter.go
@@ -8,11 +8,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
+
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 var ( // interface checks to ensure we implement the hooks properly

--- a/plugin/kotel/meter.go
+++ b/plugin/kotel/meter.go
@@ -65,7 +65,6 @@ func WithMergedConnectsMeter() MeterOpt {
 	return meterOptFunc(func(m *Meter) {
 		m.mergeConnectsMeter = true
 	})
-
 }
 
 func (o meterOptFunc) apply(m *Meter) {

--- a/plugin/kotel/meter_test.go
+++ b/plugin/kotel/meter_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -17,6 +16,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 func TestWithMeter(t *testing.T) {

--- a/plugin/kotel/meter_test.go
+++ b/plugin/kotel/meter_test.go
@@ -209,5 +209,4 @@ func TestHook_OnBrokerConnect(t *testing.T) {
 			metricdatatest.IgnoreTimestamp(),
 		)
 	})
-
 }

--- a/plugin/kotel/tracer.go
+++ b/plugin/kotel/tracer.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"unicode/utf8"
 
-	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 var ( // interface checks to ensure we implement the hooks properly.

--- a/plugin/kphuslog/kphuslog.go
+++ b/plugin/kphuslog/kphuslog.go
@@ -11,6 +11,7 @@ package kphuslog
 
 import (
 	"github.com/phuslu/log"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 

--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -1,9 +1,8 @@
 package kprom
 
 import (
-	"reflect"
-
 	"maps"
+	"reflect"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"

--- a/plugin/kvictoria/kvictoria.go
+++ b/plugin/kvictoria/kvictoria.go
@@ -73,6 +73,7 @@ import (
 	"time"
 
 	vm "github.com/VictoriaMetrics/metrics"
+
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 )

--- a/plugin/kzerolog/kzerolog.go
+++ b/plugin/kzerolog/kzerolog.go
@@ -11,6 +11,7 @@ package kzerolog
 
 import (
 	"github.com/rs/zerolog"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 


### PR DESCRIPTION
this pull request is just run

```console
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
```

and format the code to ensure that everything is readable and the imports are sorted

original list

```console
$ go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/internal/sticky/sticky.go:455:4: Loop can be simplified using slices.Contains
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/client.go:599:13: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/client.go:1319:17: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/client.go:1320:12: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/client.go:1321:24: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/compression.go:377:32: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/compression.go:402:10: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/compression.go:421:10: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:2383:15: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:2388:19: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_group.go:362:15: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_group.go:1506:16: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:2217:13: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/topics_and_partitions.go:807:27: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/topics_and_partitions.go:808:19: Replace append with slices.Clone
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:852:22: interface{} can be replaced by any
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:36:10: Replace []byte(fmt.Sprintf...) with fmt.Appendf
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:38:9: Replace []byte(fmt.Sprintf...) with fmt.Appendf
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:1321:10: Replace []byte(fmt.Sprintf...) with fmt.Appendf
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:1323:9: Replace []byte(fmt.Sprintf...) with fmt.Appendf
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct.go:35:4: Replace m[k]=v loop with maps.Copy
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_group.go:2836:5: Replace m[k]=v loop with maps.Copy
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/topics_and_partitions.go:23:3: Replace m[k]=v loop with maps.Copy
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/topics_and_partitions.go:331:3: Replace m[k]=v loop with maps.Copy
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/broker.go:1031:6: if statement can be modernized using max
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/compression.go:186:7: if statement can be modernized using max
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/metadata.go:256:8: if statement can be modernized using min
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/metrics_714.go:116:7: if statement can be modernized using max
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:581:7: if statement can be modernized using min
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:2226:7: if statement can be modernized using max
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/client.go:2783:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/sink.go:111:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:665:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:1564:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer.go:1572:18: Replace append with slices.Delete
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:2254:14: Replace append with slices.Delete
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/source.go:2285:13: Replace append with slices.Delete
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_group.go:1513:3: sort.Slice can be modernized using slices.Sort
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/group_balancer.go:298:4: sort.Slice can be modernized using slices.Sort
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/group_balancer.go:435:5: sort.Slice can be modernized using slices.Sort
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/metadata.go:1025:5: sort.Slice can be modernized using slices.Sort
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/topics_and_partitions.go:101:3: sort.Slice can be modernized using slices.Sort
/home/tiago/work/go/src/github.com/peczenyj/franz-go/generate/gen.go:193:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/generate/gen.go:207:7: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/generate/gen.go:252:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/generate/gen.go:577:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/compression_test.go:103:9: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:75:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:358:7: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:437:7: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:647:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:775:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:825:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/group_test.go:53:7: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/helpers_test.go:531:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/helpers_test.go:542:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/helpers_test.go:588:7: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/produce_request_test.go:45:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/produce_request_test.go:212:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/txn_test.go:60:7: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/consumer_direct_test.go:79:2: sort.Slice can be modernized using slices.Sort
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/internal/sticky/sticky_test.go:1663:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/internal/sticky/sticky_test.go:1672:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/internal/sticky/sticky_test.go:1697:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/internal/sticky/sticky_test.go:1755:6: for loop can be modernized using range over int
/home/tiago/work/go/src/github.com/peczenyj/franz-go/pkg/kgo/internal/sticky/sticky_test.go:1762:6: for loop can be modernized using range over int
exit status 3

```