### PR TITLE
Include uncompressed/compressed message size in MessageTooLarge error

### DIFF
--- a/pkg/kerr/kerr.go
+++ b/pkg/kerr/kerr.go
@@ -83,7 +83,7 @@ var (
 	RequestTimedOut                    = &Error{"REQUEST_TIMED_OUT", 7, true, "The request timed out."}
 	BrokerNotAvailable                 = &Error{"BROKER_NOT_AVAILABLE", 8, true, "The broker is not available."}
 	ReplicaNotAvailable                = &Error{"REPLICA_NOT_AVAILABLE", 9, true, "The replica is not available for the requested topic-partition."}
-	MessageTooLarge                    = &Error{"MESSAGE_TOO_LARGE", 10, false, "The request included a message larger than the max message size the server will accept."}
+	MessageTooLarge                    = &Error{"MESSAGE_TOO_LARGE", 10, false, "The request included a message larger than the max message size the server will accept"} /* error description doesn't have period at the end as more info would be appended to it upstream */
 	StaleControllerEpoch               = &Error{"STALE_CONTROLLER_EPOCH", 11, false, "The controller moved to another broker."}
 	OffsetMetadataTooLarge             = &Error{"OFFSET_METADATA_TOO_LARGE", 12, false, "The metadata field of the offset request was too large."}
 	NetworkException                   = &Error{"NETWORK_EXCEPTION", 13, true, "The server disconnected before a response was received."}

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -260,18 +260,18 @@ var randsha = func() func() string {
 	}
 }()
 
-func tmpTopic(tb testing.TB) (string, func()) {
+func tmpTopic(tb testing.TB, configs ...kmsg.CreateTopicsRequestTopicConfig) (string, func()) {
 	partitions := npartitions[int(atomic.AddInt64(&npartitionsAt, 1))%len(npartitions)]
 	topic := randsha()
-	return tmpNamedTopicPartitions(tb, topic, partitions)
+	return tmpNamedTopicPartitions(tb, topic, partitions, configs...)
 }
 
-func tmpTopicPartitions(tb testing.TB, partitions int) (string, func()) {
+func tmpTopicPartitions(tb testing.TB, partitions int, configs ...kmsg.CreateTopicsRequestTopicConfig) (string, func()) {
 	topic := randsha()
-	return tmpNamedTopicPartitions(tb, topic, partitions)
+	return tmpNamedTopicPartitions(tb, topic, partitions, configs...)
 }
 
-func tmpNamedTopicPartitions(tb testing.TB, topic string, partitions int) (string, func()) {
+func tmpNamedTopicPartitions(tb testing.TB, topic string, partitions int, configs ...kmsg.CreateTopicsRequestTopicConfig) (string, func()) {
 	tb.Helper()
 
 	req := kmsg.NewPtrCreateTopicsRequest()
@@ -279,6 +279,7 @@ func tmpNamedTopicPartitions(tb testing.TB, topic string, partitions int) (strin
 	reqTopic.Topic = topic
 	reqTopic.NumPartitions = int32(partitions)
 	reqTopic.ReplicationFactor = int16(testrf)
+	reqTopic.Configs = append(reqTopic.Configs, configs...)
 	req.Topics = append(req.Topics, reqTopic)
 
 	start := time.Now()

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -35,8 +35,6 @@ type producer struct {
 		unbuffered  []HookProduceRecordUnbuffered
 	}
 
-	hasHookBatchWritten bool
-
 	// unknownTopics buffers all records for topics that are not loaded.
 	// The map is to a pointer to a slice for reasons documented in
 	// waitUnknownTopic.
@@ -203,9 +201,6 @@ func (p *producer) init(cl *Client) {
 		if h, ok := h.(HookProduceRecordUnbuffered); ok {
 			inithooks()
 			p.hooks.unbuffered = append(p.hooks.unbuffered, h)
-		}
-		if _, ok := h.(HookProduceBatchWritten); ok {
-			p.hasHookBatchWritten = true
 		}
 	})
 }

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -484,7 +484,10 @@ func (cl *Client) produce(
 
 	userSize := r.userSize()
 	if cl.cfg.maxBufferedBytes > 0 && userSize > cl.cfg.maxBufferedBytes {
-		p.promiseRecordBeforeBuf(promisedRec{ctx, promise, r}, kerr.MessageTooLarge)
+		p.promiseRecordBeforeBuf(
+			promisedRec{ctx, promise, r},
+			fmt.Errorf("%w (uncompressed_bytes=%d).", kerr.MessageTooLarge, userSize),
+		)
 		return
 	}
 

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -88,7 +88,6 @@ func (s *sink) createReq(id int64, epoch int16) (*produceRequest, *kmsg.AddParti
 		producerID:    id,
 		producerEpoch: epoch,
 
-		hasHook:    s.cl.producer.hasHookBatchWritten,
 		compressor: s.cl.cfg.compressor,
 
 		wireLength:      s.cl.baseProduceRequestLength(), // start length with no topics
@@ -1788,7 +1787,6 @@ type produceRequest struct {
 	//
 	// We use this in handleReqResp for the OnProduceHook.
 	metrics produceMetrics
-	hasHook bool
 
 	compressor Compressor
 


### PR DESCRIPTION
Fixes [1204](https://github.com/twmb/franz-go/issues/1204)

Error message when originated from client-side:

`MESSAGE_TOO_LARGE: The request included a message larger than the max message size the server will accept (uncompressed_bytes=100000500).`

Error message when originated from broker-side:

`MESSAGE_TOO_LARGE: The request included a message larger than the max message size the server will accept (uncompressed_bytes=100000513, compressed_bytes=5000045)`