### PR TITLE
kfake: create brokers with net.Listener interface

### DIFF
--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -105,6 +105,9 @@ func NewCluster(opts ...Opt) (*Cluster, error) {
 	if len(cfg.ports) > 0 {
 		cfg.nbrokers = len(cfg.ports)
 	}
+	if len(cfg.listeners) > 0 {
+		cfg.nbrokers = len(cfg.listeners)
+	}
 
 	c := &Cluster{
 		cfg: cfg,
@@ -167,14 +170,18 @@ func NewCluster(opts ...Opt) (*Cluster, error) {
 	}
 
 	for i := 0; i < cfg.nbrokers; i++ {
-		var port int
-		if len(cfg.ports) > 0 {
-			port = cfg.ports[i]
-		}
 		var ln net.Listener
-		ln, err = newListener(port, c.cfg.tls)
-		if err != nil {
-			return nil, err
+		if len(cfg.listeners) > 0 {
+			ln = cfg.listeners[i]
+		} else {
+			var port int
+			if len(cfg.ports) > 0 {
+				port = cfg.ports[i]
+			}
+			ln, err = newListener(port, c.cfg.tls)
+			if err != nil {
+				return nil, err
+			}
 		}
 		b := &broker{
 			c:     c,

--- a/pkg/kfake/config.go
+++ b/pkg/kfake/config.go
@@ -2,6 +2,7 @@ package kfake
 
 import (
 	"crypto/tls"
+	"net"
 	"time"
 )
 
@@ -22,6 +23,7 @@ type seedTopics struct {
 type cfg struct {
 	nbrokers        int
 	ports           []int
+	listeners       []net.Listener
 	logger          Logger
 	clusterID       string
 	allowAutoTopic  bool
@@ -47,6 +49,13 @@ func NumBrokers(n int) Opt {
 // amount of ports.
 func Ports(ports ...int) Opt {
 	return opt{func(cfg *cfg) { cfg.ports = ports }}
+}
+
+// Listeners sets the listeners to use, overriding randomly choosing NumBrokers
+// amount of ports. This allows providing custom net.Listener implementations
+// for testing scenarios.
+func Listeners(listeners ...net.Listener) Opt {
+	return opt{func(cfg *cfg) { cfg.listeners = listeners }}
 }
 
 // WithLogger sets the logger to use.


### PR DESCRIPTION
This change introduces a new option to provide custom `net.Listener` implementations to `kfake`.
By using the `Listeners(...net.Listener)` option, users can now inject their own `net.Listener` (e.g., in-memory listeners), enabling more flexible testing scenarios.
Existing port-based configuration remains supported.
