### PR TITLE
kgo: fix panic in metadata updates from inconsistent broker state

### DIFF
--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -870,6 +870,7 @@ func (cl *Client) mergeTopicPartitions(
 					"topic", topic,
 					"partition", part,
 				)
+				*newTP = *oldTP
 				retryWhy.add(topic, int32(part), errMissingTopicID)
 				continue
 			}


### PR DESCRIPTION
Scenario is:
* cluster returns topic ID on metadata update 1
* cluster does not return topic ID on metadata update 2
* metadata update 3 causes a panic

By not copying the old topic partition data into the new pointer, the new pointer is seen as a new partition -- and almost all fields were not initialized. So, the third update is now updating a partially initialized cursor. The `cursorsIdx` field is -1 on initialization (which is the bug, since we did not copy the old index), and we panic when trying to remove that index from the cursors slice.

This is only possible against a cluster that does not properly handle topic IDs; in particular, this bug has existed since 2023 and has never been encountered. This popped up against a broker implementation that also has a followup to fix here.