### PR TITLE
TestConsumeRegex: make even more robust

### DIFF
--- a/pkg/kgo/consumer_direct_test.go
+++ b/pkg/kgo/consumer_direct_test.go
@@ -112,9 +112,9 @@ func TestConsumeRegex(t *testing.T) {
 		ConsumeRegex(),
 	)
 	defer cl.Close()
-	cl.triggerUpdateMetadataNow("querying metadata for consumer initialization")
 	var topics []string
 	wait(t, 5*time.Second, func() error {
+		cl.triggerUpdateMetadataNow("querying metadata for consumer initialization")
 		topics = cl.GetConsumeTopics()
 		if len(topics) != 2 {
 			return fmt.Errorf("expected 2 topics, got %v", topics)


### PR DESCRIPTION
If the metadata update is fast enough, it's possible that we'll miss the new topics, and then the test would fail.

By moving the metadata update inside the check loop, we force load it every time, meaning we should succeed within 5s.