### PR TITLE
kfake: harden fetch and group assignment encoding

### DIFF
--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -233,6 +233,11 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		sp := kmsg.NewFetchResponseTopicPartition()
 		sp.Partition = p
 		sp.ErrorCode = errCode
+		// Encode empty record sets as an empty-but-present byte slice rather
+		// than null. Technically the protocol allows nullable records here,
+		// but some clients (e.g. librdkafka) interpret a nil slice (length -1)
+		// as an invalid MessageSet size.
+		sp.RecordBatches = []byte{}
 		st := donet(t, id)
 		st.Partitions = append(st.Partitions, sp)
 		return &st.Partitions[len(st.Partitions)-1]


### PR DESCRIPTION
Based on PR #1187 from @cjohnson-confluent, with modifications:

- Simplify client_conn response framing for flexible vs non-flexible responses
- Improve debug logging with request key/version on parse failures
- Ensure fetch responses encode empty record sets as empty-but-present byte slices rather than null, for compatibility with clients like librdkafka
- Guarantee group member assignments are encoded as syntactically valid ConsumerMemberAssignment blobs when empty, scoped to "consumer" protocol type only (other protocol types may use different assignment formats)

Closes #1187