### PR TITLE
kfake: harden fetch and group assignment encoding

### DIFF
--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -129,6 +129,11 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		sp := kmsg.NewFetchResponseTopicPartition()
 		sp.Partition = p
 		sp.ErrorCode = errCode
+		// Encode empty record sets as an empty-but-present byte slice rather
+		// than null. A nil slice would be serialized as a length of -1 (or 0
+		// in the compact-nullable form), which some clients (for example,
+		// librdkafka) interpret as an invalid MessageSet size.
+		sp.RecordBatches = make([]byte, 0)
 		st := donet(t, id, 0)
 		st.Partitions = append(st.Partitions, sp)
 		return &st.Partitions[len(st.Partitions)-1]

--- a/pkg/kfake/client_conn.go
+++ b/pkg/kfake/client_conn.go
@@ -90,7 +90,7 @@ func (cc *clientConn) read() {
 			kmsg.SkipTags(&reader)
 		}
 		if err := kreq.ReadFrom(reader.Src); err != nil {
-			cc.c.cfg.logger.Logf(LogLevelDebug, "client %s unable to parse request: %v", who, err)
+			cc.c.cfg.logger.Logf(LogLevelDebug, "client %s unable to parse request (key=%d, version=%d): %v", who, key, version, err)
 			return
 		}
 
@@ -150,21 +150,20 @@ func (cc *clientConn) write() {
 			return
 		}
 
-		// Size, corr, and empty tag section if flexible: 9 bytes max.
-		buf = append(buf[:0], 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		buf = buf[:0]
+		buf = append(buf, 0, 0, 0, 0, 0, 0, 0, 0)
+		hasFlexHeader := resp.kresp.IsFlexible() && resp.kresp.Key() != 18
+		if hasFlexHeader {
+			buf = append(buf, 0) // zero tagged fields
+		}
 		buf = resp.kresp.AppendTo(buf)
 
-		start := 0
-		l := len(buf) - 4
-		if !resp.kresp.IsFlexible() || resp.kresp.Key() == 18 {
-			l--
-			start++
-		}
-		binary.BigEndian.PutUint32(buf[start:], uint32(l))
-		binary.BigEndian.PutUint32(buf[start+4:], uint32(resp.corr))
+		binary.BigEndian.PutUint32(buf[:4], uint32(len(buf)-4))
+		binary.BigEndian.PutUint32(buf[4:8], uint32(resp.corr))
 
+		payload := append([]byte(nil), buf...)
 		go func() {
-			_, err := cc.conn.Write(buf[start:])
+			_, err := cc.conn.Write(payload)
 			writeCh <- err
 		}()
 

--- a/pkg/kfake/groups_assignment_test.go
+++ b/pkg/kfake/groups_assignment_test.go
@@ -1,0 +1,173 @@
+package kfake
+
+import (
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func TestCompleteLeaderSyncEmitsEmptyAssignment(t *testing.T) {
+	c := newTestCluster()
+	defer close(c.die)
+
+	b := &broker{c: c, node: 0}
+	c.bs = []*broker{b}
+
+	g := (&groups{c: c}).newGroup("group")
+	g.protocolType = "consumer"
+	g.protocol = "range"
+	g.generation = 1
+	g.state = groupCompletingRebalance
+	g.leader = "leader"
+
+	leader := newTestGroupMember("leader")
+	follower := newTestGroupMember("follower")
+	g.members = map[string]*groupMember{
+		leader.memberID:   leader,
+		follower.memberID: follower,
+	}
+
+	leaderReq := newSyncClientReq(c, b, "group", leader.memberID, g.generation)
+	followerReq := newSyncClientReq(c, b, "group", follower.memberID, g.generation)
+	leader.waitingReply = leaderReq
+	follower.waitingReply = followerReq
+
+	leaderSync := leaderReq.kreq.(*kmsg.SyncGroupRequest)
+	leaderSync.GroupAssignment = append(leaderSync.GroupAssignment, newSyncAssignment("leader", map[string][]int32{
+		"t": {0},
+	}))
+
+	g.completeLeaderSync(leaderSync)
+
+	leaderResp := <-leaderReq.cc.respCh
+	followerResp := <-followerReq.cc.respCh
+
+	assertAssignment(t, leaderResp, func(a *kmsg.ConsumerMemberAssignment) {
+		if len(a.Topics) != 1 || a.Topics[0].Topic != "t" || len(a.Topics[0].Partitions) != 1 || a.Topics[0].Partitions[0] != 0 {
+			t.Fatalf("expected leader assignment topic t/0, got %#v", a.Topics)
+		}
+	})
+
+	assertAssignment(t, followerResp, func(a *kmsg.ConsumerMemberAssignment) {
+		if len(a.Topics) != 0 {
+			t.Fatalf("expected follower assignment to be empty, got %#v", a.Topics)
+		}
+	})
+
+	stopMemberTimer(leader)
+	stopMemberTimer(follower)
+}
+
+func TestHandleSyncStableReturnsEmptyAssignment(t *testing.T) {
+	c := newTestCluster()
+	defer close(c.die)
+
+	b := &broker{c: c, node: 0}
+	c.bs = []*broker{b}
+
+	g := (&groups{c: c}).newGroup("group")
+	g.protocolType = "consumer"
+	g.protocol = "range"
+	g.generation = 3
+	g.state = groupStable
+
+	member := newTestGroupMember("member")
+	g.members = map[string]*groupMember{
+		member.memberID: member,
+	}
+
+	req := newSyncClientReq(c, b, "group", member.memberID, g.generation)
+	resp := g.handleSync(req)
+
+	sgResp, ok := resp.(*kmsg.SyncGroupResponse)
+	if !ok {
+		t.Fatalf("expected SyncGroupResponse, got %T", resp)
+	}
+	var assn kmsg.ConsumerMemberAssignment
+	if err := assn.ReadFrom(sgResp.MemberAssignment); err != nil {
+		t.Fatalf("failed to decode assignment: %v", err)
+	}
+	if len(assn.Topics) != 0 {
+		t.Fatalf("expected empty assignment, got %#v", assn.Topics)
+	}
+}
+
+func newTestCluster() *Cluster {
+	c := &Cluster{
+		cfg: cfg{
+			minSessionTimeout: time.Second,
+			maxSessionTimeout: time.Minute,
+		},
+		die: make(chan struct{}),
+	}
+	c.groups.c = c
+	return c
+}
+
+func newTestGroupMember(id string) *groupMember {
+	return &groupMember{
+		memberID: id,
+		join: &kmsg.JoinGroupRequest{
+			ProtocolType:           "consumer",
+			Protocols:              []kmsg.JoinGroupRequestProtocol{{Name: "range"}},
+			SessionTimeoutMillis:   int32((10 * time.Minute) / time.Millisecond),
+			RebalanceTimeoutMillis: int32((10 * time.Minute) / time.Millisecond),
+		},
+	}
+}
+
+func newSyncClientReq(c *Cluster, b *broker, group, member string, generation int32) *clientReq {
+	req := kmsg.NewPtrSyncGroupRequest()
+	req.Version = 5
+	req.Group = group
+	req.MemberID = member
+	req.Generation = generation
+	req.ProtocolType = kmsg.StringPtr("consumer")
+	req.Protocol = kmsg.StringPtr("range")
+	cc := &clientConn{
+		c:      c,
+		b:      b,
+		respCh: make(chan clientResp, 1),
+	}
+	return &clientReq{
+		cc:   cc,
+		kreq: req,
+	}
+}
+
+func newSyncAssignment(member string, topics map[string][]int32) kmsg.SyncGroupRequestGroupAssignment {
+	var assignment kmsg.ConsumerMemberAssignment
+	for topic, partitions := range topics {
+		topicAssignment := kmsg.NewConsumerMemberAssignmentTopic()
+		topicAssignment.Topic = topic
+		topicAssignment.Partitions = append([]int32(nil), partitions...)
+		assignment.Topics = append(assignment.Topics, topicAssignment)
+	}
+	sg := kmsg.NewSyncGroupRequestGroupAssignment()
+	sg.MemberID = member
+	sg.MemberAssignment = assignment.AppendTo(nil)
+	return sg
+}
+
+func assertAssignment(t *testing.T, resp clientResp, fn func(*kmsg.ConsumerMemberAssignment)) {
+	t.Helper()
+	sgResp, ok := resp.kresp.(*kmsg.SyncGroupResponse)
+	if !ok {
+		t.Fatalf("expected SyncGroupResponse, got %T", resp.kresp)
+	}
+	if len(sgResp.MemberAssignment) == 0 {
+		t.Fatalf("expected non-empty assignment payload")
+	}
+	var assn kmsg.ConsumerMemberAssignment
+	if err := assn.ReadFrom(sgResp.MemberAssignment); err != nil {
+		t.Fatalf("failed to decode assignment: %v", err)
+	}
+	fn(&assn)
+}
+
+func stopMemberTimer(m *groupMember) {
+	if m != nil && m.t != nil {
+		m.t.Stop()
+	}
+}

--- a/pkg/kfake/seed_topics_test.go
+++ b/pkg/kfake/seed_topics_test.go
@@ -1,0 +1,47 @@
+package kfake
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// TestSeedTopicsProduceSync_NoHang verifies that producing to a topic created
+// via SeedTopics succeeds without hanging in the client metadata path.
+func TestSeedTopicsProduceSync_NoHang(t *testing.T) {
+	const topic = "test_seed_topic"
+
+	cluster, err := NewCluster(SeedTopics(1, topic))
+	if err != nil {
+		t.Fatalf("NewCluster failed: %v", err)
+	}
+	defer cluster.Close()
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(cluster.ListenAddrs()...),
+	)
+	if err != nil {
+		t.Fatalf("NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer pingCancel()
+	if err := client.Ping(pingCtx); err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+
+	produceCtx, produceCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer produceCancel()
+
+	results := client.ProduceSync(produceCtx,
+		&kgo.Record{Topic: topic, Value: []byte("value1")},
+		&kgo.Record{Topic: topic, Value: []byte("value2")},
+	)
+	if err := results.FirstErr(); err != nil {
+		t.Fatalf("ProduceSync FirstErr: %v", err)
+	}
+}
+


### PR DESCRIPTION
* Ensure fetch responses always include non-nil `RecordBatches` so empty/error partitions encode as empty-but-present record sets, matching Kafka clients such as `librdkafka`.

* Fix race condition in `client_conn` response writing: the old code reused a single `buf` slice across the response loop and passed `buf[start:]` directly to goroutines for writing. This meant concurrent goroutines could read corrupted data if the main loop modified `buf` for the next response before the previous write completed. The fix copies `buf` into a goroutine-local `payload` slice before launching each write goroutine, ensuring each concurrent writer has an independent snapshot of the response data.

* Simplify `client_conn` request parsing and response framing for flexible vs non-flexible responses, and improve debug logging with request key/version.

* Guarantee group member assignments are always encoded as syntactically valid `ConsumerMemberAssignment` blobs (even when logically empty) via `assignmentOrEmpty`/`ensureMemberAssignment`, so followers and stable members can always decode assignments.

* Add `groups_assignment_test` to exercise `completeLeaderSync` and `handleSync` for leader/follower members, and `seed_topics_test` to verify `SeedTopics`-created topics work with `ProduceSync`/`Ping` against `SeedTopics`-created topics.

* Scope all changes to `pkg/kfake` and tests; no exported API or kgo client semantics are modified.