### PR TITLE
kgo: Do not try next broker in Client.Ping if context is done

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -615,9 +615,11 @@ func (cl *Client) Ping(ctx context.Context) error {
 			if lastErr = err; lastErr == nil {
 				cl.updateMetadataBrokers(resp.(*kmsg.MetadataResponse))
 				return nil
-			} else if ctx.Err() != nil {
+			} else if isContextErr(lastErr) && ctx.Err() != nil {
 				// No point in trying the next broker if context is done
-				// as it will create noise in OnBrokerConnect hook
+				// as it will create noise in OnBrokerConnect hook.
+				// Check both lastErr and ctx.Err() to avoid race condition
+				// where context error happens immediately after waitResp.
 				return lastErr
 			}
 		}


### PR DESCRIPTION
There is no point in trying the next broker if context is done. This will remove any unwanted noise in OnBrokerConnect hooks.

With this PR, `Ping` now returns the error immediately if context is done instead of a subsequent error like `unable to dial: dial tcp: lookup kafka.broker.example: operation was canceled`
