### PR TITLE
fixed typo in group consuming examples

### DIFF
--- a/examples/goroutine_per_partition_consuming/autocommit_marks/main.go
+++ b/examples/goroutine_per_partition_consuming/autocommit_marks/main.go
@@ -34,7 +34,7 @@ type pconsumer struct {
 }
 
 type splitConsume struct {
-	// Using BlockRebalanceOnCommit means we do not need a mu to manage
+	// Using BlockRebalanceOnPoll means we do not need a mu to manage
 	// consumers, unlike the autocommit normal example.
 	consumers map[tp]*pconsumer
 }

--- a/examples/goroutine_per_partition_consuming/manual_commit/main.go
+++ b/examples/goroutine_per_partition_consuming/manual_commit/main.go
@@ -34,7 +34,7 @@ type pconsumer struct {
 }
 
 type splitConsume struct {
-	// Using BlockRebalanceOnCommit means we do not need a mu to manage
+	// Using BlockRebalanceOnPoll means we do not need a mu to manage
 	// consumers, unlike the autocommit normal example.
 	consumers map[tp]*pconsumer
 }


### PR DESCRIPTION
See issue #1107 