### PR TITLE
kfake: fix missing reset of `nbytes` variable while fetching

### DIFF
--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -150,6 +150,7 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 	}()
 
 	var batchesAdded int
+	nbytes = 0
 full:
 	for _, rt := range req.Topics {
 		for _, rp := range rt.Partitions {


### PR DESCRIPTION
See #1139,
Closes #1139.