### PR TITLE
Update session timeout comment in config.go

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1960,7 +1960,7 @@ func AutoCommitMarks() GroupOpt {
 // when closing. This allows for the client to restart with the same instance
 // ID and rejoin the group to avoid a rebalance. It is strongly recommended to
 // increase the session timeout enough to allow time for the restart (remember
-// that the default session timeout is 10s).
+// that the default session timeout is 45s).
 //
 // To actually leave the group, you must use an external admin command that
 // issues a leave group request on behalf of this instance ID (see kcl), or you


### PR DESCRIPTION
Updated the default session timeout in comments from 10s to 45s.

The `defaultCfg` in the config.go has a value of `sessionTimeout:    45000 * time.Millisecond,`. Just wanting to reflect that in the documentation.

Am in a situation where I may want to use instanceIds and the timeout seemed a bit too low for the use case.