### PR TITLE
kgo: add ProducerBatchMaxBytesFn for per-topic batch size limits

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -326,6 +326,8 @@ func (cl *Client) OptValues(opt any) []any {
 	case namefn(WithCompressor):
 		return []any{cfg.compressor}
 	case namefn(ProducerBatchMaxBytes):
+		return []any{cfg.maxRecordBatchBytes("")}
+	case namefn(ProducerBatchMaxBytesFn):
 		return []any{cfg.maxRecordBatchBytes}
 	case namefn(MaxBufferedRecords):
 		return []any{cfg.maxBufferedRecords}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -2099,7 +2099,7 @@ func (cl *Client) maxRecordBatchBytesForTopic(topic string) int32 {
 	wireLengthLimit := cl.cfg.maxBrokerWriteBytes
 
 	recordBatchLimit := wireLengthLimit - minOnePartitionBatchLength
-	if cfgLimit := cl.cfg.maxRecordBatchBytes; cfgLimit < recordBatchLimit {
+	if cfgLimit := cl.cfg.maxRecordBatchBytes(topic); cfgLimit < recordBatchLimit {
 		recordBatchLimit = cfgLimit
 	}
 	return recordBatchLimit


### PR DESCRIPTION
Users producing to multiple topics with different broker-side max.message.bytes need per-topic control over the batch max bytes. ProducerBatchMaxBytesFn(func(string) int32) follows the existing RetryTimeout/RetryTimeoutFn pattern, taking a topic name and returning the max batch size for that topic. ProducerBatchMaxBytes now delegates to ProducerBatchMaxBytesFn.

Closes #1251