### PR TITLE
all: fix all lint issues and add lint.sh

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -15,34 +15,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  golangci-root:
+  golangci:
     if: github.repository == 'twmb/franz-go'
     runs-on: ubuntu-latest
-    name: "golangci-lint-root on amd64"
+    name: "golangci-lint"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-      - uses: golangci/golangci-lint-action@v7
-        with:
-          version: latest
-          args: --timeout=5m
-
-  golangci-kadm:
-    if: github.repository == 'twmb/franz-go'
-    runs-on: ubuntu-latest
-    name: "golangci-lint-kadm on amd64"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
-      - uses: golangci/golangci-lint-action@v7
-        with:
-          working-directory: pkg/kadm
-          version: latest
-          args: --timeout=5m
+      - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - run: ./lint.sh
 
   test-kfake:
     if: github.repository == 'twmb/franz-go'
@@ -60,7 +43,7 @@ jobs:
     container: golang:latest
     steps:
       - uses: actions/checkout@v4
-      - run: cd pkg/sr && go work init ../.. . && go test .
+      - run: cd pkg/sr && go work init ../.. . && go test ./... && go test -race ./...
 
   integration-test-kfake:
     if: github.repository == 'twmb/franz-go'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,6 @@ linters:
     - spancheck
     - sqlclosecheck
     - unconvert
-    - unparam
     - usestdlibvars
     - usetesting
     - wastedassign
@@ -64,6 +63,7 @@ linters:
         - evalOrder
         - ifElseChain
         - importShadow
+        - nestingReduce # stylistic - sometimes the positive condition reads better
         - ptrToRefParam
         - sloppyReassign
         - tooManyResultsChecker
@@ -85,11 +85,17 @@ linters:
     gosec:
       excludes:
         - G104
+        - G109 # int overflow from Atoi to int32 - all instances are small values (broker IDs, ports)
         - G404
         - G115
         - G117
+        - G301 # directory permissions 0o755 - standard for data directories
+        - G302 # file permissions 0o644 - standard for data files
+        - G304 # file inclusion via variable - unavoidable for any filesystem code
+        - G306 # WriteFile permissions 0o644 - standard for data files
         - G602 # https://github.com/securego/gosec/issues/1406
         - G118 # does not track cancel funcs passed to goroutines or stored in structs
+        - G703 # path traversal via taint analysis - all instances are tests or kfake persistence writing to controlled directories
 
     nolintlint:
       require-explanation: true
@@ -147,9 +153,12 @@ linters:
         - all
         - -SA1012
         - -SA1019
+        - -SA1029 # context.WithValue with string key - deliberate for 848 opt-in
         - -ST1003
         - -ST1016
         - -QF1001
+        - -QF1006 # suggests lifting break condition into for - doesn't fit when loops have multiple break conditions
+        - -QF1008 # suggests removing embedded field from selector - explicit selector is clearer
 
   exclusions:
     generated: lax
@@ -157,6 +166,16 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - pkg/kmsg/generated\.go$ # generated from generate/definitions - fix typos there, not here
+    rules:
+      - linters: [noctx] # test code doesn't need request contexts
+        path: _test\.go$
+      - linters: [revive]
+        text: "unused-parameter" # test callbacks must match required function signatures
+        path: _test\.go$
+      - linters: [revive]
+        text: "context-keys-type" # 848 opt-in uses deliberate string key
+        path: _test\.go$
 
 issues:
   max-same-issues: 0

--- a/generate/definitions/01_fetch
+++ b/generate/definitions/01_fetch
@@ -187,7 +187,7 @@ FetchResponse =>
       // LastStableOffset is the offset at which all prior offsets have
       // been "decided". Non transactional records are always decided
       // immediately, but transactional records are only decided once
-      // they are commited or aborted.
+      // they are committed or aborted.
       //
       // The LastStableOffset will always be at or under the HighWatermark.
       LastStableOffset: int64(-1) // v4+

--- a/generate/definitions/35_describe_log_dirs
+++ b/generate/definitions/35_describe_log_dirs
@@ -15,7 +15,7 @@ DescribeLogDirsResponse =>
   // The error code, or 0 if there was no error.
   ErrorCode: int16 // v3+
   // Dirs pairs log directories with the topics and partitions that are
-  // stored in those directores.
+  // stored in those directories.
   Dirs: [=>]
     // ErrorCode is the error code returned for describing log dirs.
     //

--- a/generate/definitions/65_describe_transactions
+++ b/generate/definitions/65_describe_transactions
@@ -13,7 +13,7 @@ DescribeTransactionsResponse =>
     // NOT_COORDINATOR is returned if the broker receiving this transactional
     // ID does not own the ID.
     //
-    // COORDINATOR_LOAD_IN_PROGRESS is returned if the coordiantor is laoding.
+    // COORDINATOR_LOAD_IN_PROGRESS is returned if the coordinator is loading.
     //
     // COORDINATOR_NOT_AVAILABLE is returned if the coordinator is being shutdown.
     //

--- a/generate/main.go
+++ b/generate/main.go
@@ -414,7 +414,7 @@ func main() {
 
 	{ // first parse all enums for use in definitions
 		path := filepath.Join(dir, enums)
-		f, err := os.ReadFile(path) //nolint:gosec // reading known definitions directory
+		f, err := os.ReadFile(path)
 		if err != nil {
 			die("unable to read %s: %v", path, err)
 		}
@@ -426,7 +426,7 @@ func main() {
 			continue
 		}
 		path := filepath.Join(dir, ent.Name())
-		f, err := os.ReadFile(path) //nolint:gosec // reading known definitions directory
+		f, err := os.ReadFile(path)
 		if err != nil {
 			die("unable to read %s: %v", path, err)
 		}

--- a/generate/validate_test.go
+++ b/generate/validate_test.go
@@ -157,7 +157,7 @@ func initDSL(t *testing.T) {
 		const enumsFile = "enums"
 
 		path := filepath.Join(dir, enumsFile)
-		f, err := os.ReadFile(path) //nolint:gosec // reading known definitions directory
+		f, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("reading enums: %v", err)
 		}
@@ -172,7 +172,7 @@ func initDSL(t *testing.T) {
 				continue
 			}
 			path := filepath.Join(dir, ent.Name())
-			f, err := os.ReadFile(path) //nolint:gosec // reading known definitions directory
+			f, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("reading %s: %v", path, err)
 			}
@@ -330,7 +330,7 @@ func TestValidateDSLAgainstKafkaJSON(t *testing.T) {
 	}
 
 	jsonDir := filepath.Join(kafkaDir, "clients", "src", "main", "resources", "common", "message")
-	if _, err := os.Stat(jsonDir); err != nil { //nolint:gosec // path from trusted env var
+	if _, err := os.Stat(jsonDir); err != nil {
 		t.Fatalf("Kafka message dir not found at %s: %v", jsonDir, err)
 	}
 
@@ -374,7 +374,7 @@ func TestValidateDSLAgainstKafkaJSON(t *testing.T) {
 		if !strings.HasSuffix(ent.Name(), ".json") {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(jsonDir, ent.Name())) //nolint:gosec // reading from trusted KAFKA_DIR
+		data, err := os.ReadFile(filepath.Join(jsonDir, ent.Name()))
 		if err != nil {
 			t.Fatalf("reading %s: %v", ent.Name(), err)
 		}
@@ -674,7 +674,7 @@ func TestValidateMiscDSLAgainstKafkaJSON(t *testing.T) {
 
 	for _, m := range mappings {
 		jsonPath := filepath.Join(kafkaDir, m.jsonPath)
-		data, err := os.ReadFile(jsonPath) //nolint:gosec // path is constructed from test constant + env var, not user input
+		data, err := os.ReadFile(jsonPath)
 		if err != nil {
 			t.Errorf("reading %s: %v", m.jsonPath, err)
 			continue

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+failed=0
+
+modules=(
+	.
+	pkg/kadm
+	pkg/kfake
+	pkg/kmsg
+	pkg/sr
+	pkg/sasl/kerberos
+)
+
+for mod in "${modules[@]}"; do
+	echo "==> linting $mod"
+	if ! (cd "$root/$mod" && golangci-lint run --timeout=5m "$@"); then
+		failed=1
+	fi
+	echo
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo "FAIL: lint errors found"
+	exit 1
+fi
+echo "OK: all modules passed"

--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -542,7 +542,7 @@ func (fs *fetchSessions) getOrCreate(brokerNode, sessionID, sessionEpoch int32, 
 	return session, false, 0
 }
 
-func (s *fetchSession) updatePartition(topic string, partition int32, fetchOffset int64, maxBytes int32, currentEpoch int32) {
+func (s *fetchSession) updatePartition(topic string, partition int32, fetchOffset int64, maxBytes, currentEpoch int32) {
 	if s == nil {
 		return
 	}

--- a/pkg/kfake/33_alter_configs.go
+++ b/pkg/kfake/33_alter_configs.go
@@ -36,13 +36,12 @@ func (c *Cluster) handleAlterConfigs(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
-	doner := func(n string, t kmsg.ConfigResourceType, errCode int16) *kmsg.AlterConfigsResponseResource {
+	doner := func(n string, t kmsg.ConfigResourceType, errCode int16) {
 		st := kmsg.NewAlterConfigsResponseResource()
 		st.ResourceName = n
 		st.ResourceType = t
 		st.ErrorCode = errCode
 		resp.Resources = append(resp.Resources, st)
-		return &resp.Resources[len(resp.Resources)-1]
 	}
 
 outer:
@@ -54,11 +53,9 @@ outer:
 				doner(rr.ResourceName, rr.ResourceType, kerr.ClusterAuthorizationFailed.Code)
 				continue outer
 			}
-			id := int32(-1)
 			if rr.ResourceName != "" {
 				iid, err := strconv.Atoi(rr.ResourceName)
-				id = int32(iid)
-				if err != nil || id != b.node {
+				if err != nil || int32(iid) != b.node {
 					doner(rr.ResourceName, rr.ResourceType, kerr.InvalidRequest.Code)
 					continue outer
 				}

--- a/pkg/kfake/34_alter_replica_log_dirs.go
+++ b/pkg/kfake/34_alter_replica_log_dirs.go
@@ -56,13 +56,12 @@ func (c *Cluster) handleAlterReplicaLogDirs(creq *clientReq) (kmsg.Response, err
 		resp.Topics = append(resp.Topics, st)
 		return &resp.Topics[len(resp.Topics)-1]
 	}
-	donep := func(t string, p int32, errCode int16) *kmsg.AlterReplicaLogDirsResponseTopicPartition {
+	donep := func(t string, p int32, errCode int16) {
 		sp := kmsg.NewAlterReplicaLogDirsResponseTopicPartition()
 		sp.Partition = p
 		sp.ErrorCode = errCode
 		st := donet(t)
 		st.Partitions = append(st.Partitions, sp)
-		return &st.Partitions[len(st.Partitions)-1]
 	}
 
 	for _, rd := range req.Dirs {

--- a/pkg/kfake/43_elect_leaders.go
+++ b/pkg/kfake/43_elect_leaders.go
@@ -70,9 +70,9 @@ func (c *Cluster) handleElectLeaders(creq *clientReq) (kmsg.Response, error) {
 				pd, ok := c.data.tps.getp(rt.Topic, p)
 				if !ok {
 					donep(rt.Topic, p, kerr.UnknownTopicOrPartition.Code)
-				} else {
-					elect(rt.Topic, p, pd)
+					continue
 				}
+				elect(rt.Topic, p, pd)
 			}
 		}
 	}

--- a/pkg/kfake/44_incremental_alter_configs.go
+++ b/pkg/kfake/44_incremental_alter_configs.go
@@ -36,13 +36,12 @@ func (c *Cluster) handleIncrementalAlterConfigs(creq *clientReq) (kmsg.Response,
 		return nil, err
 	}
 
-	doner := func(n string, t kmsg.ConfigResourceType, errCode int16) *kmsg.IncrementalAlterConfigsResponseResource {
+	doner := func(n string, t kmsg.ConfigResourceType, errCode int16) {
 		st := kmsg.NewIncrementalAlterConfigsResponseResource()
 		st.ResourceName = n
 		st.ResourceType = t
 		st.ErrorCode = errCode
 		resp.Resources = append(resp.Resources, st)
-		return &resp.Resources[len(resp.Resources)-1]
 	}
 
 outer:
@@ -54,11 +53,9 @@ outer:
 				doner(rr.ResourceName, rr.ResourceType, kerr.ClusterAuthorizationFailed.Code)
 				continue outer
 			}
-			id := int32(-1)
 			if rr.ResourceName != "" {
 				iid, err := strconv.Atoi(rr.ResourceName)
-				id = int32(iid)
-				if err != nil || id != b.node {
+				if err != nil || int32(iid) != b.node {
 					doner(rr.ResourceName, rr.ResourceType, kerr.InvalidRequest.Code)
 					continue outer
 				}

--- a/pkg/kfake/48_describe_client_quotas.go
+++ b/pkg/kfake/48_describe_client_quotas.go
@@ -94,6 +94,8 @@ func matchesQuotaFilter(quota quotaEntry, components []kmsg.DescribeClientQuotas
 			if !exists || name == nil {
 				return false
 			}
+		default:
+			return false
 		}
 	}
 

--- a/pkg/kfake/51_alter_user_scram_credentials.go
+++ b/pkg/kfake/51_alter_user_scram_credentials.go
@@ -50,10 +50,9 @@ func (c *Cluster) handleAlterUserSCRAMCredentials(creq *clientReq) (kmsg.Respons
 		resp.Results = append(resp.Results, sr)
 		return &resp.Results[len(resp.Results)-1]
 	}
-	doneu := func(u string, code int16) *kmsg.AlterUserSCRAMCredentialsResponseResult {
+	doneu := func(u string, code int16) {
 		sr := addr(u)
 		sr.ErrorCode = code
-		return sr
 	}
 
 	users := make(map[string]int16)

--- a/pkg/kfake/acl.go
+++ b/pkg/kfake/acl.go
@@ -55,16 +55,23 @@ func (a *acl) matchesOp(op kmsg.ACLOperation) bool {
 	// Implied permissions only for ALLOW:
 	// DESCRIBE implied by READ, WRITE, DELETE, ALTER
 	// DESCRIBE_CONFIGS implied by ALTER_CONFIGS
-	if a.permission == kmsg.ACLPermissionTypeAllow {
-		switch op {
-		case kmsg.ACLOperationDescribe:
-			switch a.operation {
-			case kmsg.ACLOperationRead, kmsg.ACLOperationWrite, kmsg.ACLOperationDelete, kmsg.ACLOperationAlter:
-				return true
-			}
-		case kmsg.ACLOperationDescribeConfigs:
-			return a.operation == kmsg.ACLOperationAlterConfigs
+	// Implied permissions only apply to ALLOW ACLs.
+	if a.permission != kmsg.ACLPermissionTypeAllow {
+		return false
+	}
+	// KIP-253: Describe is implied by Read, Write, Delete, Alter.
+	// DescribeConfigs is implied by AlterConfigs. No other ops have
+	// implied permissions.
+	switch op {
+	case kmsg.ACLOperationDescribe:
+		switch a.operation {
+		case kmsg.ACLOperationRead, kmsg.ACLOperationWrite, kmsg.ACLOperationDelete, kmsg.ACLOperationAlter:
+			return true
+		default: // no other ops imply Describe
 		}
+	case kmsg.ACLOperationDescribeConfigs:
+		return a.operation == kmsg.ACLOperationAlterConfigs
+	default: // only Describe and DescribeConfigs have implied permissions
 	}
 	return false
 }

--- a/pkg/kfake/behavior_test.go
+++ b/pkg/kfake/behavior_test.go
@@ -477,7 +477,7 @@ func Test848TransactionalConsume(t *testing.T) {
 		t.Fatalf("expected 15 committed records, got %d", len(records))
 	}
 	for _, r := range records {
-		if string(r.Value) == "" {
+		if len(r.Value) == 0 {
 			continue
 		}
 		v := string(r.Value)
@@ -1571,7 +1571,7 @@ func TestTxnConcurrentDescribeAndInit(t *testing.T) {
 				req.TransactionTimeoutMillis = 60000
 				req.ProducerID = -1
 				req.ProducerEpoch = -1
-				req.RequestWith(ctx, cl) //nolint:errcheck
+				req.RequestWith(ctx, cl) //nolint:errcheck // fire-and-forget request
 			}
 		}()
 		wg.Add(1)
@@ -1579,7 +1579,7 @@ func TestTxnConcurrentDescribeAndInit(t *testing.T) {
 			defer wg.Done()
 			for ctx.Err() == nil {
 				req := kmsg.NewListTransactionsRequest()
-				req.RequestWith(ctx, cl) //nolint:errcheck
+				req.RequestWith(ctx, cl) //nolint:errcheck // fire-and-forget request
 			}
 		}()
 	}
@@ -2387,7 +2387,8 @@ func TestFetchSessionEviction(t *testing.T) {
 func fetchRequest(sessionID, sessionEpoch int32, topic string, partitions ...struct {
 	p      int32
 	offset int64
-}) *kmsg.FetchRequest {
+},
+) *kmsg.FetchRequest {
 	req := kmsg.NewPtrFetchRequest()
 	req.Version = 11
 	req.MaxWaitMillis = 100

--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -1,3 +1,4 @@
+// Package kfake provides a fake Kafka broker for testing.
 package kfake
 
 import (
@@ -241,7 +242,7 @@ func NewCluster(opts ...Opt) (*Cluster, error) {
 			bsIdx: len(c.bs),
 		}
 		c.bs = append(c.bs, b)
-		defer func() { go b.listen() }()
+		defer func() { go b.listen() }() //nolint:gocritic,revive // intentional - each broker's listener starts after loop iter
 	}
 	c.controller = c.bs[len(c.bs)-1]
 
@@ -756,7 +757,7 @@ func (c *Cluster) CurrentNode() int32 {
 	return -1
 }
 
-func (c *Cluster) tryControl(creq *clientReq) (kresp kmsg.Response, err error, handled bool) {
+func (c *Cluster) tryControl(creq *clientReq) (kresp kmsg.Response, err error, handled bool) { //nolint:revive // control handler signature
 	c.controlMu.Lock()
 	defer c.controlMu.Unlock()
 	if len(c.control) == 0 {
@@ -769,7 +770,7 @@ func (c *Cluster) tryControl(creq *clientReq) (kresp kmsg.Response, err error, h
 	return kresp, err, handled
 }
 
-func (c *Cluster) tryControlKey(key int16, creq *clientReq) (kmsg.Response, error, bool) {
+func (c *Cluster) tryControlKey(key int16, creq *clientReq) (kmsg.Response, error, bool) { //nolint:revive // control handler signature
 	for _, cctx := range c.control[key] {
 		if cctx.lastReq[creq.cc] == creq {
 			continue
@@ -958,10 +959,7 @@ func (bs *bsleep) enqueue(s *slept) bool {
 		go bs.wait() // Case (2)
 		return true
 	}
-	var q0 *slept
-	if !bs.c.cfg.sleepOutOfOrder {
-		q0 = bs.queue[0] // Case (3b) or (3c) -- just update values below
-	} else {
+	if bs.c.cfg.sleepOutOfOrder {
 		// Case (3a), out of order sleep: we need to check the entire
 		// queue to see if this request was already sleeping and, if
 		// so, update the values. If it was not already sleeping, we
@@ -969,6 +967,7 @@ func (bs *bsleep) enqueue(s *slept) bool {
 		bs.keep(s)
 		return true
 	}
+	q0 := bs.queue[0] // Case (3b) or (3c) -- just update values below
 	if q0.creq != s.creq {
 		panic("internal error: sleeping request not head request")
 	}
@@ -1242,19 +1241,20 @@ func (c *Cluster) RemoveNode(nodeID int32) error {
 	var err error
 	c.admin(func() {
 		for i, b := range c.bs {
-			if b.node == nodeID {
-				if len(c.bs) == 1 {
-					err = errors.New("cannot remove all brokers")
-					return
-				}
-				b.ln.Close()
-				c.cfg.nbrokers--
-				c.bs[i] = c.bs[len(c.bs)-1]
-				c.bs[i].bsIdx = i
-				c.bs = c.bs[:len(c.bs)-1]
-				c.shufflePartitionsLocked()
+			if b.node != nodeID {
+				continue
+			}
+			if len(c.bs) == 1 {
+				err = errors.New("cannot remove all brokers")
 				return
 			}
+			b.ln.Close()
+			c.cfg.nbrokers--
+			c.bs[i] = c.bs[len(c.bs)-1]
+			c.bs[i].bsIdx = i
+			c.bs = c.bs[:len(c.bs)-1]
+			c.shufflePartitionsLocked()
+			return
 		}
 		err = fmt.Errorf("node %d not found", nodeID)
 	})

--- a/pkg/kfake/data.go
+++ b/pkg/kfake/data.go
@@ -98,7 +98,6 @@ type (
 		maxTimestampSeg int // segment index, -1 if none
 		maxTimestampIdx int // index within that segment's batchMeta
 
-		rf        int8
 		leader    *broker
 		followers followers
 
@@ -418,7 +417,7 @@ func (pd *partData) findBatchMeta(target int64, field func(*batchMeta) int64) (s
 // segIdx, metaIdx: position of the found batch within pd.segments
 // found: if the offset was found
 // atEnd: if true, the requested offset is at or past the HWM - "requesting at the end, wait"
-func (pd *partData) searchOffset(o int64) (segIdx int, metaIdx int, found bool, atEnd bool) {
+func (pd *partData) searchOffset(o int64) (segIdx, metaIdx int, found, atEnd bool) {
 	if o < pd.logStartOffset || o > pd.highWatermark {
 		return 0, 0, false, false
 	}
@@ -668,6 +667,7 @@ func validateBrokerConfig(k string, v *string) bool {
 			if _, err := strconv.ParseInt(*v, 10, 64); err != nil {
 				return false
 			}
+		default: // Boolean, String, List, etc. accept any string value
 		}
 	}
 	return true
@@ -957,7 +957,7 @@ func forEachBatchRecord(batch kmsg.RecordBatch, cb func(kmsg.Record) error) erro
 	return nil
 }
 
-// BatchRecord returns the raw kmsg.Record's within a record batch, or an error
+// BatchRecords returns the raw kmsg.Record's within a record batch, or an error
 // if they could not be processed.
 func BatchRecords(b kmsg.RecordBatch) ([]kmsg.Record, error) {
 	var rs []kmsg.Record
@@ -1102,10 +1102,8 @@ func (c *Cluster) compact(pd *partData, topic string) {
 				return nil
 			}
 
-			k := string(rec.Key)
-
 			// Drop superseded records (a later record has the same key).
-			if keyOffsets[k] > absOffset {
+			if keyOffsets[string(rec.Key)] > absOffset {
 				return nil
 			}
 

--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -502,7 +502,7 @@ func (gs *groups) handleDelete(creq *clientReq) *kmsg.DeleteGroupsResponse {
 					sg.ErrorCode = kerr.GroupIDNotFound.Code
 				case groupEmpty:
 					g.quitOnce()
-				case groupPreparingRebalance, groupCompletingRebalance, groupStable:
+				case groupPreparingRebalance, groupCompletingRebalance, groupStable, groupReconciling:
 					sg.ErrorCode = kerr.NonEmptyGroup.Code
 				}
 			}
@@ -678,13 +678,12 @@ func (g *group) handleOffsetDelete(creq *clientReq) *kmsg.OffsetDeleteResponse {
 		resp.Topics = append(resp.Topics, st)
 		return &resp.Topics[len(resp.Topics)-1]
 	}
-	donep := func(t string, p int32, errCode int16) *kmsg.OffsetDeleteResponseTopicPartition {
+	donep := func(t string, p int32, errCode int16) {
 		sp := kmsg.NewOffsetDeleteResponseTopicPartition()
 		sp.Partition = p
 		sp.ErrorCode = errCode
 		st := donet(t)
 		st.Partitions = append(st.Partitions, sp)
-		return &st.Partitions[len(st.Partitions)-1]
 	}
 
 	// empty: delete everything in request
@@ -1938,20 +1937,19 @@ func (g *group) consumerJoin(creq *clientReq, req *kmsg.ConsumerGroupHeartbeatRe
 	// Same-memberID: handle static rejoin from epoch -2 or
 	// non-static rejoin (update in place).
 	if prev := g.consumerMembers[memberID]; prev != nil {
-		if prev.memberEpoch == -2 {
-			if inheritSent == nil {
-				oldTopics = prev.subscribedTopics
-				inheritSent = copyAssignment(prev.lastReconciledSent)
-				inheritTarget = copyAssignment(prev.targetAssignment)
-				inheritAssignEpochs = prev.partAssignmentEpochs
-			}
-			g.fenceConsumerMember(prev)
-			delete(g.consumerMembers, memberID)
-		} else {
+		if prev.memberEpoch != -2 {
 			// Active non-static rejoin: update subscription
 			// in place, preserving partition state.
 			return g.consumerRejoin(creq, req, resp, prev)
 		}
+		if inheritSent == nil {
+			oldTopics = prev.subscribedTopics
+			inheritSent = copyAssignment(prev.lastReconciledSent)
+			inheritTarget = copyAssignment(prev.targetAssignment)
+			inheritAssignEpochs = prev.partAssignmentEpochs
+		}
+		g.fenceConsumerMember(prev)
+		delete(g.consumerMembers, memberID)
 	}
 
 	m := &consumerMember{
@@ -2608,9 +2606,10 @@ func (g *group) assignRange(allTPs []assignorTP, memberIDs []string, memberSubs 
 // the new assigned and pending maps plus whether the assignment
 // changed.
 func (g *group) computeNextAssignment(m *consumerMember,
-	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic) (
-	newAssigned, newPending map[uuid][]int32, changed bool) {
-
+	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic,
+) (
+	newAssigned, newPending map[uuid][]int32, changed bool,
+) {
 	// Collect all topic IDs from both maps.
 	allTopics := make(map[uuid]struct{})
 	for id := range m.lastReconciledSent {
@@ -2712,16 +2711,18 @@ func (g *group) computeNextAssignment(m *consumerMember,
 	}
 
 	changed = !maps.EqualFunc(m.lastReconciledSent, newAssigned, slices.Equal) || !maps.EqualFunc(m.partitionsPendingRevocation, newPending, slices.Equal)
-	return
+
+	return newAssigned, newPending, changed
 }
 
 // updateCurrentAssignment handles subscription changes for a member
 // that is waiting for revocations. It only removes partitions for
 // unsubscribed topics from lastReconciledSent.
 func (g *group) updateCurrentAssignment(m *consumerMember,
-	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic) (
-	newAssigned, newPending map[uuid][]int32, changed bool) {
-
+	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic,
+) (
+	newAssigned, newPending map[uuid][]int32, changed bool,
+) {
 	// Compute subscribed topic IDs from subscriptions + regex.
 	subscribedIDs := make(map[uuid]struct{})
 	snap := g.lastTopicMeta
@@ -2765,7 +2766,7 @@ func (g *group) updateCurrentAssignment(m *consumerMember,
 	// Epoch doesn't change for subscription-only updates.
 
 	changed = true
-	return
+	return newAssigned, newPending, changed
 }
 
 // clearConfirmedRevocations removes partitions from
@@ -2773,8 +2774,8 @@ func (g *group) updateCurrentAssignment(m *consumerMember,
 // ownedTopicPartitions (the client confirmed releasing them).
 // Updates the partition epoch map accordingly.
 func (g *group) clearConfirmedRevocations(m *consumerMember,
-	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic) {
-
+	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic,
+) {
 	reported := topicsToAssignment(ownedTopicPartitions)
 
 	oldPending := m.partitionsPendingRevocation
@@ -2801,8 +2802,8 @@ func (g *group) clearConfirmedRevocations(m *consumerMember,
 // maybeReconcile dispatches to the appropriate reconciliation path
 // based on the member's current state.
 func (g *group) maybeReconcile(m *consumerMember, hasSubscriptionChanged bool,
-	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic) bool {
-
+	ownedTopicPartitions []kmsg.ConsumerGroupHeartbeatRequestTopic,
+) bool {
 	// Clear confirmed revocations first.
 	if ownedTopicPartitions != nil {
 		g.clearConfirmedRevocations(m, ownedTopicPartitions)
@@ -2988,7 +2989,7 @@ func (g *group) scheduleConsumerRebalanceTimeout(m *consumerMember) {
 	})
 }
 
-func (g *group) cancelConsumerRebalanceTimeout(m *consumerMember) {
+func (*group) cancelConsumerRebalanceTimeout(m *consumerMember) {
 	if m.tRebal != nil {
 		m.tRebal.Stop()
 		m.tRebal = nil
@@ -3047,8 +3048,7 @@ func (g *group) handleConsumerOffsetCommit(creq *clientReq) *kmsg.OffsetCommitRe
 	// (admin / kadm commits). Use activeConsumerCount to skip
 	// epoch -2 (static leave) members.
 	var cm *consumerMember
-	if g.activeConsumerCount() == 0 && req.Generation < 0 {
-		// Fall through to commit.
+	if g.activeConsumerCount() == 0 && req.Generation < 0 { //nolint:revive // intentional empty block, falls through to commit
 	} else if req.MemberID == "" {
 		fillOffsetCommit(req, resp, kerr.UnknownMemberID.Code)
 		return resp

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -476,10 +476,10 @@ func TestIssueTimestampInclusivity(t *testing.T) {
 			offset := i * 4
 			r1 := kgo.StringRecord(strconv.Itoa(offset))
 			r1.Timestamp = time.UnixMilli(10_000 + int64(offset))
-			offset += 1
+			offset++
 			r2 := kgo.StringRecord(strconv.Itoa(offset))
 			r2.Timestamp = time.UnixMilli(10_000 + int64(offset))
-			offset += 1
+			offset++
 			r3 := kgo.StringRecord(strconv.Itoa(offset))
 			r3.Timestamp = time.UnixMilli(10_000 + int64(offset))
 			err := cl.ProduceSync(context.Background(), r1, r2, r3).FirstErr()
@@ -1510,7 +1510,6 @@ func TestGroupRebalanceOnNonLeaderMetadataChange(t *testing.T) {
 	}
 }
 
-
 // TestKIP447RequireStable verifies that OffsetFetch with RequireStable=true
 // returns UNSTABLE_OFFSET_COMMIT when there are pending transactional offset commits.
 func TestKIP447RequireStable(t *testing.T) {
@@ -2140,7 +2139,7 @@ func TestKadmCachedMetadata(t *testing.T) {
 	}
 
 	var metadataRequests atomic.Int32
-	c.ControlKey(int16(kmsg.Metadata), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+	c.ControlKey(int16(kmsg.Metadata), func(_ kmsg.Request) (kmsg.Response, error, bool) {
 		c.KeepControl()
 		metadataRequests.Add(1)
 		return nil, nil, false

--- a/pkg/kfake/kafka_tests/consumer_assign_test.go
+++ b/pkg/kfake/kafka_tests/consumer_assign_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-const assignTestTopic = "assign-test"
-const assignTestRecords = 10
+const (
+	assignTestTopic   = "assign-test"
+	assignTestRecords = 10
+)
 
 // setupAssignTest creates a cluster with one partition, produces records, and
 // returns the cluster.

--- a/pkg/kfake/persist.go
+++ b/pkg/kfake/persist.go
@@ -289,7 +289,7 @@ func encodeIndexEntry(epoch int32, maxEarlierTS int64, inTx bool) [indexEntrySiz
 	return buf
 }
 
-func decodeIndexEntry(buf []byte) (epoch int32, maxEarlierTS int64, inTx bool, ok bool) {
+func decodeIndexEntry(buf []byte) (epoch int32, maxEarlierTS int64, inTx, ok bool) {
 	if len(buf) < indexEntrySize {
 		return 0, 0, false, false
 	}
@@ -480,7 +480,7 @@ func writeJSONFile(fsys fs, path string, v any) error {
 		return fmt.Errorf("marshaling %s: %w", path, err)
 	}
 	tmpPath := path + ".tmp"
-	f, err := fsys.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	f, err := fsys.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating %s: %w", tmpPath, err)
 	}
@@ -540,7 +540,7 @@ func (c *Cluster) saveToDisk() error {
 	fsys := c.fs
 	dir := c.cfg.dataDir
 
-	if err := fsys.MkdirAll(dir, 0755); err != nil {
+	if err := fsys.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating data dir: %w", err)
 	}
 
@@ -719,9 +719,9 @@ func (c *Cluster) savePartitions(fsys fs, dir string) error {
 	})
 }
 
-func (c *Cluster) savePartition(fsys fs, dir string, topic string, part int32, pd *partData) error {
+func (c *Cluster) savePartition(fsys fs, dir, topic string, part int32, pd *partData) error {
 	pdir := partDir(dir, topic, part)
-	if err := fsys.MkdirAll(pdir, 0755); err != nil {
+	if err := fsys.MkdirAll(pdir, 0o755); err != nil {
 		return err
 	}
 
@@ -811,17 +811,17 @@ func (c *Cluster) rebuildSegments(pd *partData, batches []*partBatch) {
 	}
 
 	// Write segment (.dat) and index (.idx) files.
-	c.fs.MkdirAll(pdir, 0755)
+	c.fs.MkdirAll(pdir, 0o755)
 	for _, g := range groups {
 		si := segmentInfo{base: g.base}
 		segPath := filepath.Join(pdir, segmentFileName(g.base))
 		idxPath := filepath.Join(pdir, indexFileName(g.base))
-		sf, err := c.fs.OpenFile(segPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		sf, err := c.fs.OpenFile(segPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 		if err != nil {
 			c.cfg.logger.Logf(LogLevelWarn, "rebuildSegments %s-%d: create %s: %v", pd.t, pd.p, segPath, err)
 			continue
 		}
-		xf, err := c.fs.OpenFile(idxPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		xf, err := c.fs.OpenFile(idxPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 		if err != nil {
 			sf.Close()
 			c.cfg.logger.Logf(LogLevelWarn, "rebuildSegments %s-%d: create %s: %v", pd.t, pd.p, idxPath, err)
@@ -873,7 +873,7 @@ func (c *Cluster) saveGroupsLog(fsys fs, dir string) error {
 
 	path := filepath.Join(dir, "groups.log")
 	tmpPath := path + ".tmp"
-	f, err := fsys.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	f, err := fsys.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
@@ -893,7 +893,7 @@ func (c *Cluster) saveGroupsLog(fsys fs, dir string) error {
 // collectGroupEntries gathers all persistable state from a group.
 // This must be called from within the group's manage goroutine via
 // waitControl, OR after the group has been stopped (shutdown).
-func (c *Cluster) collectGroupEntries(g *group) []groupLogEntry {
+func (*Cluster) collectGroupEntries(g *group) []groupLogEntry {
 	var entries []groupLogEntry
 
 	// Group metadata
@@ -928,7 +928,7 @@ func (c *Cluster) savePIDsLog(fsys fs, dir string) error {
 
 	path := filepath.Join(dir, "pids.log")
 	tmpPath := path + ".tmp"
-	f, err := fsys.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	f, err := fsys.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}
@@ -1492,7 +1492,7 @@ func (c *Cluster) loadSegmentBatches(pd *partData, fsys fs, pdir string, base in
 		c.cfg.logger.Logf(LogLevelWarn, "partition %s-%d segment %d: truncating %d corrupt bytes",
 			pd.t, pd.p, base, len(raw)-pos)
 		path := filepath.Join(pdir, segmentFileName(base))
-		if f, err := fsys.OpenFile(path, os.O_WRONLY, 0644); err != nil {
+		if f, err := fsys.OpenFile(path, os.O_WRONLY, 0o644); err != nil {
 			c.cfg.logger.Logf(LogLevelWarn, "partition %s-%d segment %d: open for truncate: %v", pd.t, pd.p, base, err)
 		} else {
 			defer f.Close()
@@ -1507,7 +1507,7 @@ func (c *Cluster) loadSegmentBatches(pd *partData, fsys fs, pdir string, base in
 	expectedIdxBytes := int64(batchIdx * indexEntrySize)
 	if int64(len(idxRaw)) > expectedIdxBytes {
 		idxPath := filepath.Join(pdir, indexFileName(base))
-		if f, err := fsys.OpenFile(idxPath, os.O_WRONLY, 0644); err == nil {
+		if f, err := fsys.OpenFile(idxPath, os.O_WRONLY, 0o644); err == nil {
 			f.Truncate(expectedIdxBytes)
 			f.Close()
 		}
@@ -1739,12 +1739,12 @@ func (c *Cluster) loadSeqWindows(fsys fs, dir string) error {
 func (c *Cluster) openSegmentFiles(pd *partData, pdir string) error {
 	base := pd.segments[len(pd.segments)-1].base
 	segPath := filepath.Join(pdir, segmentFileName(base))
-	sf, err := c.fs.OpenFile(segPath, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	sf, err := c.fs.OpenFile(segPath, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}
 	idxPath := filepath.Join(pdir, indexFileName(base))
-	idxF, err := c.fs.OpenFile(idxPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	idxF, err := c.fs.OpenFile(idxPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		sf.Close()
 		return err
@@ -1767,7 +1767,7 @@ func (c *Cluster) persistBatchToSegment(pd *partData, b *partBatch) int64 {
 	}
 
 	if pd.activeSegFile == nil {
-		if err := fsys.MkdirAll(pdir, 0755); err != nil {
+		if err := fsys.MkdirAll(pdir, 0o755); err != nil {
 			c.cfg.logger.Logf(LogLevelWarn, "persist batch mkdir %s: %v", pdir, err)
 			return -1
 		}
@@ -1831,7 +1831,7 @@ func (c *Cluster) persistGroupEntry(entry groupLogEntry) error {
 	defer c.groupsLogMu.Unlock()
 	if c.groupsLogFile == nil {
 		path := filepath.Join(c.cfg.dataDir, "groups.log")
-		f, err := c.fs.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		f, err := c.fs.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 		if err != nil {
 			c.cfg.logger.Logf(LogLevelWarn, "persist group entry open: %v", err)
 			return err
@@ -1859,7 +1859,7 @@ func (c *Cluster) persistPIDEntry(entry pidLogEntry) error {
 	}
 	if c.pidsLogFile == nil {
 		path := filepath.Join(c.cfg.dataDir, "pids.log")
-		f, err := c.fs.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		f, err := c.fs.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 		if err != nil {
 			c.cfg.logger.Logf(LogLevelWarn, "persist pid entry open: %v", err)
 			return err
@@ -1944,7 +1944,7 @@ func (c *Cluster) compactGroupsLog() {
 
 	// Write compacted entries to tmp, then atomic rename.
 	tmpPath := path + ".tmp"
-	f, err := c.fs.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	f, err := c.fs.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		c.cfg.logger.Logf(LogLevelWarn, "compact groups.log: create: %v", err)
 		return

--- a/pkg/kfake/persist_fs.go
+++ b/pkg/kfake/persist_fs.go
@@ -293,7 +293,7 @@ func (f *memFile) Sync() error {
 	return nil
 }
 
-func (f *memFile) Close() error { return nil }
+func (*memFile) Close() error { return nil }
 
 // memDirEntry implements os.DirEntry for memFS.
 type memDirEntry struct {
@@ -302,9 +302,9 @@ type memDirEntry struct {
 	size  int64
 }
 
-func (e memDirEntry) Name() string      { return e.name }
-func (e memDirEntry) IsDir() bool       { return e.isDir }
-func (e memDirEntry) Type() os.FileMode { return 0 }
+func (e memDirEntry) Name() string    { return e.name }
+func (e memDirEntry) IsDir() bool     { return e.isDir }
+func (memDirEntry) Type() os.FileMode { return 0 }
 func (e memDirEntry) Info() (os.FileInfo, error) {
 	return memFileInfo{name: e.name, isDir: e.isDir, size: e.size}, nil
 }
@@ -316,9 +316,9 @@ type memFileInfo struct {
 	isDir bool
 }
 
-func (i memFileInfo) Name() string       { return i.name }
-func (i memFileInfo) Size() int64        { return i.size }
-func (i memFileInfo) Mode() os.FileMode  { return 0644 }
-func (i memFileInfo) ModTime() time.Time { return time.Time{} }
-func (i memFileInfo) IsDir() bool        { return i.isDir }
-func (i memFileInfo) Sys() any           { return nil }
+func (i memFileInfo) Name() string     { return i.name }
+func (i memFileInfo) Size() int64      { return i.size }
+func (memFileInfo) Mode() os.FileMode  { return 0o644 }
+func (memFileInfo) ModTime() time.Time { return time.Time{} }
+func (i memFileInfo) IsDir() bool      { return i.isDir }
+func (memFileInfo) Sys() any           { return nil }

--- a/pkg/kfake/persist_fuzz_test.go
+++ b/pkg/kfake/persist_fuzz_test.go
@@ -91,7 +91,7 @@ func FuzzDecodeBatchRaw(f *testing.F) {
 		f.Add(make([]byte, size))
 	}
 
-	f.Fuzz(func(t *testing.T, input []byte) {
+	f.Fuzz(func(_ *testing.T, input []byte) {
 		// Must not panic
 		rb, err := decodeBatchRaw(input)
 		_ = rb
@@ -189,7 +189,7 @@ func TestWriteReadEntryRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	mfs := newMemFS()
-	f, err := mfs.OpenFile("test.log", os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := mfs.OpenFile("test.log", os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,12 +307,12 @@ func TestMemFSRoundTrip(t *testing.T) {
 	mfs := newMemFS()
 
 	// MkdirAll
-	if err := mfs.MkdirAll("/a/b/c", 0755); err != nil {
+	if err := mfs.MkdirAll("/a/b/c", 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	// WriteFile via OpenFile
-	f, err := mfs.OpenFile("/a/b/c/test.txt", os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := mfs.OpenFile("/a/b/c/test.txt", os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +375,7 @@ func TestMemFSFaultInjection(t *testing.T) {
 	t.Parallel()
 	mfs := newMemFS()
 
-	f, err := mfs.OpenFile("/test.dat", os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := mfs.OpenFile("/test.dat", os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,12 +416,12 @@ func TestMemFSAppendMode(t *testing.T) {
 	mfs := newMemFS()
 
 	// Write initial data
-	f, _ := mfs.OpenFile("/test.log", os.O_CREATE|os.O_WRONLY, 0644)
+	f, _ := mfs.OpenFile("/test.log", os.O_CREATE|os.O_WRONLY, 0o644)
 	f.Write([]byte("initial"))
 	f.Close()
 
 	// Append
-	f, _ = mfs.OpenFile("/test.log", os.O_APPEND|os.O_WRONLY, 0644)
+	f, _ = mfs.OpenFile("/test.log", os.O_APPEND|os.O_WRONLY, 0o644)
 	f.Write([]byte("-appended"))
 	f.Close()
 
@@ -437,12 +437,12 @@ func TestMemFSTruncateFlag(t *testing.T) {
 	mfs := newMemFS()
 
 	// Write initial data
-	f, _ := mfs.OpenFile("/test.dat", os.O_CREATE|os.O_WRONLY, 0644)
+	f, _ := mfs.OpenFile("/test.dat", os.O_CREATE|os.O_WRONLY, 0o644)
 	f.Write([]byte("old data that is very long"))
 	f.Close()
 
 	// Truncate on open
-	f, _ = mfs.OpenFile("/test.dat", os.O_TRUNC|os.O_WRONLY, 0644)
+	f, _ = mfs.OpenFile("/test.dat", os.O_TRUNC|os.O_WRONLY, 0o644)
 	f.Write([]byte("new"))
 	f.Close()
 
@@ -517,7 +517,6 @@ func TestChaosProduceCloseCrashRecover(t *testing.T) {
 			if !ok {
 				t.Fatalf("iter %d: topic %s missing after %s",
 					iter, topic, shutdownType(cleanShutdown))
-				continue
 			}
 
 			if pd.highWatermark != expectedHWM[topic] {
@@ -662,7 +661,7 @@ func TestChaosTopicCreateDeleteRestart(t *testing.T) {
 	rng := rand.New(rand.NewSource(77))
 	dir := t.TempDir()
 
-	var allTopics = []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+	allTopics := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
 
 	c, err := NewCluster(DataDir(dir), NumBrokers(1))
 	if err != nil {
@@ -1389,7 +1388,7 @@ func TestPersistSnapshotLogStartOffsetClamp(t *testing.T) {
 			path := filepath.Join(segDir, e.Name())
 			raw, _ := os.ReadFile(path)
 			// Keep roughly 1/3 of the file.
-			os.WriteFile(path, raw[:len(raw)/3], 0644)
+			os.WriteFile(path, raw[:len(raw)/3], 0o644)
 		}
 	}
 
@@ -1632,7 +1631,7 @@ func TestCompactBailsOnPartialReadError(t *testing.T) {
 			raw[i] = 0xFF
 		}
 	}
-	f, err := c.fs.OpenFile(path, os.O_TRUNC|os.O_WRONLY, 0644)
+	f, err := c.fs.OpenFile(path, os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kfake/persist_test.go
+++ b/pkg/kfake/persist_test.go
@@ -1,6 +1,7 @@
 package kfake_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -320,7 +321,7 @@ func TestPersistPIDEpochRestart(t *testing.T) {
 		}
 		for _, txn := range txns {
 			origPID = txn.ProducerID
-			origEpoch = int16(txn.ProducerEpoch)
+			origEpoch = txn.ProducerEpoch
 		}
 		cl.Close()
 		c.Close()
@@ -373,7 +374,7 @@ func TestPersistPIDEpochRestart(t *testing.T) {
 			if txn.ProducerID != origPID {
 				t.Fatalf("expected same PID %d after restart, got %d", origPID, txn.ProducerID)
 			}
-			if int16(txn.ProducerEpoch) <= origEpoch {
+			if txn.ProducerEpoch <= origEpoch {
 				t.Fatalf("expected epoch > %d after restart, got %d", origEpoch, txn.ProducerEpoch)
 			}
 		}
@@ -636,7 +637,7 @@ func TestPersistCRCCorruption(t *testing.T) {
 				// Corrupt the last few bytes
 				data[len(data)-3] ^= 0xFF
 				data[len(data)-5] ^= 0xFF
-				os.WriteFile(path, data, 0644)
+				os.WriteFile(path, data, 0o644)
 			}
 		}
 	}
@@ -871,7 +872,7 @@ func TestPersistEntryFraming(t *testing.T) {
 	// Create a temp file and write an entry
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.log")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -918,7 +919,7 @@ func TestPersistEntryFraming(t *testing.T) {
 	}
 
 	recoveredData := raw[10:]
-	if string(recoveredData) != string(testData) {
+	if !bytes.Equal(recoveredData, testData) {
 		t.Fatalf("data mismatch: %q vs %q", recoveredData, testData)
 	}
 }
@@ -1415,7 +1416,7 @@ func TestPersistClassicGroupGenerationCrash(t *testing.T) {
 		cl := newPlainClient(t, c)
 		defer cl.Close()
 
-		recoveredGen := rawJoinGeneration(t, ctx, cl, group, topic)
+		recoveredGen := rawJoinGeneration(ctx, t, cl, group, topic)
 		// After recovery, the next join should produce generation > lastGeneration.
 		if recoveredGen <= lastGeneration {
 			t.Fatalf("expected recovered generation > %d, got %d", lastGeneration, recoveredGen)
@@ -1424,7 +1425,7 @@ func TestPersistClassicGroupGenerationCrash(t *testing.T) {
 }
 
 // rawJoinGeneration performs a raw JoinGroup+SyncGroup to observe the generation.
-func rawJoinGeneration(t *testing.T, ctx context.Context, cl *kgo.Client, group, topic string, instanceID ...string) int32 {
+func rawJoinGeneration(ctx context.Context, t *testing.T, cl *kgo.Client, group, topic string, instanceID ...string) int32 {
 	t.Helper()
 
 	proto := kmsg.NewJoinGroupRequestProtocol()
@@ -1618,7 +1619,7 @@ func TestPersistStaticMemberDeleteCrash(t *testing.T) {
 		cl := newPlainClient(t, c)
 		defer cl.Close()
 
-		gen := rawJoinGeneration(t, ctx, cl, group, topic, instanceID)
+		gen := rawJoinGeneration(ctx, t, cl, group, topic, instanceID)
 		if gen <= 0 {
 			t.Fatalf("expected positive generation, got %d", gen)
 		}
@@ -2261,17 +2262,18 @@ func TestPersistSnapshotTruncatedSegment(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, e := range entries {
-		if filepath.Ext(e.Name()) == ".dat" {
-			path := filepath.Join(partDir, e.Name())
-			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// Truncate to half the file size.
-			half := len(data) / 2
-			if half > 0 {
-				os.WriteFile(path, data[:half], 0644)
-			}
+		if filepath.Ext(e.Name()) != ".dat" {
+			continue
+		}
+		path := filepath.Join(partDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Truncate to half the file size.
+		half := len(data) / 2
+		if half > 0 {
+			os.WriteFile(path, data[:half], 0o644)
 		}
 	}
 
@@ -2839,7 +2841,7 @@ func TestPersistSessionStateExpired(t *testing.T) {
 	oldTime, _ := json.Marshal(time.Now().Add(-1 * time.Hour))
 	ss["shutdownAt"] = oldTime
 	newData, _ := json.Marshal(ss)
-	if err := os.WriteFile(ssPath, newData, 0644); err != nil {
+	if err := os.WriteFile(ssPath, newData, 0o644); err != nil {
 		t.Fatalf("writing modified session_state.json: %v", err)
 	}
 
@@ -3573,7 +3575,7 @@ func copyDir(t *testing.T, src, dst string) {
 		sp := filepath.Join(src, e.Name())
 		dp := filepath.Join(dst, e.Name())
 		if e.IsDir() {
-			if err := os.MkdirAll(dp, 0755); err != nil {
+			if err := os.MkdirAll(dp, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			copyDir(t, sp, dp)
@@ -3582,7 +3584,7 @@ func copyDir(t *testing.T, src, dst string) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := os.WriteFile(dp, data, 0644); err != nil {
+			if err := os.WriteFile(dp, data, 0o644); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/kfake/sasl.go
+++ b/pkg/kfake/sasl.go
@@ -48,7 +48,7 @@ const (
 	saslStageComplete
 )
 
-func (c *Cluster) handleSASL(creq *clientReq) (allow bool) {
+func (*Cluster) handleSASL(creq *clientReq) (allow bool) {
 	switch creq.cc.saslStage {
 	case saslStageBegin:
 		switch creq.kreq.(type) {

--- a/pkg/kfake/txns.go
+++ b/pkg/kfake/txns.go
@@ -408,12 +408,11 @@ func (pids *pids) doTxnOffsetCommit(creq *clientReq) kmsg.Response {
 	// KIP-890 Part 2: For v5+ requests, implicitly start the transaction
 	// if not already started. For v0-4, require transaction to be active.
 	if !pidinf.inTx {
-		if req.Version >= 5 {
-			pidinf.maybeStart()
-		} else {
+		if req.Version < 5 {
 			doneall(kerr.InvalidTxnState.Code)
 			return resp
 		}
+		pidinf.maybeStart()
 	}
 
 	// Check if group exists. For generation >= 0, return
@@ -451,12 +450,11 @@ func (pids *pids) doTxnOffsetCommit(creq *clientReq) kmsg.Response {
 	// KIP-890: For v5+ requests, implicitly add the group to the transaction
 	// if it's not already there. This allows clients to skip AddOffsetsToTxn.
 	if !groupInTx {
-		if req.Version >= 5 {
-			pidinf.txGroups = append(pidinf.txGroups, req.Group)
-		} else {
+		if req.Version < 5 {
 			doneall(kerr.InvalidTxnState.Code)
 			return resp
 		}
+		pidinf.txGroups = append(pidinf.txGroups, req.Group)
 	}
 
 	// Store pending offset commits; will be actually mirrored into

--- a/pkg/kgo/consumer_test.go
+++ b/pkg/kgo/consumer_test.go
@@ -885,7 +885,7 @@ func TestGroupSimple(t *testing.T) {
 				UnknownTopicRetries(-1),
 			}
 			if tc.enable848 {
-				ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true) //nolint:revive,staticcheck // intentional string key for beta opt-in
+				ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true)
 				opts = append(opts, WithContext(ctx848))
 			}
 

--- a/pkg/kgo/group_test.go
+++ b/pkg/kgo/group_test.go
@@ -181,7 +181,7 @@ func (c *testConsumer) etl(etlsBeforeQuit int) {
 		opts = append(opts, InstanceID(myInstanceID))
 	}
 	if c.enable848 {
-		ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true) //nolint:revive,staticcheck // intentional string key for beta opt-in
+		ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true)
 		opts = append(opts, WithContext(ctx848))
 	}
 	if testChaos {

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -141,7 +141,7 @@ func init() {
 			}
 		}
 		if caPath != "" {
-			ca, err := os.ReadFile(caPath) //nolint:gosec // we are deliberately including a file from a variable
+			ca, err := os.ReadFile(caPath)
 			if err != nil {
 				panic(fmt.Sprintf("unable to read ca: %v", err))
 			}

--- a/pkg/kgo/txn_test.go
+++ b/pkg/kgo/txn_test.go
@@ -179,7 +179,7 @@ func (c *testConsumer) transact(txnsBeforeQuit int) {
 		opts = append(opts, InstanceID(myInstanceID))
 	}
 	if c.enable848 {
-		ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true) //nolint:revive,staticcheck // intentional string key for beta opt-in
+		ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true)
 		opts = append(opts, WithContext(ctx848))
 	}
 	opts = append(opts, testClientOpts()...)

--- a/pkg/kmsg/api.go
+++ b/pkg/kmsg/api.go
@@ -127,11 +127,11 @@ type Response interface {
 	RequestKind() Request
 }
 
-// UnsafeReadFrom, implemented by all requests and responses generated in this
-// package, switches to using unsafe slice-to-string conversions when reading.
-// This can be used to avoid a lot of garbage, but it means to have to be
-// careful when using any strings in structs: if you hold onto the string, the
-// underlying response slice will not be garbage collected.
+// UnsafeReadFrom is implemented by all requests and responses generated in
+// this package, and switches to using unsafe slice-to-string conversions when
+// reading. This can be used to avoid a lot of garbage, but it means you have
+// to be careful when using any strings in structs: if you hold onto the
+// string, the underlying response slice will not be garbage collected.
 type UnsafeReadFrom interface {
 	UnsafeReadFrom([]byte) error
 }
@@ -232,8 +232,7 @@ func (f *RequestFormatter) AppendRequest(
 	if r.IsFlexible() {
 		var numTags uint8
 		dst = append(dst, numTags)
-		if numTags != 0 {
-			// TODO when tags are added
+		if numTags != 0 { //nolint:revive,staticcheck // TODO when tags are added
 		}
 	}
 
@@ -346,14 +345,6 @@ func SkipTags(b TagReader) {
 	}
 }
 
-// internalSkipTags skips tags in the duplicated inner kbin.Reader.
-func internalSkipTags(b *kbin.Reader) {
-	for num := b.Uvarint(); num > 0; num-- {
-		_, size := b.Uvarint(), b.Uvarint()
-		b.Span(int(size))
-	}
-}
-
 // ReadTags reads tags in a TagReader and returns the tags.
 func ReadTags(b TagReader) Tags {
 	var t Tags
@@ -426,19 +417,29 @@ func (t *Tags) AppendEach(dst []byte) []byte {
 // DEPRECATED RENAMES //
 ////////////////////////
 
-// Deprecated: this was renamed to ControlRecordKeyTypeSnapshotHeader.
+// ControlRecordKeyTypeLeaderChange was renamed to ControlRecordKeyTypeSnapshotHeader.
+//
+// Deprecated: Use ControlRecordKeyTypeSnapshotHeader.
 const ControlRecordKeyTypeLeaderChange = ControlRecordKeyTypeSnapshotHeader
 
 type (
-	// Deprecated: this was renamed to ListConfigResourcesRequest.
+	// ListClientMetricsResourcesRequest was renamed to ListConfigResourcesRequest.
+	//
+	// Deprecated: Use ListConfigResourcesRequest.
 	ListClientMetricsResourcesRequest = ListConfigResourcesRequest
-	// Deprecated: this was renamed to ListConfigResourcesResponse.
+	// ListClientMetricsResourcesResponse was renamed to ListConfigResourcesResponse.
+	//
+	// Deprecated: Use ListConfigResourcesResponse.
 	ListClientMetricsResourcesResponse = ListConfigResourcesResponse
-	// Deprecated: this was renamed to ListConfigResourcesResponseConfigResource.
+	// ListClientMetricsResourcesResponseClientMetricsResource was renamed to ListConfigResourcesResponseConfigResource.
+	//
+	// Deprecated: Use ListConfigResourcesResponseConfigResource.
 	ListClientMetricsResourcesResponseClientMetricsResource = ListConfigResourcesResponseConfigResource
 )
 
-// Deprecated: this was renamed to ListConfigResources.
+// ListClientMetricsResources was renamed to ListConfigResources.
+//
+// Deprecated: Use ListConfigResources.
 var ListClientMetricsResources Key = 74
 
 // Deprecated: this was renamed to NewPtrListConfigResourcesRequest.

--- a/pkg/kmsg/generated.go
+++ b/pkg/kmsg/generated.go
@@ -5242,7 +5242,7 @@ type FetchResponseTopicPartition struct {
 	// LastStableOffset is the offset at which all prior offsets have
 	// been "decided". Non transactional records are always decided
 	// immediately, but transactional records are only decided once
-	// they are commited or aborted.
+	// they are committed or aborted.
 	//
 	// The LastStableOffset will always be at or under the HighWatermark.
 	//
@@ -16516,7 +16516,8 @@ type ListGroupsRequest struct {
 	// StatesFilter, proposed in KIP-518 and introduced in Kafka 2.6.0,
 	// allows filtering groups by state, where a state is any of
 	// "Preparing", "PreparingRebalance", "CompletingRebalance", "Stable",
-	// "Dead", or "Empty". If empty, all groups are returned.
+	// "Dead", "Empty", "Assigning", "Reconciling", or "NotReady".
+	// If empty, all groups are returned.
 	StatesFilter []string // v4+
 
 	// TypesFilter, part of KIP-848, filters the types of groups we want
@@ -28408,7 +28409,7 @@ type DescribeLogDirsResponse struct {
 	ErrorCode int16 // v3+
 
 	// Dirs pairs log directories with the topics and partitions that are
-	// stored in those directores.
+	// stored in those directories.
 	Dirs []DescribeLogDirsResponseDir
 
 	// UnknownTags are tags Kafka sent that we do not know the purpose of.
@@ -38994,7 +38995,7 @@ func (v *EndQuorumEpochRequest) AppendTo(dst []byte) []byte {
 						v := v.LeaderEpoch
 						dst = kbin.AppendInt32(dst, v)
 					}
-					{
+					if version >= 0 && version <= 0 {
 						v := v.PreferredSuccessors
 						if isFlexible {
 							dst = kbin.AppendCompactArrayLen(dst, len(v))
@@ -39185,7 +39186,7 @@ func (v *EndQuorumEpochRequest) readFrom(src []byte, unsafe bool) error {
 						v := b.Int32()
 						s.LeaderEpoch = v
 					}
-					{
+					if version >= 0 && version <= 0 {
 						v := s.PreferredSuccessors
 						a := v
 						var l int32
@@ -40761,7 +40762,7 @@ type AlterPartitionRequestTopicPartitionNewEpochISR struct {
 	// The broker's epoch; -1 if the epoch check is not supported.
 	//
 	// This field has a default of -1.
-	BrokerEpoch int32
+	BrokerEpoch int64
 
 	// UnknownTags are tags Kafka sent that we do not know the purpose of.
 	UnknownTags Tags
@@ -40961,7 +40962,7 @@ func (v *AlterPartitionRequest) AppendTo(dst []byte) []byte {
 							}
 							{
 								v := v.BrokerEpoch
-								dst = kbin.AppendInt32(dst, v)
+								dst = kbin.AppendInt64(dst, v)
 							}
 							if isFlexible {
 								dst = kbin.AppendUvarint(dst, 0+uint32(v.UnknownTags.Len()))
@@ -41137,7 +41138,7 @@ func (v *AlterPartitionRequest) readFrom(src []byte, unsafe bool) error {
 								s.BrokerID = v
 							}
 							{
-								v := b.Int32()
+								v := b.Int64()
 								s.BrokerEpoch = v
 							}
 							if isFlexible {
@@ -41848,7 +41849,7 @@ type UpdateFeaturesResponse struct {
 	ErrorMessage *string
 
 	// The results for each feature update request.
-	Results []UpdateFeaturesResponseResult
+	Results []UpdateFeaturesResponseResult // v0-v1
 
 	// UnknownTags are tags Kafka sent that we do not know the purpose of.
 	UnknownTags Tags
@@ -41886,7 +41887,7 @@ func (v *UpdateFeaturesResponse) AppendTo(dst []byte) []byte {
 			dst = kbin.AppendNullableString(dst, v)
 		}
 	}
-	{
+	if version >= 0 && version <= 1 {
 		v := v.Results
 		if isFlexible {
 			dst = kbin.AppendCompactArrayLen(dst, len(v))
@@ -41969,7 +41970,7 @@ func (v *UpdateFeaturesResponse) readFrom(src []byte, unsafe bool) error {
 		}
 		s.ErrorMessage = v
 	}
-	{
+	if version >= 0 && version <= 1 {
 		v := s.Results
 		a := v
 		var l int32
@@ -45825,7 +45826,7 @@ type DescribeTransactionsResponseTransactionState struct {
 	// NOT_COORDINATOR is returned if the broker receiving this transactional
 	// ID does not own the ID.
 	//
-	// COORDINATOR_LOAD_IN_PROGRESS is returned if the coordiantor is laoding.
+	// COORDINATOR_LOAD_IN_PROGRESS is returned if the coordinator is loading.
 	//
 	// COORDINATOR_NOT_AVAILABLE is returned if the coordinator is being shutdown.
 	//
@@ -51218,7 +51219,7 @@ func NewDescribeTopicPartitionsRequest() DescribeTopicPartitionsRequest {
 
 type DescribeTopicPartitionsResponseTopicPartition struct {
 	// The partition error, or 0 if there is no error.
-	ErrorCode int32
+	ErrorCode int16
 
 	// The partition this is a response for.
 	Partition int32
@@ -51266,7 +51267,7 @@ func NewDescribeTopicPartitionsResponseTopicPartition() DescribeTopicPartitionsR
 
 type DescribeTopicPartitionsResponseTopic struct {
 	// The topic error, or 0 if there is no error.
-	ErrorCode int32
+	ErrorCode int16
 
 	// The topic name.
 	Topic *string
@@ -51381,7 +51382,7 @@ func (v *DescribeTopicPartitionsResponse) AppendTo(dst []byte) []byte {
 			v := &v[i]
 			{
 				v := v.ErrorCode
-				dst = kbin.AppendInt32(dst, v)
+				dst = kbin.AppendInt16(dst, v)
 			}
 			{
 				v := v.Topic
@@ -51410,7 +51411,7 @@ func (v *DescribeTopicPartitionsResponse) AppendTo(dst []byte) []byte {
 					v := &v[i]
 					{
 						v := v.ErrorCode
-						dst = kbin.AppendInt32(dst, v)
+						dst = kbin.AppendInt16(dst, v)
 					}
 					{
 						v := v.Partition
@@ -51572,7 +51573,7 @@ func (v *DescribeTopicPartitionsResponse) readFrom(src []byte, unsafe bool) erro
 			v.Default()
 			s := v
 			{
-				v := b.Int32()
+				v := b.Int16()
 				s.ErrorCode = v
 			}
 			{
@@ -51621,7 +51622,7 @@ func (v *DescribeTopicPartitionsResponse) readFrom(src []byte, unsafe bool) erro
 					v.Default()
 					s := v
 					{
-						v := b.Int32()
+						v := b.Int16()
 						s.ErrorCode = v
 					}
 					{
@@ -53585,7 +53586,7 @@ func (v *ShareFetchRequest) AppendTo(dst []byte) []byte {
 						v := v.Partition
 						dst = kbin.AppendInt32(dst, v)
 					}
-					{
+					if version >= 0 && version <= 0 {
 						v := v.PartitionMaxBytes
 						dst = kbin.AppendInt32(dst, v)
 					}
@@ -53796,7 +53797,7 @@ func (v *ShareFetchRequest) readFrom(src []byte, unsafe bool) error {
 						v := b.Int32()
 						s.Partition = v
 					}
-					{
+					if version >= 0 && version <= 0 {
 						v := b.Int32()
 						s.PartitionMaxBytes = v
 					}
@@ -55632,7 +55633,7 @@ type AddRaftVoterRequestListener struct {
 	Host string
 
 	// The port.
-	Port int16
+	Port uint16
 
 	// UnknownTags are tags Kafka sent that we do not know the purpose of.
 	UnknownTags Tags
@@ -55755,7 +55756,7 @@ func (v *AddRaftVoterRequest) AppendTo(dst []byte) []byte {
 			}
 			{
 				v := v.Port
-				dst = kbin.AppendInt16(dst, v)
+				dst = kbin.AppendUint16(dst, v)
 			}
 			if isFlexible {
 				dst = kbin.AppendUvarint(dst, 0+uint32(v.UnknownTags.Len()))
@@ -55870,7 +55871,7 @@ func (v *AddRaftVoterRequest) readFrom(src []byte, unsafe bool) error {
 				s.Host = v
 			}
 			{
-				v := b.Int16()
+				v := b.Uint16()
 				s.Port = v
 			}
 			if isFlexible {
@@ -56298,7 +56299,7 @@ type UpdateRaftVoterRequestListener struct {
 	Host string
 
 	// The port.
-	Port int16
+	Port uint16
 
 	// UnknownTags are tags Kafka sent that we do not know the purpose of.
 	UnknownTags Tags
@@ -56441,7 +56442,7 @@ func (v *UpdateRaftVoterRequest) AppendTo(dst []byte) []byte {
 			}
 			{
 				v := v.Port
-				dst = kbin.AppendInt16(dst, v)
+				dst = kbin.AppendUint16(dst, v)
 			}
 			if isFlexible {
 				dst = kbin.AppendUvarint(dst, 0+uint32(v.UnknownTags.Len()))
@@ -56571,7 +56572,7 @@ func (v *UpdateRaftVoterRequest) readFrom(src []byte, unsafe bool) error {
 				s.Host = v
 			}
 			{
-				v := b.Int16()
+				v := b.Uint16()
 				s.Port = v
 			}
 			if isFlexible {

--- a/pkg/kmsg/record.go
+++ b/pkg/kmsg/record.go
@@ -127,8 +127,7 @@ func (v *Record) readFrom(src []byte, unsafe bool) error {
 	{
 		v := s.Headers
 		a := v
-		var l int32
-		l = b.VarintArrayLen()
+		l := b.VarintArrayLen()
 		if !b.Ok() {
 			return b.Complete()
 		}
@@ -162,7 +161,7 @@ func (v *Record) readFrom(src []byte, unsafe bool) error {
 
 // Default sets any default fields. Calling this allows for future compatibility
 // if new fields are added to Record.
-func (v *Record) Default() {
+func (*Record) Default() {
 }
 
 // NewRecord returns a default Record

--- a/pkg/sr/clientopt_test.go
+++ b/pkg/sr/clientopt_test.go
@@ -9,8 +9,7 @@ import (
 
 func TestDialTLSConfigOpt(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
-		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
-
+		tlscfg := &tls.Config{}
 		rcl, err := NewClient(DialTLSConfig(tlscfg))
 		if err != nil {
 			t.Fatalf("unable to create client: %s", err)
@@ -28,8 +27,7 @@ func TestDialTLSConfigOpt(t *testing.T) {
 
 	t.Run("CustomHTTPClient", func(t *testing.T) {
 		httpcl := &http.Client{}
-		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
-
+		tlscfg := &tls.Config{}
 		rcl, err := NewClient(
 			HTTPClient(httpcl),
 			DialTLSConfig(tlscfg),
@@ -51,8 +49,7 @@ func TestDialTLSConfigOpt(t *testing.T) {
 	t.Run("CustomHTTPTransport", func(t *testing.T) {
 		httptr := &http.Transport{}
 		httpcl := &http.Client{Transport: httptr}
-		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
-
+		tlscfg := &tls.Config{}
 		rcl, err := NewClient(
 			HTTPClient(httpcl),
 			DialTLSConfig(tlscfg),
@@ -75,8 +72,7 @@ func TestDialTLSConfigOpt(t *testing.T) {
 		dialFn := func(_, _ string) (net.Conn, error) { return nil, nil }
 		httptr := &http.Transport{Dial: dialFn}
 		httpcl := &http.Client{Transport: httptr}
-		tlscfg := &tls.Config{} //nolint:gosec // not relevant for this test case
-
+		tlscfg := &tls.Config{}
 		_, err := NewClient(
 			HTTPClient(httpcl),
 			DialTLSConfig(tlscfg),

--- a/pkg/sr/serde.go
+++ b/pkg/sr/serde.go
@@ -42,11 +42,11 @@ type (
 	}
 )
 
-func (o serdeOpt) serdeOrEncodingOpt() { /* satisfy interface */ }
-func (o serdeOpt) apply(s *Serde)      { o.fn(s) }
+func (serdeOpt) serdeOrEncodingOpt() { /* satisfy interface */ }
+func (o serdeOpt) apply(s *Serde)    { o.fn(s) }
 
-func (o encodingOpt) serdeOrEncodingOpt() { /* satisfy interface */ }
-func (o encodingOpt) apply(t *tserde)     { o.fn(t) }
+func (encodingOpt) serdeOrEncodingOpt() { /* satisfy interface */ }
+func (o encodingOpt) apply(t *tserde)   { o.fn(t) }
 
 // EncodeFn allows Serde to encode a value.
 func EncodeFn(fn func(any) ([]byte, error)) EncodingOpt {

--- a/pkg/sr/serde_test.go
+++ b/pkg/sr/serde_test.go
@@ -239,7 +239,6 @@ func TestConfluentHeader(t *testing.T) {
 			t.Errorf("#%d: UpdateID(%v) != exp(%v)", i, b, test.expEncUpd)
 			continue
 		}
-
 	}
 
 	if _, _, err := h.DecodeID([]byte{1, 0, 0, 0, 0, 1}); err != ErrBadHeader {

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -51,7 +51,7 @@ func (r *Registry) interceptorMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (r *Registry) contextMiddleware(next http.Handler) http.Handler {
+func (*Registry) contextMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		p := req.URL.Path
 		if !strings.HasPrefix(p, "/contexts/") {

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -416,7 +416,7 @@ func TestConfigHandlers(t *testing.T) {
 
 	t.Run("Global config", func(t *testing.T) {
 		// 1. Get initial global config
-		req, _ := http.NewRequest("GET", reg.URL()+"/config", http.NoBody)
+		req, _ := http.NewRequest(http.MethodGet, reg.URL()+"/config", http.NoBody)
 		resp, _ := client.Do(req)
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
@@ -425,7 +425,7 @@ func TestConfigHandlers(t *testing.T) {
 		}
 
 		// 2. Update global config
-		putReq, _ := http.NewRequest("PUT", reg.URL()+"/config", strings.NewReader(`{"compatibility": "FORWARD"}`))
+		putReq, _ := http.NewRequest(http.MethodPut, reg.URL()+"/config", strings.NewReader(`{"compatibility": "FORWARD"}`))
 		putReq.Header.Set("Content-Type", "application/json")
 		putResp, _ := client.Do(putReq)
 		putResp.Body.Close()
@@ -434,7 +434,7 @@ func TestConfigHandlers(t *testing.T) {
 		}
 
 		// 3. Get updated global config
-		req2, _ := http.NewRequest("GET", reg.URL()+"/config", http.NoBody)
+		req2, _ := http.NewRequest(http.MethodGet, reg.URL()+"/config", http.NoBody)
 		resp2, _ := client.Do(req2)
 		body2, _ := io.ReadAll(resp2.Body)
 		resp2.Body.Close()
@@ -448,7 +448,7 @@ func TestConfigHandlers(t *testing.T) {
 		subject := "my-topic"
 
 		// 1. Get subject config, should fallback to global
-		req, _ := http.NewRequest("GET", reg.URL()+"/config/"+subject, http.NoBody)
+		req, _ := http.NewRequest(http.MethodGet, reg.URL()+"/config/"+subject, http.NoBody)
 		resp, _ := client.Do(req)
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
@@ -457,7 +457,7 @@ func TestConfigHandlers(t *testing.T) {
 		}
 
 		// 2. Set subject config
-		putReq, _ := http.NewRequest("PUT", reg.URL()+"/config/"+subject, strings.NewReader(`{"compatibility": "FULL"}`))
+		putReq, _ := http.NewRequest(http.MethodPut, reg.URL()+"/config/"+subject, strings.NewReader(`{"compatibility": "FULL"}`))
 		putResp, _ := client.Do(putReq)
 		putResp.Body.Close()
 		if putResp.StatusCode != http.StatusOK {
@@ -465,7 +465,7 @@ func TestConfigHandlers(t *testing.T) {
 		}
 
 		// 3. Get subject config, should show specific level
-		req2, _ := http.NewRequest("GET", reg.URL()+"/config/"+subject, http.NoBody)
+		req2, _ := http.NewRequest(http.MethodGet, reg.URL()+"/config/"+subject, http.NoBody)
 		resp2, _ := client.Do(req2)
 		body2, _ := io.ReadAll(resp2.Body)
 		resp2.Body.Close()
@@ -482,7 +482,7 @@ func TestConfigHandlers(t *testing.T) {
 		}
 
 		// 5. Get subject config again, should fall back to global
-		req3, _ := http.NewRequest("GET", reg.URL()+"/config/"+subject, http.NoBody)
+		req3, _ := http.NewRequest(http.MethodGet, reg.URL()+"/config/"+subject, http.NoBody)
 		resp3, _ := client.Do(req3)
 		body3, _ := io.ReadAll(resp3.Body)
 		resp3.Body.Close()
@@ -522,7 +522,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", reg.URL()+"/subjects", http.NoBody)
+			req, _ := http.NewRequest(http.MethodGet, reg.URL()+"/subjects", http.NoBody)
 			if tc.authHeader != "" {
 				req.Header.Set("Authorization", tc.authHeader)
 			}
@@ -2037,7 +2037,7 @@ func TestErrorHandling(t *testing.T) {
 		})
 
 		// Soft-delete the subject by making an HTTP request
-		req, _ := http.NewRequest("DELETE", registry.URL()+"/subjects/test", http.NoBody)
+		req, _ := http.NewRequest(http.MethodDelete, registry.URL()+"/subjects/test", http.NoBody)
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("failed to delete subject: %v", err)


### PR DESCRIPTION
Add lint.sh to run golangci-lint across all modules. Update GHA workflow to use lint.sh. Expand golangci config with additional exclusions and suppression rules. Fix all lint issues across kgo, kfake, kmsg, and sr: octal literals, param combining, early returns, exhaustive switches, spelling fixes in generate/definitions, deprecated comment format, unused receivers/nolints, usestdlibvars, and formatting.