### PR TITLE
kfake: fix new test, bump franz-go to latest

### DIFF
--- a/pkg/kfake/go.mod
+++ b/pkg/kfake/go.mod
@@ -3,7 +3,7 @@ module github.com/twmb/franz-go/pkg/kfake
 go 1.24.0
 
 require (
-	github.com/twmb/franz-go v1.20.0
+	github.com/twmb/franz-go v1.20.1
 	github.com/twmb/franz-go/pkg/kadm v1.15.0
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
 	golang.org/x/crypto v0.43.0

--- a/pkg/kfake/go.sum
+++ b/pkg/kfake/go.sum
@@ -2,8 +2,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/twmb/franz-go v1.20.0 h1:j+FLLIo8wuMtp4IV7ulT5MVsQyAtl/GJqFmncIq6BkU=
-github.com/twmb/franz-go v1.20.0/go.mod h1:YCnepDd4gl6vdzG03I5Wa57RnCTIC6DVEyMpDX/J8UA=
+github.com/twmb/franz-go v1.20.1 h1:ql6+OXi0DPJPSEeOY2zApQu+IssoRLTazl+u2cy5xAo=
+github.com/twmb/franz-go v1.20.1/go.mod h1:YCnepDd4gl6vdzG03I5Wa57RnCTIC6DVEyMpDX/J8UA=
 github.com/twmb/franz-go/pkg/kadm v1.15.0 h1:Yo3NAPfcsx3Gg9/hdhq4vmwO77TqRRkvpUcGWzjworc=
 github.com/twmb/franz-go/pkg/kadm v1.15.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
 github.com/twmb/franz-go/pkg/kmsg v1.12.0 h1:CbatD7ers1KzDNgJqPbKOq0Bz/WLBdsTH75wgzeVaPc=

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -577,7 +577,7 @@ func TestIssue1142(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	resp, err := client.BrokerMetadata(ctx)
+	resp, err := client.Metadata(ctx)
 	if err != nil {
 		t.Fatal(err)
 		return


### PR DESCRIPTION
The new test originally used BrokerMetadata which returns broker information only (no topics).

Checking for all topics was added as a suggestion, but BrokerMetadata was kept -- this was masked because I requested moving the kfake test to a new PR, and then merged it pre-emptively because eh, it's kinda a pain to have kfake be dependent on franz-go and then adding tests for a new franz-go release that hasn't been cut yet.

Anyway, in the process of bumping the dep, the test started failing; this is the small fix.