### PR TITLE
kgo: cap reap ticker interval at 20s

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -619,7 +619,7 @@ func (cl *Client) reapConnectionsLoop() {
 		return
 	}
 
-	ticker := time.NewTicker(idleTimeout)
+	ticker := time.NewTicker(min(20*time.Second, idleTimeout))
 	defer ticker.Stop()
 	last := time.Now()
 	for {

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -665,9 +665,8 @@ func RequestTimeoutOverhead(overhead time.Duration) Opt {
 // ConnIdleTimeout is a rough amount of time to allow connections to idle
 // before they are closed, overriding the default 20s.
 //
-// In the worst case, a connection can be allowed to idle for up to 2x this
-// time, while the average is expected to be 1.5x (essentially, a uniform
-// distribution from this interval to 2x the interval).
+// Connections are evaluated for reaping every min(20s, connIdleTimeout),
+// so the worst case idle time is roughly timeout + min(20s, timeout).
 //
 // It is possible that a connection can be reaped just as it is about to be
 // written to, but the client internally retries in these cases.


### PR DESCRIPTION
The reap ticker previously fired at connIdleTimeout, meaning connections could idle for up to 2x the configured timeout before being reaped. For large timeouts (e.g. 9 minutes), the worst case idle time of 18 minutes can exceed typical server-side connections.max.idle.ms.

Evaluate connections every min(20s, connIdleTimeout) so worst-case idle is timeout + min(20s, timeout). For timeouts <= 20s, behavior is unchanged.
```
  connIdleTimeout | Reap interval | Worst-case idle
  1s (min)        | 1s            | 2s (unchanged)
  20s (default)   | 20s           | 40s (unchanged)
  1m              | 20s           | 1m20s (was 2m)
  9m              | 20s           | 9m20s (was 18m)
```
Closes #1231