### PR TITLE
kgo: fix data race in allowUsable reading c.source after Swap

### DIFF
--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -203,11 +203,16 @@ func (c *cursor) usable() bool {
 }
 
 // allowUsable allows a cursor to be fetched, and is called either in assigning
-// offsets, or when a buffered fetch is taken or discarded,  or when listing /
+// offsets, or when a buffered fetch is taken or discarded, or when listing /
 // epoch loading finishes.
+//
+// We capture c.source before Swap because Swap makes this cursor immediately
+// eligible for fetching. With kfake (in-process), a fetch can complete and
+// move() can overwrite c.source before we reach maybeConsume.
 func (c *cursor) allowUsable() {
+	s := c.source
 	c.useState.Swap(true)
-	c.source.maybeConsume()
+	s.maybeConsume()
 }
 
 // setOffset sets the cursors offset which will be used the next time a fetch


### PR DESCRIPTION
After useState.Swap(true), the cursor is immediately eligible for fetching. If a source's loopFetch picks it up, completes a fetch, and the response triggers move() (preferred replica migration), move() writes c.source before allowUsable finishes reading it for maybeConsume. Capture c.source before the Swap to ensure the read happens-before any concurrent write.

In practice this is very low severity: it requires an in-process broker (kfake) for the fetch round-trip to complete between the Swap and the subsequent read, and on all mainstream architectures (x86-64, ARM64) naturally aligned pointer-sized reads and writes are atomic at the hardware level, so even if the race occurs the pointer is never torn. The worst outcome would be calling maybeConsume on the old source (a no-op since move already removed the cursor), while move's addCursor already triggers maybeConsume on the new source.