### PR TITLE
feat: add Schema Registry error code constants

### DIFF
--- a/pkg/sr/client.go
+++ b/pkg/sr/client.go
@@ -54,6 +54,12 @@ func (e *ResponseError) Error() string {
 	return string(e.Raw)
 }
 
+// SchemaError returns the typed Error corresponding to this response error's error code.
+// If the error code is unknown, this returns nil.
+func (e *ResponseError) SchemaError() *Error {
+	return ErrorForCode(e.ErrorCode)
+}
+
 // Client talks to a schema registry and contains helper functions to serialize
 // and deserialize objects according to schemas.
 type Client struct {

--- a/pkg/sr/errors.go
+++ b/pkg/sr/errors.go
@@ -1,0 +1,123 @@
+package sr
+
+// Schema Registry error codes as defined in the official Confluent Schema Registry.
+// These constants allow clients to programmatically check for specific error conditions
+// when interacting with the Schema Registry API.
+//
+// The error codes are organized by HTTP status code categories:
+//   - 404xx: Not Found errors
+//   - 409: Conflict errors
+//   - 422xx: Unprocessable Entity errors
+//   - 500xx: Internal Server errors
+//
+// Reference: https://github.com/confluentinc/schema-registry/blob/master/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
+const (
+	// HTTP 404 - Not Found errors
+	
+	// ErrCodeSubjectNotFound indicates that the specified subject does not exist.
+	ErrCodeSubjectNotFound = 40401
+	
+	// ErrCodeVersionNotFound indicates that the specified version does not exist for the subject.
+	ErrCodeVersionNotFound = 40402
+	
+	// ErrCodeSchemaNotFound indicates that the specified schema does not exist.
+	ErrCodeSchemaNotFound = 40403
+	
+	// ErrCodeSubjectSoftDeleted indicates that the subject was soft deleted.
+	// Set permanent=true to delete permanently.
+	ErrCodeSubjectSoftDeleted = 40404
+	
+	// ErrCodeSubjectNotSoftDeleted indicates that the subject was not deleted first
+	// before being permanently deleted.
+	ErrCodeSubjectNotSoftDeleted = 40405
+	
+	// ErrCodeSchemaVersionSoftDeleted indicates that the specific version of the subject
+	// was soft deleted. Set permanent=true to delete permanently.
+	ErrCodeSchemaVersionSoftDeleted = 40406
+	
+	// ErrCodeSchemaVersionNotSoftDeleted indicates that the specific version of the subject
+	// was not deleted first before being permanently deleted.
+	ErrCodeSchemaVersionNotSoftDeleted = 40407
+	
+	// ErrCodeSubjectLevelCompatibilityNotConfigured indicates that the subject does not have
+	// subject-level compatibility configured.
+	ErrCodeSubjectLevelCompatibilityNotConfigured = 40408
+	
+	// ErrCodeSubjectLevelModeNotConfigured indicates that the subject does not have
+	// subject-level mode configured.
+	ErrCodeSubjectLevelModeNotConfigured = 40409
+
+	// HTTP 409 - Conflict errors
+	
+	// ErrCodeIncompatibleSchema indicates that the schema being registered is incompatible
+	// with an earlier schema for the same subject, according to the configured compatibility level.
+	ErrCodeIncompatibleSchema = 409
+
+	// HTTP 422 - Unprocessable Entity errors
+	
+	// ErrCodeInvalidSchema indicates that the provided schema is invalid.
+	ErrCodeInvalidSchema = 42201
+	
+	// ErrCodeInvalidVersion indicates that the provided version is invalid.
+	ErrCodeInvalidVersion = 42202
+	
+	// ErrCodeInvalidCompatibilityLevel indicates that the provided compatibility level is invalid.
+	ErrCodeInvalidCompatibilityLevel = 42203
+	
+	// ErrCodeInvalidMode indicates that the provided mode is invalid.
+	ErrCodeInvalidMode = 42204
+	
+	// ErrCodeOperationNotPermitted indicates that the requested operation is not permitted.
+	ErrCodeOperationNotPermitted = 42205
+	
+	// ErrCodeReferenceExists indicates that the schema reference already exists.
+	ErrCodeReferenceExists = 42206
+	
+	// ErrCodeIDDoesNotMatch indicates that the provided ID does not match the expected ID.
+	ErrCodeIDDoesNotMatch = 42207
+	
+	// ErrCodeInvalidSubject indicates that the provided subject name is invalid.
+	ErrCodeInvalidSubject = 42208
+	
+	// ErrCodeSchemaTooLarge indicates that the schema is too large.
+	ErrCodeSchemaTooLarge = 42209
+	
+	// ErrCodeInvalidRuleset indicates that the provided ruleset is invalid.
+	ErrCodeInvalidRuleset = 42210
+	
+	// ErrCodeContextNotEmpty indicates that the context is not empty when it should be.
+	ErrCodeContextNotEmpty = 42211
+
+	// HTTP 500 - Internal Server errors
+	
+	// ErrCodeStoreError indicates an error in the backend datastore.
+	ErrCodeStoreError = 50001
+	
+	// ErrCodeOperationTimeout indicates that the operation timed out.
+	ErrCodeOperationTimeout = 50002
+	
+	// ErrCodeRequestForwardingFailed indicates an error while forwarding the request to the primary.
+	ErrCodeRequestForwardingFailed = 50003
+	
+	// ErrCodeUnknownLeader indicates that the leader is unknown.
+	ErrCodeUnknownLeader = 50004
+	
+	// ErrCodeJSONParseError indicates a JSON parsing error (error code 50005 is used 
+	// by the RestService to indicate a JSON Parse Error).
+	ErrCodeJSONParseError = 50005
+)
+
+// IsNotFoundError returns true if the error code indicates a "not found" condition.
+func IsNotFoundError(code int) bool {
+	return code >= 40401 && code <= 40409
+}
+
+// IsInvalidRequestError returns true if the error code indicates an invalid request.
+func IsInvalidRequestError(code int) bool {
+	return code >= 42201 && code <= 42211
+}
+
+// IsServerError returns true if the error code indicates a server-side error.
+func IsServerError(code int) bool {
+	return code >= 50001 && code <= 50005
+}

--- a/pkg/sr/errors.go
+++ b/pkg/sr/errors.go
@@ -1,123 +1,198 @@
 package sr
 
-// Schema Registry error codes as defined in the official Confluent Schema Registry.
-// These constants allow clients to programmatically check for specific error conditions
+import "log/slog"
+
+// Error represents a Schema Registry error with its code, name, and description.
+type Error struct {
+	// Code is the numeric error code returned by the Schema Registry.
+	Code int
+	// Name is the string representation of the error.
+	Name string
+	// Description is a human-readable description of what this error means.
+	Description string
+}
+
+// Error implements the error interface, returning the human-readable description.
+func (e *Error) Error() string {
+	return e.Description
+}
+
+// LogValue implements slog.LogValuer to provide structured logging output.
+func (e *Error) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int("code", e.Code),
+		slog.String("name", e.Name),
+		slog.String("description", e.Description),
+	)
+}
+
+// Schema Registry errors as defined in the official Confluent Schema Registry.
+// These allow clients to programmatically check for specific error conditions
 // when interacting with the Schema Registry API.
 //
-// The error codes are organized by HTTP status code categories:
+// The errors are organized by HTTP status code categories:
 //   - 404xx: Not Found errors
 //   - 409: Conflict errors
 //   - 422xx: Unprocessable Entity errors
 //   - 500xx: Internal Server errors
 //
 // Reference: https://github.com/confluentinc/schema-registry/blob/master/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
-const (
+var (
+	// ErrUnknown represents an unknown Schema Registry error code.
+	// This is returned when the Schema Registry returns an error code that is not
+	// recognized by this client version.
+	ErrUnknown = &Error{-1, "UNKNOWN_SCHEMA_REGISTRY_ERROR", "Unknown Schema Registry error"}
+
 	// HTTP 404 - Not Found errors
-	
-	// ErrCodeSubjectNotFound indicates that the specified subject does not exist.
-	ErrCodeSubjectNotFound = 40401
-	
-	// ErrCodeVersionNotFound indicates that the specified version does not exist for the subject.
-	ErrCodeVersionNotFound = 40402
-	
-	// ErrCodeSchemaNotFound indicates that the specified schema does not exist.
-	ErrCodeSchemaNotFound = 40403
-	
-	// ErrCodeSubjectSoftDeleted indicates that the subject was soft deleted.
+
+	// ErrSubjectNotFound indicates that the specified subject does not exist.
+	ErrSubjectNotFound = &Error{40401, "SUBJECT_NOT_FOUND", "Subject does not exist"}
+
+	// ErrVersionNotFound indicates that the specified version does not exist for the subject.
+	ErrVersionNotFound = &Error{40402, "VERSION_NOT_FOUND", "Version does not exist for subject"}
+
+	// ErrSchemaNotFound indicates that the specified schema does not exist.
+	ErrSchemaNotFound = &Error{40403, "SCHEMA_NOT_FOUND", "Schema does not exist"}
+
+	// ErrSubjectSoftDeleted indicates that the subject was soft deleted.
 	// Set permanent=true to delete permanently.
-	ErrCodeSubjectSoftDeleted = 40404
-	
-	// ErrCodeSubjectNotSoftDeleted indicates that the subject was not deleted first
+	ErrSubjectSoftDeleted = &Error{40404, "SUBJECT_SOFT_DELETED", "Subject was soft deleted"}
+
+	// ErrSubjectNotSoftDeleted indicates that the subject was not deleted first
 	// before being permanently deleted.
-	ErrCodeSubjectNotSoftDeleted = 40405
-	
-	// ErrCodeSchemaVersionSoftDeleted indicates that the specific version of the subject
+	ErrSubjectNotSoftDeleted = &Error{40405, "SUBJECT_NOT_SOFT_DELETED", "Subject was not deleted first before being permanently deleted"}
+
+	// ErrSchemaVersionSoftDeleted indicates that the specific version of the subject
 	// was soft deleted. Set permanent=true to delete permanently.
-	ErrCodeSchemaVersionSoftDeleted = 40406
-	
-	// ErrCodeSchemaVersionNotSoftDeleted indicates that the specific version of the subject
+	ErrSchemaVersionSoftDeleted = &Error{40406, "SCHEMA_VERSION_SOFT_DELETED", "Schema version was soft deleted"}
+
+	// ErrSchemaVersionNotSoftDeleted indicates that the specific version of the subject
 	// was not deleted first before being permanently deleted.
-	ErrCodeSchemaVersionNotSoftDeleted = 40407
-	
-	// ErrCodeSubjectLevelCompatibilityNotConfigured indicates that the subject does not have
+	ErrSchemaVersionNotSoftDeleted = &Error{40407, "SCHEMA_VERSION_NOT_SOFT_DELETED", "Schema version was not deleted first before being permanently deleted"}
+
+	// ErrSubjectLevelCompatibilityNotConfigured indicates that the subject does not have
 	// subject-level compatibility configured.
-	ErrCodeSubjectLevelCompatibilityNotConfigured = 40408
-	
-	// ErrCodeSubjectLevelModeNotConfigured indicates that the subject does not have
+	ErrSubjectLevelCompatibilityNotConfigured = &Error{40408, "SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED", "Subject does not have subject-level compatibility configured"}
+
+	// ErrSubjectLevelModeNotConfigured indicates that the subject does not have
 	// subject-level mode configured.
-	ErrCodeSubjectLevelModeNotConfigured = 40409
+	ErrSubjectLevelModeNotConfigured = &Error{40409, "SUBJECT_LEVEL_MODE_NOT_CONFIGURED", "Subject does not have subject-level mode configured"}
 
 	// HTTP 409 - Conflict errors
-	
-	// ErrCodeIncompatibleSchema indicates that the schema being registered is incompatible
+
+	// ErrIncompatibleSchema indicates that the schema being registered is incompatible
 	// with an earlier schema for the same subject, according to the configured compatibility level.
-	ErrCodeIncompatibleSchema = 409
+	ErrIncompatibleSchema = &Error{409, "INCOMPATIBLE_SCHEMA", "Schema is incompatible with an earlier schema"}
 
 	// HTTP 422 - Unprocessable Entity errors
-	
-	// ErrCodeInvalidSchema indicates that the provided schema is invalid.
-	ErrCodeInvalidSchema = 42201
-	
-	// ErrCodeInvalidVersion indicates that the provided version is invalid.
-	ErrCodeInvalidVersion = 42202
-	
-	// ErrCodeInvalidCompatibilityLevel indicates that the provided compatibility level is invalid.
-	ErrCodeInvalidCompatibilityLevel = 42203
-	
-	// ErrCodeInvalidMode indicates that the provided mode is invalid.
-	ErrCodeInvalidMode = 42204
-	
-	// ErrCodeOperationNotPermitted indicates that the requested operation is not permitted.
-	ErrCodeOperationNotPermitted = 42205
-	
-	// ErrCodeReferenceExists indicates that the schema reference already exists.
-	ErrCodeReferenceExists = 42206
-	
-	// ErrCodeIDDoesNotMatch indicates that the provided ID does not match the expected ID.
-	ErrCodeIDDoesNotMatch = 42207
-	
-	// ErrCodeInvalidSubject indicates that the provided subject name is invalid.
-	ErrCodeInvalidSubject = 42208
-	
-	// ErrCodeSchemaTooLarge indicates that the schema is too large.
-	ErrCodeSchemaTooLarge = 42209
-	
-	// ErrCodeInvalidRuleset indicates that the provided ruleset is invalid.
-	ErrCodeInvalidRuleset = 42210
-	
-	// ErrCodeContextNotEmpty indicates that the context is not empty when it should be.
-	ErrCodeContextNotEmpty = 42211
+
+	// ErrInvalidSchema indicates that the provided schema is invalid.
+	ErrInvalidSchema = &Error{42201, "INVALID_SCHEMA", "Schema is invalid"}
+
+	// ErrInvalidVersion indicates that the provided version is invalid.
+	ErrInvalidVersion = &Error{42202, "INVALID_VERSION", "Version is invalid"}
+
+	// ErrInvalidCompatibilityLevel indicates that the provided compatibility level is invalid.
+	ErrInvalidCompatibilityLevel = &Error{42203, "INVALID_COMPATIBILITY_LEVEL", "Compatibility level is invalid"}
+
+	// ErrInvalidMode indicates that the provided mode is invalid.
+	ErrInvalidMode = &Error{42204, "INVALID_MODE", "Mode is invalid"}
+
+	// ErrOperationNotPermitted indicates that the requested operation is not permitted.
+	ErrOperationNotPermitted = &Error{42205, "OPERATION_NOT_PERMITTED", "Operation is not permitted"}
+
+	// ErrReferenceExists indicates that the schema reference already exists.
+	ErrReferenceExists = &Error{42206, "REFERENCE_EXISTS", "Schema reference already exists"}
+
+	// ErrIDDoesNotMatch indicates that the provided ID does not match the expected ID.
+	ErrIDDoesNotMatch = &Error{42207, "ID_DOES_NOT_MATCH", "Provided ID does not match expected ID"}
+
+	// ErrInvalidSubject indicates that the provided subject name is invalid.
+	ErrInvalidSubject = &Error{42208, "INVALID_SUBJECT", "Subject name is invalid"}
+
+	// ErrSchemaTooLarge indicates that the schema is too large.
+	ErrSchemaTooLarge = &Error{42209, "SCHEMA_TOO_LARGE", "Schema is too large"}
+
+	// ErrInvalidRuleset indicates that the provided ruleset is invalid.
+	ErrInvalidRuleset = &Error{42210, "INVALID_RULESET", "Ruleset is invalid"}
+
+	// ErrContextNotEmpty indicates that the context is not empty when it should be.
+	ErrContextNotEmpty = &Error{42211, "CONTEXT_NOT_EMPTY", "Context is not empty when it should be"}
 
 	// HTTP 500 - Internal Server errors
-	
-	// ErrCodeStoreError indicates an error in the backend datastore.
-	ErrCodeStoreError = 50001
-	
-	// ErrCodeOperationTimeout indicates that the operation timed out.
-	ErrCodeOperationTimeout = 50002
-	
-	// ErrCodeRequestForwardingFailed indicates an error while forwarding the request to the primary.
-	ErrCodeRequestForwardingFailed = 50003
-	
-	// ErrCodeUnknownLeader indicates that the leader is unknown.
-	ErrCodeUnknownLeader = 50004
-	
-	// ErrCodeJSONParseError indicates a JSON parsing error (error code 50005 is used 
+
+	// ErrStoreError indicates an error in the backend datastore.
+	ErrStoreError = &Error{50001, "STORE_ERROR", "Error in backend datastore"}
+
+	// ErrOperationTimeout indicates that the operation timed out.
+	ErrOperationTimeout = &Error{50002, "OPERATION_TIMEOUT", "Operation timed out"}
+
+	// ErrRequestForwardingFailed indicates an error while forwarding the request to the primary.
+	ErrRequestForwardingFailed = &Error{50003, "REQUEST_FORWARDING_FAILED", "Error forwarding request to primary"}
+
+	// ErrUnknownLeader indicates that the leader is unknown.
+	ErrUnknownLeader = &Error{50004, "UNKNOWN_LEADER", "Leader is unknown"}
+
+	// ErrJSONParseError indicates a JSON parsing error (error code 50005 is used
 	// by the RestService to indicate a JSON Parse Error).
-	ErrCodeJSONParseError = 50005
+	ErrJSONParseError = &Error{50005, "JSON_PARSE_ERROR", "JSON parsing error"}
 )
+
+// ErrorForCode returns the Error corresponding to the given error code.
+// If the code is unknown, this returns ErrUnknown.
+func ErrorForCode(code int) *Error {
+	err, exists := codeToError[code]
+	if !exists {
+		return ErrUnknown
+	}
+	return err
+}
+
+// codeToError maps error codes to their corresponding Error instances.
+var codeToError = map[int]*Error{
+	ErrSubjectNotFound.Code:                        ErrSubjectNotFound,
+	ErrVersionNotFound.Code:                        ErrVersionNotFound,
+	ErrSchemaNotFound.Code:                         ErrSchemaNotFound,
+	ErrSubjectSoftDeleted.Code:                     ErrSubjectSoftDeleted,
+	ErrSubjectNotSoftDeleted.Code:                  ErrSubjectNotSoftDeleted,
+	ErrSchemaVersionSoftDeleted.Code:               ErrSchemaVersionSoftDeleted,
+	ErrSchemaVersionNotSoftDeleted.Code:            ErrSchemaVersionNotSoftDeleted,
+	ErrSubjectLevelCompatibilityNotConfigured.Code: ErrSubjectLevelCompatibilityNotConfigured,
+	ErrSubjectLevelModeNotConfigured.Code:          ErrSubjectLevelModeNotConfigured,
+	ErrIncompatibleSchema.Code:                     ErrIncompatibleSchema,
+	ErrInvalidSchema.Code:                          ErrInvalidSchema,
+	ErrInvalidVersion.Code:                         ErrInvalidVersion,
+	ErrInvalidCompatibilityLevel.Code:              ErrInvalidCompatibilityLevel,
+	ErrInvalidMode.Code:                            ErrInvalidMode,
+	ErrOperationNotPermitted.Code:                  ErrOperationNotPermitted,
+	ErrReferenceExists.Code:                        ErrReferenceExists,
+	ErrIDDoesNotMatch.Code:                         ErrIDDoesNotMatch,
+	ErrInvalidSubject.Code:                         ErrInvalidSubject,
+	ErrSchemaTooLarge.Code:                         ErrSchemaTooLarge,
+	ErrInvalidRuleset.Code:                         ErrInvalidRuleset,
+	ErrContextNotEmpty.Code:                        ErrContextNotEmpty,
+	ErrStoreError.Code:                             ErrStoreError,
+	ErrOperationTimeout.Code:                       ErrOperationTimeout,
+	ErrRequestForwardingFailed.Code:                ErrRequestForwardingFailed,
+	ErrUnknownLeader.Code:                          ErrUnknownLeader,
+	ErrJSONParseError.Code:                         ErrJSONParseError,
+}
 
 // IsNotFoundError returns true if the error code indicates a "not found" condition.
 func IsNotFoundError(code int) bool {
 	return code >= 40401 && code <= 40409
 }
 
+
 // IsInvalidRequestError returns true if the error code indicates an invalid request.
 func IsInvalidRequestError(code int) bool {
 	return code >= 42201 && code <= 42211
 }
 
+
 // IsServerError returns true if the error code indicates a server-side error.
 func IsServerError(code int) bool {
 	return code >= 50001 && code <= 50005
 }
+
+

--- a/pkg/sr/srfake/errors.go
+++ b/pkg/sr/srfake/errors.go
@@ -34,41 +34,41 @@ func newErr(httpStatus, srCode int, format string, a ...any) *registryError {
 // Specific error constructors for common error scenarios
 
 func errSubjectNotFound(subject string) *registryError {
-	return newErr(http.StatusNotFound, errCodeSubjectNotFound, "subject %q not found", subject)
+	return newErr(http.StatusNotFound, sr.ErrCodeSubjectNotFound, "subject %q not found", subject)
 }
 
 func errVersionNotFound(subject string, version int) *registryError {
-	return newErr(http.StatusNotFound, errCodeVersionNotFound, "version %d not found for %q", version, subject)
+	return newErr(http.StatusNotFound, sr.ErrCodeVersionNotFound, "version %d not found for %q", version, subject)
 }
 
 func errSchemaNotFound() *registryError {
-	return newErr(http.StatusNotFound, errCodeSchemaNotFound, "schema not found")
+	return newErr(http.StatusNotFound, sr.ErrCodeSchemaNotFound, "schema not found")
 }
 
 func errSchemaIsReferenced(subject string, version int, by []int) *registryError {
-	return newErr(http.StatusConflict, errCodeInvalidSchema, "Cannot delete schema %s:%d as it is still referenced by schema IDs: %v", subject, version, by)
+	return newErr(http.StatusConflict, sr.ErrCodeInvalidSchema, "Cannot delete schema %s:%d as it is still referenced by schema IDs: %v", subject, version, by)
 }
 
 func errInvalidReference(ref sr.SchemaReference) *registryError {
-	return newErr(http.StatusUnprocessableEntity, errCodeInvalidSchema, "reference %q subject %q version %d not found", ref.Name, ref.Subject, ref.Version)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, "reference %q subject %q version %d not found", ref.Name, ref.Subject, ref.Version)
 }
 
 func errInvalidSchema(msg string) *registryError {
-	return newErr(http.StatusUnprocessableEntity, errCodeInvalidSchema, msg)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, msg)
 }
 
 func errInvalidSchemaWithCause(cause error, msg string) *registryError {
-	return newErr(http.StatusUnprocessableEntity, errCodeInvalidSchema, msg)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, msg)
 }
 
 func errInvalidVersion(msg string) *registryError {
-	return newErr(http.StatusBadRequest, errCodeInvalidVersion, msg)
+	return newErr(http.StatusBadRequest, sr.ErrCodeInvalidVersion, msg)
 }
 
 func errInvalidCompatLevel(msg string) *registryError {
-	return newErr(http.StatusBadRequest, errCodeInvalidCompatLevel, msg)
+	return newErr(http.StatusBadRequest, sr.ErrCodeInvalidCompatibilityLevel, msg)
 }
 
 func errCircularDependency(subject string) *registryError {
-	return newErr(http.StatusUnprocessableEntity, errCodeInvalidSchema, "circular dependency detected: subject %s is referenced in a cycle", subject)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, "circular dependency detected: subject %s is referenced in a cycle", subject)
 }

--- a/pkg/sr/srfake/errors.go
+++ b/pkg/sr/srfake/errors.go
@@ -34,41 +34,41 @@ func newErr(httpStatus, srCode int, format string, a ...any) *registryError {
 // Specific error constructors for common error scenarios
 
 func errSubjectNotFound(subject string) *registryError {
-	return newErr(http.StatusNotFound, sr.ErrCodeSubjectNotFound, "subject %q not found", subject)
+	return newErr(http.StatusNotFound, sr.ErrSubjectNotFound.Code, "subject %q not found", subject)
 }
 
 func errVersionNotFound(subject string, version int) *registryError {
-	return newErr(http.StatusNotFound, sr.ErrCodeVersionNotFound, "version %d not found for %q", version, subject)
+	return newErr(http.StatusNotFound, sr.ErrVersionNotFound.Code, "version %d not found for %q", version, subject)
 }
 
 func errSchemaNotFound() *registryError {
-	return newErr(http.StatusNotFound, sr.ErrCodeSchemaNotFound, "schema not found")
+	return newErr(http.StatusNotFound, sr.ErrSchemaNotFound.Code, "schema not found")
 }
 
 func errSchemaIsReferenced(subject string, version int, by []int) *registryError {
-	return newErr(http.StatusConflict, sr.ErrCodeInvalidSchema, "Cannot delete schema %s:%d as it is still referenced by schema IDs: %v", subject, version, by)
+	return newErr(http.StatusConflict, sr.ErrInvalidSchema.Code, "Cannot delete schema %s:%d as it is still referenced by schema IDs: %v", subject, version, by)
 }
 
 func errInvalidReference(ref sr.SchemaReference) *registryError {
-	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, "reference %q subject %q version %d not found", ref.Name, ref.Subject, ref.Version)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrInvalidSchema.Code, "reference %q subject %q version %d not found", ref.Name, ref.Subject, ref.Version)
 }
 
 func errInvalidSchema(msg string) *registryError {
-	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, msg)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrInvalidSchema.Code, msg)
 }
 
 func errInvalidSchemaWithCause(cause error, msg string) *registryError {
-	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, msg)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrInvalidSchema.Code, msg)
 }
 
 func errInvalidVersion(msg string) *registryError {
-	return newErr(http.StatusBadRequest, sr.ErrCodeInvalidVersion, msg)
+	return newErr(http.StatusBadRequest, sr.ErrInvalidVersion.Code, msg)
 }
 
 func errInvalidCompatLevel(msg string) *registryError {
-	return newErr(http.StatusBadRequest, sr.ErrCodeInvalidCompatibilityLevel, msg)
+	return newErr(http.StatusBadRequest, sr.ErrInvalidCompatibilityLevel.Code, msg)
 }
 
 func errCircularDependency(subject string) *registryError {
-	return newErr(http.StatusUnprocessableEntity, sr.ErrCodeInvalidSchema, "circular dependency detected: subject %s is referenced in a cycle", subject)
+	return newErr(http.StatusUnprocessableEntity, sr.ErrInvalidSchema.Code, "circular dependency detected: subject %s is referenced in a cycle", subject)
 }

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -16,11 +16,11 @@ import (
 func (r *Registry) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Header.Get("Authorization") == "" {
-			writeError(w, http.StatusUnauthorized, sr.ErrCodeOperationTimeout, "Missing Authorization header")
+			writeError(w, http.StatusUnauthorized, sr.ErrOperationTimeout.Code, "Missing Authorization header")
 			return
 		}
 		if req.Header.Get("Authorization") != r.expectedAuth {
-			writeError(w, http.StatusForbidden, sr.ErrCodeOperationTimeout, "User not authorized")
+			writeError(w, http.StatusForbidden, sr.ErrOperationTimeout.Code, "User not authorized")
 			return
 		}
 		next.ServeHTTP(w, req)
@@ -492,6 +492,6 @@ func (*Registry) handleAPIError(w http.ResponseWriter, err error) {
 	} else {
 		// This is an unexpected or generic error.
 		// Return a generic 500 error.
-		writeError(w, http.StatusInternalServerError, sr.ErrCodeStoreError, err.Error())
+		writeError(w, http.StatusInternalServerError, sr.ErrStoreError.Code, err.Error())
 	}
 }

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -16,11 +16,11 @@ import (
 func (r *Registry) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Header.Get("Authorization") == "" {
-			writeError(w, http.StatusUnauthorized, errCodeOperationTimeout, "Missing Authorization header")
+			writeError(w, http.StatusUnauthorized, sr.ErrCodeOperationTimeout, "Missing Authorization header")
 			return
 		}
 		if req.Header.Get("Authorization") != r.expectedAuth {
-			writeError(w, http.StatusForbidden, errCodeOperationTimeout, "User not authorized")
+			writeError(w, http.StatusForbidden, sr.ErrCodeOperationTimeout, "User not authorized")
 			return
 		}
 		next.ServeHTTP(w, req)
@@ -492,6 +492,6 @@ func (*Registry) handleAPIError(w http.ResponseWriter, err error) {
 	} else {
 		// This is an unexpected or generic error.
 		// Return a generic 500 error.
-		writeError(w, http.StatusInternalServerError, errCodeBackendDataStore, err.Error())
+		writeError(w, http.StatusInternalServerError, sr.ErrCodeStoreError, err.Error())
 	}
 }

--- a/pkg/sr/srfake/http.go
+++ b/pkg/sr/srfake/http.go
@@ -7,18 +7,6 @@ import (
 	"net/http"
 )
 
-const (
-	errCodeSubjectNotFound     = 40401
-	errCodeVersionNotFound     = 40402
-	errCodeSchemaNotFound      = 40403
-	errCodeInvalidSchema       = 42201
-	errCodeInvalidVersion      = 42202
-	errCodeInvalidCompatLevel  = 42203
-	errCodeBackendDataStore    = 50001
-	errCodeOperationTimeout    = 50002
-	errCodeForwardRequestError = 50003
-)
-
 func respondJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/vnd.schemaregistry.v1+json")
 	w.WriteHeader(status)

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -411,7 +411,7 @@ func (r *Registry) deleteSubject(subject string, permanent bool) ([]int, error) 
 		}
 	}
 	if len(allReferencingIDs) > 0 {
-		return nil, newErr(http.StatusConflict, errCodeInvalidSchema,
+		return nil, newErr(http.StatusConflict, sr.ErrCodeInvalidSchema,
 			"Cannot delete subject %s as its schemas are still referenced by schema IDs: %v",
 			subject, allReferencingIDs)
 	}

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -411,7 +411,7 @@ func (r *Registry) deleteSubject(subject string, permanent bool) ([]int, error) 
 		}
 	}
 	if len(allReferencingIDs) > 0 {
-		return nil, newErr(http.StatusConflict, sr.ErrCodeInvalidSchema,
+		return nil, newErr(http.StatusConflict, sr.ErrInvalidSchema.Code,
 			"Cannot delete subject %s as its schemas are still referenced by schema IDs: %v",
 			subject, allReferencingIDs)
 	}


### PR DESCRIPTION
## Summary
- Add comprehensive error code constants from official Confluent Schema Registry
- Include helper functions for error categorization
- Update srfake package to use centralized constants

## Changes
- New pkg/sr/errors.go with all 24 official error codes
- Helper functions: IsNotFoundError(), IsInvalidRequestError(), IsServerError()
- Remove duplicate constants from srfake package
- Maintains backward compatibility