### PR TITLE
sr: fix unit testing after recent `Param.rawParams` addition

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,6 +38,15 @@ jobs:
       - uses: actions/checkout@v4
       - run: cd pkg/kfake && go work init ../.. . && go test .
 
+  test-sr:
+    if: github.repository == 'twmb/franz-go'
+    runs-on: ubuntu-latest
+    name: "test sr"
+    container: golang:latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cd pkg/sr && go work init ../.. . && go test .
+
   integration-test-kafka:
     if: github.repository == 'twmb/franz-go'
     runs-on: ubuntu-latest

--- a/pkg/sr/client_test.go
+++ b/pkg/sr/client_test.go
@@ -367,10 +367,27 @@ func TestOptValue(t *testing.T) {
 			assertDefFn: func(v any) bool { return v.(func(*http.Request) error) == nil },
 		},
 		{
-			name:        "DefaultParams",
-			opt:         DefaultParams,
-			assertFn:    func(v any) bool { return v.(Param).normalize && v.(Param).verbose },
-			assertDefFn: func(v any) bool { return v.(Param) == Param{} },
+			name:     "DefaultParams",
+			opt:      DefaultParams,
+			assertFn: func(v any) bool { return v.(Param).normalize && v.(Param).verbose },
+			assertDefFn: func(v any) bool {
+				vp := v.(Param)
+				return !vp.normalize &&
+					!vp.verbose &&
+					!vp.fetchMaxID &&
+					!vp.defaultToGlobal &&
+					!vp.force &&
+					!vp.latestOnly &&
+					!vp.showDeleted &&
+					!vp.deletedOnly &&
+					vp.format == "" &&
+					vp.subjectPrefix == "" &&
+					vp.subject == "" &&
+					vp.page == nil &&
+					vp.limit == 0 &&
+					!vp.hardDelete &&
+					len(vp.rawParams) == 0
+			},
 		},
 		{
 			name:        "unknown option name",


### PR DESCRIPTION
PR #1060 broke the testing suite in the `sr` package:
```
# github.com/twmb/franz-go/pkg/sr [github.com/twmb/franz-go/pkg/sr.test]
./client_test.go:373:43: invalid operation: v.(Param) == Param{} (struct containing url.Values cannot be compared)
FAIL    github.com/twmb/franz-go/pkg/sr [build failed]
FAIL
```
This PR fixes the testing suite after the recent addition of `rawParams` to `Param`.

EDIT: I added a GA workflow now to also run tests for the `sr` package. This should help detect future breakage.