### PR TITLE
kfake: add tests for issue 1217 batch poisoning

### DIFF
--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1152,7 +1152,7 @@ func (s *sink) handleRetryBatches(
 			return
 		}
 
-		if canFail || s.cl.cfg.disableIdempotency {
+		if (canFail && !batch.unsureIfProduced) || s.cl.cfg.disableIdempotency {
 			if err := batch.maybeFailErr(&s.cl.cfg); err != nil {
 				batch.owner.failAllRecords(err)
 				return


### PR DESCRIPTION
kgo: guard unsureIfProduced in handleRetryBatches

After handleReqRespBatch correctly decides to retry a poisoned batch (unsureIfProduced=true), handleRetryBatches independently called maybeFailErr which could fail the batch when tries exceeded recordRetries. This was a missing guard from the original fix.

Tested in TestIssue1217/request_timed_out: the batch receives REQUEST_TIMED_OUT (poisoned), then NOT_LEADER_FOR_PARTITION with RecordRetries(1). Without this fix, handleRetryBatches fails the batch with ErrRecordRetries on the second response.