### PR TITLE
kfake: remove PartitionLeaderEpoch validation

### DIFF
--- a/pkg/kfake/00_produce.go
+++ b/pkg/kfake/00_produce.go
@@ -143,10 +143,10 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 				donep(rt, rp, kerr.CorruptMessage.Code, "Batch length mismatch.")
 				continue
 			}
-			if b.PartitionLeaderEpoch != -1 {
-				donep(rt, rp, kerr.CorruptMessage.Code, "Partition leader epoch must be -1.")
-				continue
-			}
+			// PartitionLeaderEpoch is not validated: real Kafka brokers
+			// overwrite this field with the current leader epoch. Clients
+			// send different values (franz-go sends -1, Sarama sends 0).
+
 			if b.Magic != 2 {
 				donep(rt, rp, kerr.CorruptMessage.Code, "Unsupported message format version.")
 				continue


### PR DESCRIPTION
## Summary

Real Kafka brokers overwrite the `PartitionLeaderEpoch` field with the current leader epoch when processing produce requests - they don't validate the value sent by the client. This field is deliberately excluded from CRC computation to make this overwrite efficient.

This strict validation in kfake caused it to reject produce requests from Sarama, which sends `0` instead of `-1` for this field. By removing the validation, kfake now matches real Kafka behavior and works with all clients.

Fixes #1229

## Changes

- Removed the `PartitionLeaderEpoch != -1` check in `pkg/kfake/00_produce.go`
- Added a comment explaining why the field is not validated

## Testing

All existing kfake tests pass.