### PR TITLE
kgo: add more logging on 0-successful-reads path

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -688,7 +688,7 @@ func (b *broker) connect(ctx context.Context) (net.Conn, error) {
 		if !errors.Is(err, ErrClientClosed) && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "operation was canceled") {
 			if errors.Is(err, io.EOF) {
 				b.cl.cfg.logger.Log(LogLevelWarn, "unable to open connection to broker due to an immediate EOF, which often means the client is using TLS when the broker is not expecting it (is TLS misconfigured?)", "addr", b.addr, "broker", logID(b.meta.NodeID), "err", err)
-				return nil, &ErrFirstReadEOF{kind: firstReadTLS, err: err}
+				return nil, &ErrFirstReadEOF{kind: firstReadDial, err: err}
 			}
 			b.cl.cfg.logger.Log(LogLevelWarn, "unable to open connection to broker", "addr", b.addr, "broker", logID(b.meta.NodeID), "err", err)
 		}
@@ -1540,12 +1540,17 @@ func (cxn *brokerCxn) handleResp(pr promisedResp) {
 	)
 	if err != nil {
 		if !errors.Is(err, ErrClientClosed) && !errors.Is(err, context.Canceled) {
-			if cxn.successes > 0 || len(cxn.b.cl.cfg.sasls) > 0 {
+			if cxn.successes > 0 {
 				cxn.b.cl.cfg.logger.Log(LogLevelDebug, "read from broker errored, killing connection", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "successful_reads", cxn.successes, "err", err)
-			} else {
-				cxn.b.cl.cfg.logger.Log(LogLevelWarn, "read from broker errored, killing connection after 0 successful responses (is SASL missing?)", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
+			} else if len(cxn.b.cl.cfg.sasls) > 0 {
+				cxn.b.cl.cfg.logger.Log(LogLevelWarn, "read from broker errored, killing connection after 0 successful responses (is TLS missing?)", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
 				if err == io.EOF { // specifically avoid checking errors.Is to ensure this is not already wrapped
-					err = &ErrFirstReadEOF{kind: firstReadSASL, err: err}
+					err = &ErrFirstReadEOF{kind: firstReadYesSASL, err: err}
+				}
+			} else {
+				cxn.b.cl.cfg.logger.Log(LogLevelWarn, "read from broker errored, killing connection after 0 successful responses (is SASL or TLS missing?)", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
+				if err == io.EOF { // specifically avoid checking errors.Is to ensure this is not already wrapped
+					err = &ErrFirstReadEOF{kind: firstReadNoSASL, err: err}
 				}
 			}
 		}

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -256,16 +256,19 @@ func (e *errProducerIDLoadFail) Error() string {
 func (e *errProducerIDLoadFail) Unwrap() error { return e.err }
 
 const (
-	firstReadSASL uint8 = iota
-	firstReadTLS
+	firstReadNoSASL uint8 = iota
+	firstReadYesSASL
+	firstReadDial
 )
 
 func (e *ErrFirstReadEOF) Error() string {
 	switch e.kind {
-	case firstReadTLS:
+	case firstReadDial:
 		return "broker closed the connection immediately after a dial, which happens if the client is using TLS when the broker is not expecting it: is TLS misconfigured on the client or the broker?"
-	default: // firstReadSASL
-		return "broker closed the connection immediately after a request was issued, which happens when SASL is required but not provided: is SASL missing?"
+	case firstReadYesSASL:
+		return "broker closed the connection immediately after a request was issued and the client is using SASL, are TLS configs missing?"
+	default: // firstReadNoSASL
+		return "broker closed the connection immediately after a request was issued, are SASL or TLS configs missing?"
 	}
 }
 


### PR DESCRIPTION
If the client is missing TLS settings AND if the broker requires TLS but does not send a TLS alert record:
* Previously the client would just warn-log and return an EOF error
* Now the client warn-logs a better guess and returns ErrFirstReadEOF

It's not possible to accurately determine whether it's TLS or SASL that are misconfigured. If SASL is configured, we'll assume that's intentional and only hint at TLS.