### PR TITLE
Panic fix in kadm.Lag function

### DIFF
--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -1485,7 +1485,12 @@ func (cl *Client) Lag(ctx context.Context, groups ...string) (DescribedGroupLags
 		return nil, err
 	case errors.As(err, &se) && !se.AllFailed:
 		for _, se := range se.Errs {
-			for _, g := range se.Req.(*kmsg.DescribeGroupsRequest).Groups {
+			// can be ListGroupsRequest as well
+			req, ok := se.Req.(*kmsg.DescribeGroupsRequest)
+			if !ok {
+				continue
+			}
+			for _, g := range req.Groups {
 				lags[g] = DescribedGroupLag{
 					Group:       g,
 					Coordinator: se.Broker,


### PR DESCRIPTION
Hello! First of all, I want to say that I really appreciate your brilliant work! 🙏

We've got a panic using Lag function and I decided to investigate the reason.

DescribeGroups makes ListGroups request if there was no groups passed explicitly. We can get errors from ListGroups and in that case this code will panic.

I'm not sure wether this code is absolutely correct because we simply skip errors and nobody will be aware about some possibly skipped groups.