### PR TITLE
kfake: bump deps, improve test

### DIFF
--- a/pkg/kfake/go.mod
+++ b/pkg/kfake/go.mod
@@ -4,12 +4,12 @@ go 1.24.0
 
 require (
 	github.com/twmb/franz-go v1.20.1
-	github.com/twmb/franz-go/pkg/kadm v1.15.0
+	github.com/twmb/franz-go/pkg/kadm v1.17.1
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0
 	golang.org/x/crypto v0.43.0
 )
 
 require (
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 )

--- a/pkg/kfake/go.sum
+++ b/pkg/kfake/go.sum
@@ -1,11 +1,11 @@
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
+github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/twmb/franz-go v1.20.1 h1:ql6+OXi0DPJPSEeOY2zApQu+IssoRLTazl+u2cy5xAo=
 github.com/twmb/franz-go v1.20.1/go.mod h1:YCnepDd4gl6vdzG03I5Wa57RnCTIC6DVEyMpDX/J8UA=
-github.com/twmb/franz-go/pkg/kadm v1.15.0 h1:Yo3NAPfcsx3Gg9/hdhq4vmwO77TqRRkvpUcGWzjworc=
-github.com/twmb/franz-go/pkg/kadm v1.15.0/go.mod h1:MUdcUtnf9ph4SFBLLA/XxE29rvLhWYLM9Ygb8dfSCvw=
+github.com/twmb/franz-go/pkg/kadm v1.17.1 h1:Bt02Y/RLgnFO2NP2HVP1kd2TFtGRiJZx+fSArjZDtpw=
+github.com/twmb/franz-go/pkg/kadm v1.17.1/go.mod h1:s4duQmrDbloVW9QTMXhs6mViTepze7JLG43xwPcAeTg=
 github.com/twmb/franz-go/pkg/kmsg v1.12.0 h1:CbatD7ers1KzDNgJqPbKOq0Bz/WLBdsTH75wgzeVaPc=
 github.com/twmb/franz-go/pkg/kmsg v1.12.0/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2,7 +2,6 @@ package kfake
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -393,7 +392,6 @@ func TestIssue906(t *testing.T) {
 		kgo.ConsumeTopics("^foo.*"),
 		kgo.ConsumeRegex(),
 		kgo.AllowAutoTopicCreation(),
-		kgo.WithLogger(kgo.BasicLogger(os.Stderr, kgo.LogLevelDebug, nil)),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -567,7 +565,6 @@ func TestIssue1142(t *testing.T) {
 	client, err := kadm.NewOptClient(
 		kgo.SeedBrokers(c.ListenAddrs()...),
 		kgo.AllowAutoTopicCreation(),
-		kgo.WithLogger(kgo.BasicLogger(os.Stderr, kgo.LogLevelDebug, nil)),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -577,21 +574,23 @@ func TestIssue1142(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	resp, err := client.Metadata(ctx)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-	if resp.Cluster != "kfake" {
-		t.Fatalf("expected cluster kfake, got %s", resp.Cluster)
-	}
-	if resp.Controller != 0 {
-		t.Fatalf("expected controller 0, got %d", resp.Controller)
-	}
-	if len(resp.Brokers) != 1 {
-		t.Fatalf("expected 1 broker, got %d", len(resp.Brokers))
-	}
-	if len(resp.Topics.Names()) != 1 {
-		t.Fatalf("expected 1 topic, got %d", len(resp.Topics.Names()))
+	for i := 0; i < 2; i++ {
+		resp, err := client.Metadata(ctx)
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+		if resp.Cluster != "kfake" {
+			t.Fatalf("expected cluster kfake, got %s", resp.Cluster)
+		}
+		if resp.Controller != 0 {
+			t.Fatalf("expected controller 0, got %d", resp.Controller)
+		}
+		if len(resp.Brokers) != 1 {
+			t.Fatalf("expected 1 broker, got %d", len(resp.Brokers))
+		}
+		if len(resp.Topics.Names()) != 1 {
+			t.Fatalf("expected 1 topic, got %d", len(resp.Topics.Names()))
+		}
 	}
 }


### PR DESCRIPTION
Looping the test twice catches any problems with metadata caching where logic runs the first time when the cache does not exist, but does not run the second time when the cache does exist.