### PR TITLE
pkg/kfake: exit group managers on cluster shutdown

### DIFF
--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -399,6 +399,7 @@ func TestIssue906(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
+	defer client.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Ensure consumer group goroutines exit after the cluster is closed.

Also, ensure clients are closed in all tests.

Closes https://github.com/twmb/franz-go/issues/1037