### PR TITLE
kadm: fix ListTopics filtering internal topics when explicitly requested

### DIFF
--- a/pkg/kadm/topics.go
+++ b/pkg/kadm/topics.go
@@ -26,7 +26,11 @@ func (cl *Client) ListTopics(
 	if err != nil {
 		return nil, err
 	}
-	t.FilterInternal()
+	// Only filter internal topics when listing all topics (no specific topics requested).
+	// If specific topics are named, include them even if they are internal.
+	if len(topics) == 0 {
+		t.FilterInternal()
+	}
 	return t, nil
 }
 


### PR DESCRIPTION
`ListTopics` was filtering internal topics even when explicitly requested by name, breaking `ListStartOffsets`/`ListEndOffsets` for topics like `__consumer_offsets`. This fix only applies `FilterInternal` when listing all topics (no specific topics requested). Fixes the documented behavior that internal topics should be included when specifically requested.