### PR TITLE
kgo: add Fetches.RecordsAll to return a Go native iterator of records in fetches

### DIFF
--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -202,8 +202,7 @@ func (c *testConsumer) etl(etlsBeforeQuit int) {
 		}
 		netls++
 
-		for iter := fetches.RecordIter(); !iter.Done(); {
-			r := iter.Next()
+		for r := range fetches.RecordsAll() {
 			keyNum, err := strconv.Atoi(string(r.Key))
 			if err != nil {
 				c.errCh <- err

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -3,6 +3,7 @@ package kgo
 import (
 	"context"
 	"errors"
+	"iter"
 	"reflect"
 	"time"
 	"unsafe"
@@ -518,6 +519,19 @@ beforePartition:
 		i.pi++
 		i.ri = 0
 		goto beforePartition
+	}
+}
+
+// RecordsAll returns a Go native iterator that yields the records in a fetch.
+//
+// Similarly to RecordIter(), the errors should be inspected separately.
+func (fs Fetches) RecordsAll() iter.Seq[*Record] {
+	return func(yield func(*Record) bool) {
+		for iter := fs.RecordIter(); !iter.Done(); {
+			if !yield(iter.Next()) {
+				return
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The PR adds a new method `Fetches.RecordsApp`, to return an iterator over the records in the fetches.

The method is similar to the existing `Fetches.RecordIter` and `Fetches.EachRecord`, but it returns the `iter.Seq`, allowing the user to use the range-over-function.