### PR TITLE
kgo: source.fetch stop fetching again when context is done

### DIFF
--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -871,6 +871,11 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 
 	select {
 	case <-requested:
+		// As `select` is pseudo-random when both cases are ready,
+		// check for context error in this branch to avoid retrying immediately with a failed context.
+		if isContextErr(err) && ctx.Err() != nil {
+			return fetched
+		}
 		fetched = true
 	case <-ctx.Done():
 		return fetched


### PR DESCRIPTION
As `select` is pseudo-random when both cases are ready, check for context error in requested branch to avoid retrying immediately in next iteration in fetch loop with a failed context.

This may remove `unable to dial: dial tcp: lookup kafka.broker.example: operation was canceled` noise in the consumer code path OnBrokerConnect.
