### PR TITLE
kzerolog: fixes stack frame attribution quirk

### DIFF
--- a/plugin/kzerolog/kzerolog.go
+++ b/plugin/kzerolog/kzerolog.go
@@ -47,7 +47,7 @@ func (l *Logger) Level() kgo.LogLevel {
 
 // Log is for the kgo.Logger interface.
 func (l *Logger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
-	l.zl.WithLevel(logLevelToZerolog(level)).Fields(keyvals).Msg(msg)
+	l.zl.WithLevel(logLevelToZerolog(level)).Fields(keyvals).CallerSkipFrame(2).Msg(msg)
 }
 
 func logLevelToZerolog(level kgo.LogLevel) zerolog.Level {


### PR DESCRIPTION
As implemented the logger will record the stack frame of the zerolog adapter as the source of a log line rather than the actual source. This makes log messages a bit less expressive.

This diff adds `CallerSkipFrame(2)` to the `kzerolog.Logger.Log` so that log lines are properly attributed. Note that we skip two frames to hop over the wrappedLogger.

Before:

```
2025-11-06T08:34:24-08:00 INF ../../../../go/pkg/mod/github.com/twmb/franz-go/plugin/kzerolog@v1.0.0/kzerolog.go:49 > immediate metadata update triggered component=kgo_client why="from AddConsumeTopics"
```

After:

```
2025-11-06T08:34:51-08:00 INF ../../../../go/pkg/mod/github.com/twmb/franz-go@v1.20.2/pkg/kgo/metadata.go:196 > immediate metadata update triggered component=kgo_client why="from AddConsumeTopics"
```