### PR TITLE
Fix documentation for `Metadata.Cluster`

### DIFF
--- a/pkg/kadm/metadata.go
+++ b/pkg/kadm/metadata.go
@@ -185,7 +185,7 @@ func (ds TopicDetails) TopicsList() TopicsList {
 
 // Metadata is the data from a metadata response.
 type Metadata struct {
-	Cluster              string         // Cluster is the cluster name, if any.
+	Cluster              string         // Cluster is the cluster ID, if any.
 	Controller           int32          // Controller is the node ID of the controller broker, if available, otherwise -1.
 	Brokers              BrokerDetails  // Brokers contains broker details, sorted by default.
 	Topics               TopicDetails   // Topics contains topic details.


### PR DESCRIPTION
The Metadata response object does not have a cluster name, just a cluster ID. See:

- https://cwiki.apache.org/confluence/display/KAFKA/KIP-78%3A+Cluster+Id
- https://github.com/twmb/franz-go/blob/252fa6ef6880b46c1dac896156c80b4bd135aeb7/pkg/kadm/metadata.go#L284-L286