### PR TITLE
kgo: fix mark <=> epoch interaction, make epoch handling more resilient

### DIFF
--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -926,8 +926,20 @@ func (cl *Client) mergeTopicPartitions(
 	for _, newTP := range newPartitions {
 		if isProduce && newTP.records.recBufsIdx == -1 {
 			newTP.records.sink.addRecBuf(newTP.records)
+			cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new produce partition",
+				"topic", topic,
+				"partition", newTP.partition(),
+				"leader", newTP.leader,
+				"leader_epoch", newTP.leaderEpoch,
+			)
 		} else if !isProduce && newTP.cursor.cursorsIdx == -1 {
 			newTP.cursor.source.addCursor(newTP.cursor)
+			cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new consume partition",
+				"topic", topic,
+				"partition", newTP.partition(),
+				"leader", newTP.leader,
+				"leader_epoch", newTP.leaderEpoch,
+			)
 		}
 	}
 }

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -624,7 +624,7 @@ func (p *producer) finishPromises(b batchPromise) {
 	}()
 start:
 	for i, pr := range b.recs {
-		pr.LeaderEpoch = 0
+		pr.LeaderEpoch = -1
 		if b.baseOffset == -1 {
 			// if the base offset is invalid/unknown (-1), all record offsets should
 			// be treated as unknown

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -130,7 +130,9 @@ type Record struct {
 	ProducerID int64
 
 	// LeaderEpoch is the leader epoch of the broker at the time this
-	// record was written, or -1 if on message sets.
+	// record was written, or -1 if on message sets. When producing,
+	// this is always set to -1 (producers do not use this field and the
+	// broker does not reply with the epoch).
 	//
 	// For committing records, it is not recommended to modify the
 	// LeaderEpoch. Clients use the LeaderEpoch for data loss detection.


### PR DESCRIPTION
MarkCommit{Records,Offsets} compared the epoch/offset you were marking against the existing head epoch/offset. If the there was no internally existing epoch/offset, or only `dirty` was set (via being consumed) while `head` / `committed` were both the default struct value {0,0}, then trying to mark a record with a negative epoch would be ignored.

Note that returning -1 via the broker epoch requires a broker to both (a) SUPPORT epochs, i.e. implement all the Kafka APIs with leader epoch support, and then (b) NOT SUPPORT epochs, i.e. return / use -1 everywhere. This has only been seen against Azure Event hubs.

Anyway, now, when initializing an EpochOffset internally (for an uncommit {dirty,head,committed}, the epoch is explicitly initialized with -1. Further, for added robustness, MarkCommit{Records,Offsets} only compares against existing values -- if a value does not exist, we auto-accept the mark.

This commit also:
* Improves EpochOffset.Less to assume all negative epochs are -1
* Simplifies the logic in CommitRecords to use EpochOffset.Less
* Adds debug lines in metadata when new partitions are added
* Adds the epoch to an existing debug log line when updating uncommitted
* Sets the LeaderEpoch to -1 for records when producing, and clarifies in docs that -1 should have always been the case.