### PR TITLE
kgo: avoid updating metadata before issuing ListOffsets / OffsetForLeaderEpoch

### DIFF
--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -136,12 +136,12 @@ func (cl *Client) waitmeta(ctx context.Context, wait time.Duration, why string) 
 	cl.metawait.c.Broadcast()
 }
 
-func (cl *Client) triggerUpdateMetadata(must bool, why string) bool {
+func (cl *Client) triggerUpdateMetadata(must bool, why string) {
 	if !must {
 		cl.metawait.mu.Lock()
 		defer cl.metawait.mu.Unlock()
 		if time.Since(cl.metawait.lastUpdate) < cl.cfg.metadataMinAge {
-			return false
+			return
 		}
 	}
 
@@ -149,7 +149,6 @@ func (cl *Client) triggerUpdateMetadata(must bool, why string) bool {
 	case cl.updateMetadataCh <- why:
 	default:
 	}
-	return true
 }
 
 func (cl *Client) triggerUpdateMetadataNow(why string) {

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1023,16 +1023,12 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- struct
 	// reload offsets *always* triggers a metadata update.
 	if updateWhy != nil {
 		why := updateWhy.reason(fmt.Sprintf("fetch had inner topic errors from broker %d", s.nodeID))
-		// loadWithSessionNow triggers a metadata update IF there are
-		// offsets to reload. If there are no offsets to reload, we
-		// trigger one here.
-		if !reloadOffsets.loadWithSessionNow(consumerSession, why) {
-			if updateWhy.isOnly(kerr.UnknownTopicOrPartition) || updateWhy.isOnly(kerr.UnknownTopicID) {
-				s.cl.triggerUpdateMetadata(false, why)
-			} else {
-				s.cl.triggerUpdateMetadataNow(why)
-			}
+		if updateWhy.isOnly(kerr.UnknownTopicOrPartition) || updateWhy.isOnly(kerr.UnknownTopicID) {
+			s.cl.triggerUpdateMetadata(false, why)
+		} else {
+			s.cl.triggerUpdateMetadataNow(why)
 		}
+		reloadOffsets.loadWithSession(consumerSession)
 	}
 
 	if fetch.hasErrorsOrRecords() {

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -957,5 +957,5 @@ func (css *consumerSessionStopper) maybeRestart() {
 	}
 	session := css.cl.consumer.startNewSession(css.tpsPrior)
 	defer session.decWorker()
-	css.reloadOffsets.loadWithSession(session, "resuming reload offsets after session stopped for cursor migrating in metadata")
+	css.reloadOffsets.loadWithSession(session)
 }


### PR DESCRIPTION
The metadata update was added originally with the thinking that we needed the most up to date metadata so that we could issue these requests correctly.

I *think* automatic request sharding came later? Not sure, but anyway, ListOffsets and OffsetForLeaderEpoch don't use the metadata that that triggerUpdateMetadata updates anyway: triggerUpdateMetadata updates the main metadata used for producing & consuming, whereas all admin requests use a cached metadata. The cache already evicts topics or partitions that have errors.

Point is, the metadata update in listOrEpoch, at this point, existed only to have a bit of a pause to collapse many listOrEpoch calls into one chunk of running logic.

Removing the whole metadata updating makes it easier to reason about (do we need to update metadata now, or later?), and we can keep the same listOrEpoch coalescing behavior by waiting 5s on retries and merging ever listOrEpoch that fires during those 5s.

It's possible that users may see 5s pauses in some scenarios where they previously would not: a retry may pause things while other non-retry requests are trying to come in. In general we can point to retry collapsing being better anyway, but if the need arises, we can separate the wait to ONLY happen on requests that are retrying, and to ALWAYS allow non-retrying requests to go through ASAP with no merging.