### PR TITLE
repo: fix two typos

### DIFF
--- a/generate/definitions/01_fetch
+++ b/generate/definitions/01_fetch
@@ -51,7 +51,7 @@ FetchRequest => key 1, max version 17, flexible v12+
   // ID used should be 0, and thereafter (until session resets) the ID should
   // be the ID returned in the fetch response.
   //
-  // Read KIP-227 for more details. Use -1 if you want to disable sessions.
+  // Read KIP-227 for more details.
   SessionID: int32 // v7+
   // SessionEpoch is the session epoch for this request if using sessions.
   //

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1341,7 +1341,7 @@ type ProcessFetchPartitionOpts struct {
 	// Topic is used to populate the Topic field of each Record.
 	Topic string
 
-	// Topic is used to populate the Partition field of each Record.
+	// Partition is used to populate the Partition field of each Record.
 	Partition int32
 
 	// Pools contain potential pools to use for memory pooling.

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -4194,7 +4194,7 @@ type FetchRequest struct {
 	// ID used should be 0, and thereafter (until session resets) the ID should
 	// be the ID returned in the fetch response.
 	//
-	// Read KIP-227 for more details. Use -1 if you want to disable sessions.
+	// Read KIP-227 for more details.
 	SessionID int32 // v7+
 
 	// SessionEpoch is the session epoch for this request if using sessions.


### PR DESCRIPTION
* Incorrect doc line in generate/definitions (&& regenerate kmsg from this)
* Accidental c&p error on doc line in kgo (not sure how a linter didn't catch this)