### PR TITLE
kgo: support arbitrary Kafka RPCs

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -188,10 +188,10 @@ func (v *brokerVersions) minVersion(key int16) int16 {
 	return -1
 }
 
-func newBrokerVersions() *brokerVersions {
+func newBrokerVersions(capacity int) *brokerVersions {
 	v := &brokerVersions{
-		maxVers:  make(map[int16]int16),
-		minVers:  make(map[int16]int16),
+		maxVers:  make(map[int16]int16, capacity),
+		minVers:  make(map[int16]int16, capacity),
 		features: make(map[string]int16),
 	}
 	return v
@@ -754,7 +754,7 @@ func (cxn *brokerCxn) init(isProduceCxn bool, tries int) error {
 		} else {
 			// We have a max versions, and it indicates no support
 			// for ApiVersions. We just store a default empty map.
-			cxn.b.storeVersions(newBrokerVersions())
+			cxn.b.storeVersions(newBrokerVersions(0))
 		}
 	}
 
@@ -854,7 +854,7 @@ start:
 		return errors.New("ApiVersions response invalidly contained no ApiKeys")
 	}
 
-	v := newBrokerVersions()
+	v := newBrokerVersions(len(resp.ApiKeys))
 	for _, key := range resp.ApiKeys {
 		v.maxVers[key.ApiKey] = key.MaxVersion
 		v.minVers[key.ApiKey] = key.MinVersion


### PR DESCRIPTION
Sometimes it is desireable to have RPCs defined outside the set that
franz-go knows about. This patch enables that by storing API versions
in a map instead of a fixed length array.

Alternative solutions that achieve this same goal I would be open to
implementing instead (since one has to use a lot of low level APIs for
all this anyways):
* Just allow skipping API version checks for keys outside the range kgo
  supports via some configuration option
* Only skip the "brokerMin/brokerMax" checks if the issued request is
  outside the range kgo knows about. At this point it's clear the user
  is issuing a custom command, and it's sort of on them to check the
  versions...
Let me know if either option is preferred, then I'd happily update this
patch.
