### PR TITLE
kgo TestConsumeRegex: make more robust

### DIFF
--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -55,6 +55,23 @@ var (
 	npartitionsAt int64
 )
 
+func wait(tb testing.TB, dur time.Duration, cond func() error) {
+	tb.Helper()
+
+	start := time.Now()
+	for {
+		err := cond()
+		if err == nil {
+			return
+		}
+		if time.Since(start) > dur {
+			tb.Error(err)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 type slowConn struct {
 	net.Conn
 }


### PR DESCRIPTION
Uses a random topic prefix so the regex does not match any existing topic already on the cluster.