### PR TITLE
chore: optimize segment producing

### DIFF
--- a/examples/bench/compare/segment/go.mod
+++ b/examples/bench/compare/segment/go.mod
@@ -2,7 +2,7 @@ module segment
 
 go 1.24.2
 
-require github.com/segmentio/kafka-go v0.4.47
+require github.com/segmentio/kafka-go v0.4.48
 
 require (
 	github.com/klauspost/compress v1.18.0 // indirect

--- a/examples/bench/compare/segment/go.sum
+++ b/examples/bench/compare/segment/go.sum
@@ -9,8 +9,8 @@ github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
-github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
+github.com/segmentio/kafka-go v0.4.48 h1:9jyu9CWK4W5W+SroCe8EffbrRZVqAOkuaLd/ApID4Vs=
+github.com/segmentio/kafka-go v0.4.48/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/examples/bench/compare/segment/main.go
+++ b/examples/bench/compare/segment/main.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,12 +23,12 @@ var (
 	seedBrokers = flag.String("brokers", "localhost:9092", "comma delimited list of seed brokers")
 	topic       = flag.String("topic", "", "topic to produce to or consume from")
 
-	writeSize   = flag.Int("records-per-write", 1, "number of records to create before a single WriteMessage call")
-	batchSize   = flag.Int("batch-size", 1, "value for the kafka.Writer.BatchSize field")
-	acks        = flag.Int("acks", -1, "value for the Writer.Acks field")
-	recordBytes = flag.Int("record-bytes", 100, "bytes per record (producing)")
-	compression = flag.String("compression", "none", "compression algorithm to use (none,gzip,snappy,lz4,zstd, for producing)")
-	poolProduce = flag.Bool("pool", false, "if true, use a sync.Pool to reuse record slices (producing)")
+	batchSize           = flag.Int("batch-size", 10000, "value for the kafka.Writer.BatchSize field")
+	acks                = flag.Int("acks", 0, "value for the Writer.Acks field")
+	recordBytes         = flag.Int("record-bytes", 100, "bytes per record (producing)")
+	compression         = flag.String("compression", "none", "compression algorithm to use (none,gzip,snappy,lz4,zstd, for producing)")
+	poolProduce         = flag.Bool("pool", false, "if true, use a sync.Pool to reuse record slices (producing)")
+	noIdempotentMaxReqs = flag.Int("max-inflight-produce-per-broker", 5, "if idempotency is disabled, the number of produce requests to allow per broker")
 
 	consume = flag.Bool("consume", false, "if true, consume rather than produce")
 	group   = flag.String("group", "", "if non-empty, group to use for consuming rather than direct partition consuming (consuming)")
@@ -111,7 +113,7 @@ func main() {
 			Topic:        *topic,
 			BatchSize:    *batchSize,
 			RequiredAcks: kafka.RequiredAcks(*acks),
-			Async:        true,
+			Async:        false, // batching requires this to be false
 			Completion: func(ms []kafka.Message, err error) {
 				chk(err, "produce err: %v", err)
 				for _, m := range ms {
@@ -138,16 +140,13 @@ func main() {
 			die("unrecognized compression %s", *compression)
 		}
 
+		ctx := context.Background()
+		producer := NewProducer(w, *batchSize)
+		go producer.Run(ctx, *noIdempotentMaxReqs)
+
 		var num int64
-		var msgs []kafka.Message
 		for {
-			msgs = msgs[:0]
-			for i := 0; i < *writeSize; i++ {
-				msgs = append(msgs, kafka.Message{Value: newValue(num)})
-			}
-			w.WriteMessages(context.Background(), kafka.Message{
-				Value: newValue(num),
-			})
+			producer.Produce(&kafka.Message{Value: newValue(num)})
 			num++
 		}
 
@@ -184,20 +183,78 @@ var p = sync.Pool{
 }
 
 func newValue(num int64) []byte {
-	var buf [20]byte // max int64 takes 19 bytes, then we add a space
-	b := strconv.AppendInt(buf[:0], num, 10)
-	b = append(b, ' ')
-
 	var s []byte
 	if *poolProduce {
 		s = *(p.Get().(*[]byte))
 	} else {
 		s = make([]byte, *recordBytes)
 	}
+	formatValue(num, s)
 
-	var n int
-	for n != len(s) {
-		n += copy(s[n:], b)
-	}
 	return s
+}
+
+func formatValue(num int64, v []byte) {
+	var buf [20]byte // max int64 takes 19 bytes, then we add a space
+	b := strconv.AppendInt(buf[:0], num, 10)
+	b = append(b, ' ')
+
+	n := copy(v, b)
+	for n != len(v) {
+		n += copy(v[n:], b)
+	}
+}
+
+//------------------------------------------------------------------------------
+
+type Producer struct {
+	wr           *kafka.Writer
+	ch           chan *kafka.Message
+	maxBatchSize int
+}
+
+func NewProducer(wr *kafka.Writer, maxBatchSize int) *Producer {
+	return &Producer{
+		wr:           wr,
+		ch:           make(chan *kafka.Message, 10*maxBatchSize),
+		maxBatchSize: maxBatchSize,
+	}
+}
+
+func (p *Producer) Produce(msg *kafka.Message) {
+	p.ch <- msg
+}
+
+func (p *Producer) Run(ctx context.Context, maxThreads int) {
+	ch := make(chan []*kafka.Message, maxThreads)
+
+	for range maxThreads {
+		go func() {
+			msgs := make([]kafka.Message, p.maxBatchSize)
+
+			for batch := range ch {
+				for i, msg := range batch {
+					msgs[i] = *msg
+				}
+				p.produceBatch(ctx, msgs[:len(batch)])
+			}
+		}()
+	}
+
+	batch := make([]*kafka.Message, 0, p.maxBatchSize)
+	for msg := range p.ch {
+		batch = append(batch, msg)
+		if len(batch) == p.maxBatchSize {
+			ch <- slices.Clone(batch)
+			batch = batch[:0]
+		}
+	}
+}
+
+func (p *Producer) produceBatch(
+	ctx context.Context, batch []kafka.Message,
+) {
+	if err := p.wr.WriteMessages(ctx, batch...); err != nil {
+		slog.Error("WriteMessages failes", slog.Any("err", err))
+	}
 }

--- a/examples/bench/compare/segment/main.go
+++ b/examples/bench/compare/segment/main.go
@@ -23,12 +23,12 @@ var (
 	seedBrokers = flag.String("brokers", "localhost:9092", "comma delimited list of seed brokers")
 	topic       = flag.String("topic", "", "topic to produce to or consume from")
 
-	batchSize           = flag.Int("batch-size", 10000, "value for the kafka.Writer.BatchSize field")
-	acks                = flag.Int("acks", 0, "value for the Writer.Acks field")
-	recordBytes         = flag.Int("record-bytes", 100, "bytes per record (producing)")
-	compression         = flag.String("compression", "none", "compression algorithm to use (none,gzip,snappy,lz4,zstd, for producing)")
-	poolProduce         = flag.Bool("pool", false, "if true, use a sync.Pool to reuse record slices (producing)")
-	noIdempotentMaxReqs = flag.Int("max-inflight-produce-per-broker", 5, "if idempotency is disabled, the number of produce requests to allow per broker")
+	batchSize       = flag.Int("batch-size", 10000, "value for the kafka.Writer.BatchSize field")
+	acks            = flag.Int("acks", -1, "value for the Writer.Acks field")
+	recordBytes     = flag.Int("record-bytes", 100, "bytes per record (producing)")
+	compression     = flag.String("compression", "none", "compression algorithm to use (none,gzip,snappy,lz4,zstd, for producing)")
+	poolProduce     = flag.Bool("pool", false, "if true, use a sync.Pool to reuse record slices (producing)")
+	maxWriteThreads = flag.Int("max-write-threads", 5, "if idempotency is disabled, the number of produce requests to allow per broker")
 
 	consume = flag.Bool("consume", false, "if true, consume rather than produce")
 	group   = flag.String("group", "", "if non-empty, group to use for consuming rather than direct partition consuming (consuming)")
@@ -142,7 +142,7 @@ func main() {
 
 		ctx := context.Background()
 		producer := NewProducer(w, *batchSize)
-		go producer.Run(ctx, *noIdempotentMaxReqs)
+		go producer.Run(ctx, *maxWriteThreads)
 
 		var num int64
 		for {


### PR DESCRIPTION
Before:

```
go run . -topic foo -compression=snappy
0.42 MiB/s; 4.42k records/s
0.43 MiB/s; 4.51k records/s
0.43 MiB/s; 4.47k records/s
0.44 MiB/s; 4.60k records/s
0.46 MiB/s; 4.81k records/s
0.40 MiB/s; 4.24k records/s
0.47 MiB/s; 4.88k records/s
0.44 MiB/s; 4.65k records/s
```

After:

```
go run . -topic foo -compression=snappy
151.22 MiB/s; 1585.65k records/s
169.11 MiB/s; 1773.20k records/s
168.29 MiB/s; 1764.67k records/s
173.17 MiB/s; 1815.83k records/s
171.54 MiB/s; 1798.78k records/s
169.92 MiB/s; 1781.72k records/s
161.79 MiB/s; 1696.47k records/s
158.54 MiB/s; 1662.38k records/s
166.67 MiB/s; 1747.62k records/s
160.80 MiB/s; 1686.13k records/s
167.65 MiB/s; 1757.96k records/s
```

For some reason this is still slower than https://github.com/twmb/franz-go/pull/1064 by about 20MiB/s...