### PR TITLE
kgo: make connection reset error check portable

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -793,7 +793,8 @@ start:
 	// api versions does *not* use flexible response headers; see comment in promisedResp
 	rawResp, err := cxn.readResponse(nil, req.Key(), req.GetVersion(), corrID, false, rt, bytesWritten, writeWait, timeToWrite, readEnqueue)
 	if err != nil {
-		if errors.As(err, new(net.Error)) {
+		var opError *net.OpError
+		if errors.As(err, &opError) && opError.Op == "read" {
 			return &errApiVersionsReset{err}
 		}
 		return err

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kbin"
@@ -793,8 +794,8 @@ start:
 	// api versions does *not* use flexible response headers; see comment in promisedResp
 	rawResp, err := cxn.readResponse(nil, req.Key(), req.GetVersion(), corrID, false, rt, bytesWritten, writeWait, timeToWrite, readEnqueue)
 	if err != nil {
-		var opError *net.OpError
-		if errors.As(err, &opError) && opError.Op == "read" {
+		var errno syscall.Errno
+		if errors.As(err, &errno) && isConnReset(errno) {
 			return &errApiVersionsReset{err}
 		}
 		return err

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -793,7 +793,7 @@ start:
 	// api versions does *not* use flexible response headers; see comment in promisedResp
 	rawResp, err := cxn.readResponse(nil, req.Key(), req.GetVersion(), corrID, false, rt, bytesWritten, writeWait, timeToWrite, readEnqueue)
 	if err != nil {
-		if strings.HasSuffix(err.Error(), "connection reset by peer") {
+		if errors.As(err, new(net.Error)) {
 			return &errApiVersionsReset{err}
 		}
 		return err

--- a/pkg/kgo/connreset_unix.go
+++ b/pkg/kgo/connreset_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package kgo
+
+import (
+	"syscall"
+)
+
+func isConnReset(errno syscall.Errno) bool {
+	return errno == syscall.ECONNRESET
+}

--- a/pkg/kgo/connreset_windows.go
+++ b/pkg/kgo/connreset_windows.go
@@ -1,0 +1,9 @@
+package kgo
+
+import (
+	"syscall"
+)
+
+func isConnReset(errno syscall.Errno) bool {
+	return errno == syscall.WSAECONNRESET
+}


### PR DESCRIPTION
The connection reset error message is not the same across operating systems, so instead check if it's a net.Error.

Fixes #1102