### PR TITLE
kgo: add rack-aware partition assignment (KIP-881)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ generation.
 | [KIP-858](https://cwiki.apache.org/confluence/display/KAFKA/KIP-858%3A+Handle+JBOD+broker+disk+failure+in+KRaft) — JBOD in KRaft (protocol) | 3.7 | Supported |
 | [KIP-860](https://cwiki.apache.org/confluence/display/KAFKA/KIP-860%3A+Add+client-provided+option+to+guard+against+replication+factor+change+during+partition+reassignments) - Client side AlterPartitionAssignments RF change guard | 4.1 | Supported (kadm v1.17+) |
 | [KIP-866](https://cwiki.apache.org/confluence/display/KAFKA/KIP-866+ZooKeeper+to+KRaft+Migration) — ZK to Raft RPC changes | 3.4 | Supported |
+| [KIP-881](https://cwiki.apache.org/confluence/display/KAFKA/KIP-881%3A+Rack-aware+Partition+Assignment+for+Kafka+Consumers) — Rack-aware consumer partition assignment | 3.5 | Supported (range & sticky) |
 | [KIP-890](https://cwiki.apache.org/confluence/display/KAFKA/KIP-890%3A+Transactions+Server-Side+Defense) — Transactions server side defense | 3.8, 4.0 | Supported |
 | [KIP-893](https://cwiki.apache.org/confluence/display/KAFKA/KIP-893%3A+The+Kafka+protocol+should+support+nullable+structs) — Nullable structs in the protocol | 3.5 | Supported |
 | [KIP-899](https://cwiki.apache.org/confluence/display/KAFKA/KIP-899%3A+Allow+clients+to+rebootstrap) — Allow clients to rebootstrap | ? | Supported (`UpdateSeedBrokers`) |
@@ -440,6 +441,5 @@ KIPs intentionally not implemented (with rationale):
 - [KIP-421](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=100829515), variable substitution in config files; N/A, franz-go has no config file (same reason librdkafka skips it)
 - [KIP-436](https://cwiki.apache.org/confluence/display/KAFKA/KIP-436%3A+Add+a+metric+indicating+start+time), start-time metric; covered by hooks
 - [KIP-517](https://cwiki.apache.org/confluence/display/KAFKA/KIP-517%3A+Add+consumer+metrics+to+observe+user+poll+behavior), more consumer poll-behavior metrics; covered by hooks
-- [KIP-881](https://cwiki.apache.org/confluence/display/KAFKA/KIP-881%3A+Rack-aware+Partition+Assignment+for+Kafka+Consumers), rack aware rebalancing: probably useful, but the implementation is not clear, and the motivation is confusing with follower fetching and whether to consider replicas while rebalancing
 - [KIP-896](https://cwiki.apache.org/confluence/display/KAFKA/KIP-896%3A+Remove+old+client+protocol+API+versions+in+Kafka+4.0), which removes old client protocol API versions in Kafka 4.0; not relevant to clients, as clients do not control broker-supported protocol versions
 - [KIP-1106](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1106%3A+Add+duration+based+offset+reset+option+for+consumer+clients), for a duration-based offset reset option; not relevant, franz-go already does exact offset recovery via `OffsetForLeaderEpoch` for data loss and via `AfterMilli(lastConsumedTime)` on `OffsetOutOfRange`, picking up precisely where the consumer left off rather than approximating with a duration

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -1164,6 +1164,20 @@ func (cl *Client) updateBrokers(brokers []kmsg.MetadataResponseBroker) {
 	cl.reinitAnyBrokerOrd()
 }
 
+// brokerRacks returns a map of broker node ID to rack for all known brokers
+// that have a rack configured.
+func (cl *Client) brokerRacks() map[int32]string {
+	cl.brokersMu.Lock()
+	defer cl.brokersMu.Unlock()
+	racks := make(map[int32]string, len(cl.brokers))
+	for _, b := range cl.brokers {
+		if b.meta.Rack != nil {
+			racks[b.meta.NodeID] = *b.meta.Rack
+		}
+	}
+	return racks
+}
+
 // CloseAllowingRebalance allows rebalances, leaves any group, and closes all
 // connections and goroutines. This function is only useful if you are using
 // the BlockRebalanceOnPoll option. Close itself does not allow rebalances and

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -1600,6 +1600,22 @@ func (g *groupConsumer) joinGroupProtocols() []kmsg.JoinGroupRequestProtocol {
 		proto := kmsg.NewJoinGroupRequestProtocol()
 		proto.Name = balancer.ProtocolName()
 		proto.Metadata = balancer.JoinGroupMetadata(topics, lastDup, gen)
+
+		// KIP-881: inject our rack into the consumer metadata so the
+		// leader can do rack-aware assignment. We only set Rack if
+		// the balancer did not already set it (a user's custom
+		// balancer might use the field for something else).
+		if g.cfg.rack != "" {
+			var meta kmsg.ConsumerMemberMetadata
+			if err := meta.ReadFrom(proto.Metadata); err == nil && meta.Rack == nil {
+				meta.Rack = &g.cfg.rack
+				if meta.Version < 3 {
+					meta.Version = 3
+				}
+				proto.Metadata = meta.AppendTo(nil)
+			}
+		}
+
 		protos = append(protos, proto)
 	}
 	return protos

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -102,6 +102,10 @@ type ConsumerBalancer struct {
 	metadatas []kmsg.ConsumerMemberMetadata
 	topics    map[string]struct{}
 
+	// partitionRacks maps topic => partition index => leader rack.
+	// nil when rack-aware assignment is not active.
+	partitionRacks map[string][]string
+
 	err error
 }
 
@@ -138,6 +142,13 @@ func (b *ConsumerBalancer) MemberAt(n int) (*kmsg.JoinGroupResponseMember, *kmsg
 // allows you to fail balancing and return nil from Balance.
 func (b *ConsumerBalancer) SetError(err error) {
 	b.err = err
+}
+
+// PartitionRacks returns the partition rack mapping for rack-aware assignment
+// (KIP-881). The map is topic => partition index => leader rack. Returns nil
+// if no rack info is available.
+func (b *ConsumerBalancer) PartitionRacks() map[string][]string {
+	return b.partitionRacks
 }
 
 // MemberTopics returns the unique set of topics that all members are
@@ -423,6 +434,13 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 		g.initExternal(topicPartitionCount)
 	}
 
+	// KIP-881: build partition rack info for rack-aware assignment.
+	// We use cached broker racks and partition leaders from local
+	// metadata. This requires no extra fetches.
+	if cb, ok := memberBalancer.(*ConsumerBalancer); ok {
+		cb.partitionRacks = g.buildPartitionRacks(cb, topicPartitionCount)
+	}
+
 	// If the returned balancer is a ConsumerBalancer (which it likely
 	// always will be), then we can print some useful debugging information
 	// about what member interests are.
@@ -484,6 +502,59 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 	}
 
 	return into.IntoSyncAssignment(), nil
+}
+
+// buildPartitionRacks builds a topic => partition => rack map for rack-aware
+// assignment (KIP-881). It uses cached broker racks and partition leader info
+// from local metadata. Returns nil if no rack info is available.
+func (g *groupConsumer) buildPartitionRacks(b *ConsumerBalancer, topicPartitionCount map[string]int32) map[string][]string {
+	// Check if any member has a rack.
+	var hasRack bool
+	for i := range b.metadatas {
+		if b.metadatas[i].Rack != nil {
+			hasRack = true
+			break
+		}
+	}
+	if !hasRack {
+		return nil
+	}
+
+	// Get broker ID => rack from cached broker metadata.
+	brokerRacks := g.cl.brokerRacks()
+	if len(brokerRacks) == 0 {
+		return nil
+	}
+
+	// Build partition racks from local topic metadata. Each
+	// partition's rack is determined by its leader broker's rack.
+	partitionRacks := make(map[string][]string, len(topicPartitionCount))
+	myTopics := g.tps.load()
+	for topic, numPartitions := range topicPartitionCount {
+		racks := make([]string, numPartitions)
+		if data, ok := myTopics[topic]; ok {
+			tpd := data.load()
+			for i, p := range tpd.partitions {
+				if p == nil || int32(i) >= numPartitions {
+					continue
+				}
+				if rack, ok := brokerRacks[p.leader]; ok {
+					racks[i] = rack
+				}
+			}
+		}
+		partitionRacks[topic] = racks
+	}
+
+	// Only return rack info if at least one partition has a rack.
+	for _, racks := range partitionRacks {
+		for _, r := range racks {
+			if r != "" {
+				return partitionRacks
+			}
+		}
+	}
+	return nil
 }
 
 // helper func; range and roundrobin use v0
@@ -622,6 +693,14 @@ func (r *rangeBalancer) MemberBalancer(members []kmsg.JoinGroupResponseMember) (
 }
 
 func (*rangeBalancer) Balance(b *ConsumerBalancer, topics map[string]int32) IntoSyncAssignment {
+	// Build member rack lookup for rack-aware assignment.
+	memberRack := make(map[string]string, len(b.members))
+	for i := range b.members {
+		if b.metadatas[i].Rack != nil {
+			memberRack[b.members[i].MemberID] = *b.metadatas[i].Rack
+		}
+	}
+
 	topics2PotentialConsumers := make(map[string][]*kmsg.JoinGroupResponseMember)
 	b.EachMember(func(member *kmsg.JoinGroupResponseMember, meta *kmsg.ConsumerMemberMetadata) {
 		for _, topic := range meta.Topics {
@@ -632,28 +711,53 @@ func (*rangeBalancer) Balance(b *ConsumerBalancer, topics map[string]int32) Into
 	plan := b.NewPlan()
 	for topic, potentialConsumers := range topics2PotentialConsumers {
 		sortJoinMemberPtrs(potentialConsumers)
+		numPartitions := int(topics[topic])
+		nConsumers := len(potentialConsumers)
+		div, rem := numPartitions/nConsumers, numPartitions%nConsumers
 
-		numPartitions := topics[topic]
-		partitions := make([]int32, numPartitions)
-		for i := range partitions {
-			partitions[i] = int32(i)
-		}
-		numParts := len(partitions)
-		div, rem := numParts/len(potentialConsumers), numParts%len(potentialConsumers)
+		assigned := make([]bool, numPartitions)
+		assignCount := make([]int, nConsumers)
 
-		var consumerIdx int
-		for len(partitions) > 0 {
-			num := div
-			if rem > 0 {
-				num++
-				rem--
+		// Phase 1: if rack info is available, assign rack-matching
+		// partitions first. This is a no-op when partitionRacks is nil.
+		if topicRacks := b.partitionRacks[topic]; topicRacks != nil {
+			for ci, consumer := range potentialConsumers {
+				rack := memberRack[consumer.MemberID]
+				if rack == "" {
+					continue
+				}
+				maxForConsumer := div
+				if ci < rem {
+					maxForConsumer++
+				}
+				for p := 0; p < numPartitions && assignCount[ci] < maxForConsumer; p++ {
+					if assigned[p] {
+						continue
+					}
+					if p < len(topicRacks) && topicRacks[p] == rack {
+						plan.AddPartition(consumer, topic, int32(p))
+						assigned[p] = true
+						assignCount[ci]++
+					}
+				}
 			}
+		}
 
-			member := potentialConsumers[consumerIdx]
-			plan.AddPartitions(member, topic, partitions[:num])
-
-			consumerIdx++
-			partitions = partitions[num:]
+		// Phase 2: assign remaining partitions using range.
+		pIdx := 0
+		for ci := 0; ci < nConsumers; ci++ {
+			maxForConsumer := div
+			if ci < rem {
+				maxForConsumer++
+			}
+			quota := maxForConsumer - assignCount[ci]
+			for pIdx < numPartitions && quota > 0 {
+				if !assigned[pIdx] {
+					plan.AddPartition(potentialConsumers[ci], topic, int32(pIdx))
+					quota--
+				}
+				pIdx++
+			}
 		}
 	}
 
@@ -781,6 +885,10 @@ func (s *stickyBalancer) Balance(b *ConsumerBalancer, topics map[string]int32) I
 	// See my (slightly rambling) comment on KAFKA-8432.
 	stickyMembers := make([]sticky.GroupMember, 0, len(b.Members()))
 	b.EachMember(func(member *kmsg.JoinGroupResponseMember, meta *kmsg.ConsumerMemberMetadata) {
+		var rack string
+		if meta.Rack != nil {
+			rack = *meta.Rack
+		}
 		stickyMembers = append(stickyMembers, sticky.GroupMember{
 			ID:          member.MemberID,
 			Topics:      meta.Topics,
@@ -788,10 +896,11 @@ func (s *stickyBalancer) Balance(b *ConsumerBalancer, topics map[string]int32) I
 			Owned:       meta.OwnedPartitions,
 			Generation:  meta.Generation,
 			Cooperative: s.cooperative,
+			Rack:        rack,
 		})
 	})
 
-	p := &BalancePlan{sticky.Balance(stickyMembers, topics)}
+	p := &BalancePlan{sticky.BalanceWithRacks(stickyMembers, topics, b.partitionRacks)}
 	if s.cooperative {
 		p.AdjustCooperative(b)
 	}

--- a/pkg/kgo/group_balancer_test.go
+++ b/pkg/kgo/group_balancer_test.go
@@ -99,6 +99,253 @@ func Test_stickyAdjustCooperative(t *testing.T) {
 	}
 }
 
+func TestRangeBalancerRackAware(t *testing.T) {
+	t.Parallel()
+
+	rackA := "rackA"
+	rackB := "rackB"
+
+	members := []kmsg.JoinGroupResponseMember{
+		{MemberID: "A"},
+		{MemberID: "B"},
+	}
+	metadatas := []kmsg.ConsumerMemberMetadata{
+		{Topics: []string{"t1"}, Rack: &rackA},
+		{Topics: []string{"t1"}, Rack: &rackB},
+	}
+
+	rb := &rangeBalancer{}
+	b := &ConsumerBalancer{
+		b:         rb,
+		members:   members,
+		metadatas: metadatas,
+		topics:    map[string]struct{}{"t1": {}},
+		partitionRacks: map[string][]string{
+			"t1": {"rackA", "rackB", "rackA", "rackB"},
+		},
+	}
+
+	topics := map[string]int32{"t1": 4}
+	plan := rb.Balance(b, topics)
+	bp := plan.(*BalancePlan)
+
+	// With rack-aware, A (rackA) should get rackA partitions (0,2)
+	// and B (rackB) should get rackB partitions (1,3).
+	aParts := bp.plan["A"]["t1"]
+	bParts := bp.plan["B"]["t1"]
+	if len(aParts) != 2 || len(bParts) != 2 {
+		t.Fatalf("expected 2 partitions each, got A=%v B=%v", aParts, bParts)
+	}
+
+	for _, p := range aParts {
+		if b.partitionRacks["t1"][p] != "rackA" {
+			t.Errorf("A (rackA) got non-rackA partition %d", p)
+		}
+	}
+	for _, p := range bParts {
+		if b.partitionRacks["t1"][p] != "rackB" {
+			t.Errorf("B (rackB) got non-rackB partition %d", p)
+		}
+	}
+}
+
+func TestRangeBalancerNoRacks(t *testing.T) {
+	t.Parallel()
+	// Without rack info, range balancer should work as before.
+	members := []kmsg.JoinGroupResponseMember{
+		{MemberID: "A"},
+		{MemberID: "B"},
+	}
+	metadatas := []kmsg.ConsumerMemberMetadata{
+		{Topics: []string{"t1"}},
+		{Topics: []string{"t1"}},
+	}
+
+	rb := &rangeBalancer{}
+	b := &ConsumerBalancer{
+		b:         rb,
+		members:   members,
+		metadatas: metadatas,
+		topics:    map[string]struct{}{"t1": {}},
+	}
+
+	topics := map[string]int32{"t1": 4}
+	plan := rb.Balance(b, topics)
+	bp := plan.(*BalancePlan)
+
+	// Standard range: A gets [0,1], B gets [2,3].
+	aParts := bp.plan["A"]["t1"]
+	bParts := bp.plan["B"]["t1"]
+	if !reflect.DeepEqual(aParts, []int32{0, 1}) {
+		t.Errorf("expected A=[0,1], got %v", aParts)
+	}
+	if !reflect.DeepEqual(bParts, []int32{2, 3}) {
+		t.Errorf("expected B=[2,3], got %v", bParts)
+	}
+}
+
+// rangeBalance is a test helper that builds a ConsumerBalancer and runs the
+// range balancer. Each member is {ID, Topics, Rack} as a simple struct.
+type rangeMember struct {
+	id     string
+	topics []string
+	rack   string // empty means no rack
+}
+
+func rangeBalance(members []rangeMember, topics map[string]int32, partitionRacks map[string][]string) *BalancePlan {
+	rb := &rangeBalancer{}
+	jMembers := make([]kmsg.JoinGroupResponseMember, len(members))
+	metas := make([]kmsg.ConsumerMemberMetadata, len(members))
+	allTopics := make(map[string]struct{})
+	for i, m := range members {
+		jMembers[i] = kmsg.JoinGroupResponseMember{MemberID: m.id}
+		metas[i] = kmsg.ConsumerMemberMetadata{Topics: m.topics}
+		if m.rack != "" {
+			r := m.rack
+			metas[i].Rack = &r
+		}
+		for _, t := range m.topics {
+			allTopics[t] = struct{}{}
+		}
+	}
+	b := &ConsumerBalancer{
+		b:              rb,
+		members:        jMembers,
+		metadatas:      metas,
+		topics:         allTopics,
+		partitionRacks: partitionRacks,
+	}
+	return rb.Balance(b, topics).(*BalancePlan)
+}
+
+func TestRangeBalancerRackNoMatchingRacks(t *testing.T) {
+	t.Parallel()
+	// Partition racks don't match any consumer rack: phase 1 assigns
+	// nothing, phase 2 does standard range.
+	members := []rangeMember{
+		{"A", []string{"t1"}, "rackX"},
+		{"B", []string{"t1"}, "rackY"},
+	}
+	bp := rangeBalance(members, map[string]int32{"t1": 4}, map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB"},
+	})
+
+	// Falls through to standard range: A=[0,1], B=[2,3].
+	if !reflect.DeepEqual(bp.plan["A"]["t1"], []int32{0, 1}) {
+		t.Errorf("A: want [0,1], got %v", bp.plan["A"]["t1"])
+	}
+	if !reflect.DeepEqual(bp.plan["B"]["t1"], []int32{2, 3}) {
+		t.Errorf("B: want [2,3], got %v", bp.plan["B"]["t1"])
+	}
+}
+
+func TestRangeBalancerRackMixedMemberRacks(t *testing.T) {
+	t.Parallel()
+	// A has a rack, B has no rack. Phase 1 assigns rack-matched
+	// partitions to A up to quota. B gets remainder in phase 2.
+	members := []rangeMember{
+		{"A", []string{"t1"}, "rackA"},
+		{"B", []string{"t1"}, ""},
+	}
+	bp := rangeBalance(members, map[string]int32{"t1": 4}, map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB"},
+	})
+
+	// A's quota is 2. Phase 1: A gets p0(rackA), p2(rackA) = 2.
+	// Phase 2: B gets p1, p3 (the unassigned ones).
+	aParts := bp.plan["A"]["t1"]
+	bParts := bp.plan["B"]["t1"]
+	if len(aParts) != 2 || len(bParts) != 2 {
+		t.Fatalf("want 2 each, got A=%v B=%v", aParts, bParts)
+	}
+	// A should have the rackA partitions (0 and 2).
+	for _, p := range aParts {
+		rack := map[string][]string{"t1": {"rackA", "rackB", "rackA", "rackB"}}["t1"][p]
+		if rack != "rackA" {
+			t.Errorf("A(rackA) got partition %d with rack %s", p, rack)
+		}
+	}
+}
+
+func TestRangeBalancerRackShortRackSlice(t *testing.T) {
+	t.Parallel()
+	// partitionRacks has fewer entries than the actual partition count.
+	// Partitions beyond the rack slice should fall through to phase 2.
+	members := []rangeMember{
+		{"A", []string{"t1"}, "rackA"},
+		{"B", []string{"t1"}, "rackB"},
+	}
+	bp := rangeBalance(members, map[string]int32{"t1": 6}, map[string][]string{
+		"t1": {"rackA", "rackB"}, // only 2 entries for 6 partitions
+	})
+
+	// Phase 1: A gets p0(rackA), B gets p1(rackB). Each has 1/3 quota used.
+	// Phase 2: remaining 4 partitions distributed by range.
+	// A quota=3, used=1, needs 2 more. B quota=3, used=1, needs 2 more.
+	aTotal := len(bp.plan["A"]["t1"])
+	bTotal := len(bp.plan["B"]["t1"])
+	if aTotal != 3 || bTotal != 3 {
+		t.Errorf("want A=3 B=3, got A=%d B=%d", aTotal, bTotal)
+	}
+}
+
+func TestRangeBalancerRackOddPartitions(t *testing.T) {
+	t.Parallel()
+	// 5 partitions, 2 consumers: div=2, rem=1. First consumer gets 3.
+	// With racks: the remainder partition should still respect range order.
+	members := []rangeMember{
+		{"A", []string{"t1"}, "rackA"},
+		{"B", []string{"t1"}, "rackB"},
+	}
+	bp := rangeBalance(members, map[string]int32{"t1": 5}, map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB", "rackA"},
+	})
+
+	// A(rackA) quota=3: phase 1 grabs p0,p2,p4 (all rackA). Done.
+	// B(rackB) quota=2: phase 1 grabs p1,p3 (both rackB). Done.
+	aParts := bp.plan["A"]["t1"]
+	bParts := bp.plan["B"]["t1"]
+	if len(aParts) != 3 || len(bParts) != 2 {
+		t.Fatalf("want A=3 B=2, got A=%v B=%v", aParts, bParts)
+	}
+}
+
+func TestRangeBalancerRackMultiTopicDisjoint(t *testing.T) {
+	t.Parallel()
+	// Two topics with different subscriptions and different rack layouts.
+	// t1: A,B subscribe; all partitions rackA.
+	// t2: B,C subscribe; all partitions rackB.
+	members := []rangeMember{
+		{"A", []string{"t1"}, "rackA"},
+		{"B", []string{"t1", "t2"}, "rackB"},
+		{"C", []string{"t2"}, "rackA"},
+	}
+	bp := rangeBalance(members,
+		map[string]int32{"t1": 4, "t2": 4},
+		map[string][]string{
+			"t1": {"rackA", "rackA", "rackA", "rackA"},
+			"t2": {"rackB", "rackB", "rackB", "rackB"},
+		},
+	)
+
+	// t1: A(rackA) quota=2, gets p0,p1 via phase 1. B(rackB) quota=2,
+	//     no rack match in phase 1, gets p2,p3 via phase 2.
+	// t2: B(rackB) quota=2, gets p0,p1 via phase 1. C(rackA) quota=2,
+	//     no rack match, gets p2,p3 via phase 2.
+	if len(bp.plan["A"]["t1"]) != 2 {
+		t.Errorf("A t1: want 2, got %v", bp.plan["A"]["t1"])
+	}
+	if len(bp.plan["B"]["t1"]) != 2 {
+		t.Errorf("B t1: want 2, got %v", bp.plan["B"]["t1"])
+	}
+	if len(bp.plan["B"]["t2"]) != 2 {
+		t.Errorf("B t2: want 2, got %v", bp.plan["B"]["t2"])
+	}
+	if len(bp.plan["C"]["t2"]) != 2 {
+		t.Errorf("C t2: want 2, got %v", bp.plan["C"]["t2"])
+	}
+}
+
 func TestNewConsumerBalancerIssue493(t *testing.T) {
 	m := kmsg.NewConsumerMemberMetadata()
 	m.Version = 0

--- a/pkg/kgo/internal/sticky/sticky.go
+++ b/pkg/kgo/internal/sticky/sticky.go
@@ -29,6 +29,7 @@ type GroupMember struct {
 	Owned       []kmsg.ConsumerMemberMetadataOwnedPartition
 	Generation  int32
 	Cooperative bool
+	Rack        string // KIP-881: empty if not set
 }
 
 // Plan is the plan this package came up with (member => topic => partitions).
@@ -67,6 +68,16 @@ type balancer struct {
 	// stealGraph is a graphical representation of members and partitions
 	// they want to steal.
 	stealGraph graph
+
+	// KIP-881: rack-aware assignment. partRacks is indexed by flat
+	// partNum (same as partOwners), memberRacks by memberNum. Rack
+	// indices are 1-based so that zero-initialized slices naturally
+	// mean "no rack" (noRack == 0). When no rack info is available,
+	// both slices are nil. The nRacks field is the count of distinct
+	// racks; rackHeaps in assignRackAware is indexed by rack-1.
+	memberRacks []uint16
+	partRacks   []uint16
+	nRacks      int
 }
 
 type topicInfo struct {
@@ -75,7 +86,7 @@ type topicInfo struct {
 	topic      string
 }
 
-func newBalancer(members []GroupMember, topics map[string]int32) *balancer {
+func newBalancer(members []GroupMember, topics map[string]int32, partitionRacks map[string][]string) *balancer {
 	var (
 		nparts     int
 		topicNums  = make(map[string]uint32, len(topics))
@@ -119,7 +130,72 @@ func newBalancer(members []GroupMember, topics map[string]int32) *balancer {
 		b.plan[num] = planBuf[:0:evenDivvy]
 		planBuf = planBuf[evenDivvy:]
 	}
+
+	b.initRacks(partitionRacks)
 	return b
+}
+
+// initRacks sets up rack-aware fields if any member and any partition
+// have rack info. Both sides must have racks for rack-aware assignment
+// to be useful.
+func (b *balancer) initRacks(partitionRacks map[string][]string) {
+	if len(partitionRacks) == 0 {
+		return
+	}
+
+	// Map rack strings to small 1-based indices (0 = noRack).
+	rackIndex := make(map[string]uint16)
+	rackOf := func(s string) uint16 {
+		if s == "" {
+			return noRack
+		}
+		idx, ok := rackIndex[s]
+		if !ok {
+			idx = uint16(len(rackIndex) + 1)
+			rackIndex[s] = idx
+		}
+		return idx
+	}
+
+	memberRacks := make([]uint16, len(b.members))
+	var anyMemberRack bool
+	for i := range b.members {
+		memberRacks[i] = rackOf(b.members[i].Rack)
+		if memberRacks[i] != noRack {
+			anyMemberRack = true
+		}
+	}
+	if !anyMemberRack {
+		return
+	}
+
+	// Build flat partRacks indexed by partNum. Zero-init is noRack.
+	partRacks := make([]uint16, cap(b.partOwners))
+	var anyPartRack bool
+	for topic, racks := range partitionRacks {
+		topicNum, ok := b.topicNums[topic]
+		if !ok {
+			continue
+		}
+		info := b.topicInfos[topicNum]
+		for i, rack := range racks {
+			if int32(i) >= info.partitions {
+				break
+			}
+			if rack != "" {
+				idx := rackOf(rack)
+				partRacks[info.partNum+int32(i)] = idx
+				anyPartRack = true
+			}
+		}
+	}
+	if !anyPartRack {
+		return
+	}
+
+	b.partRacks = partRacks
+	b.memberRacks = memberRacks
+	b.nRacks = len(rackIndex)
 }
 
 func (b *balancer) into() Plan {
@@ -271,10 +347,19 @@ func (b *balancer) initPlanByNumPartitions() {
 // Balance performs sticky partitioning for the given group members and topics,
 // returning the determined plan.
 func Balance(members []GroupMember, topics map[string]int32) Plan {
+	return BalanceWithRacks(members, topics, nil)
+}
+
+// BalanceWithRacks performs sticky partitioning with rack-aware assignment
+// (KIP-881). partitionRacks maps topic => partition index => rack of the
+// partition leader. When non-nil and members also have racks, unassigned
+// partitions are preferentially placed on rack-matching members before
+// falling back to normal assignment.
+func BalanceWithRacks(members []GroupMember, topics map[string]int32, partitionRacks map[string][]string) Plan {
 	if len(members) == 0 {
 		return make(Plan)
 	}
-	b := newBalancer(members, topics)
+	b := newBalancer(members, topics, partitionRacks)
 	if cap(b.partOwners) == 0 {
 		return b.into()
 	}
@@ -493,6 +578,15 @@ func (b *balancer) assignUnassignedAndInitGraph() {
 		b.sortMemberByLiteralPartNum(memberNum)
 	}
 
+	// KIP-881: rack-aware pre-assignment for the simple path. For
+	// unassigned partitions with rack info, preferentially assign to
+	// rack-matched members via per-rack heaps. Anything left unassigned
+	// falls through to the normal heap below. The complex path handles
+	// rack preference inline via tie-breaking (see below).
+	if b.partRacks != nil && !b.isComplex {
+		b.assignRackAware(partitionConsumers, topicPotentials)
+	}
+
 	if !b.isComplex && len(topicPotentials) > 0 {
 		potentials := topicPotentials[0]
 		(&membersByPartitions{potentials, b.plan}).init()
@@ -514,13 +608,26 @@ func (b *balancer) assignUnassignedAndInitGraph() {
 			if len(potentials) == 0 {
 				continue
 			}
+			// KIP-881: when partition racks are available, break
+			// ties among equally-loaded members by preferring a
+			// rack-matched member. This preserves optimal balance
+			// while improving rack locality without needing a
+			// separate pre-assignment pass.
+			var pRack uint16 // noRack (0) when no rack info
+			if b.partRacks != nil {
+				pRack = b.partRacks[partNum]
+			}
 			leastConsumingPotential := potentials[0]
 			leastConsuming := len(b.plan[leastConsumingPotential])
+			bestRackMatch := pRack != noRack && b.memberRacks[leastConsumingPotential] == pRack
 			for _, potential := range potentials[1:] {
 				potentialConsuming := len(b.plan[potential])
-				if potentialConsuming < leastConsuming {
+				rackMatch := pRack != noRack && b.memberRacks[potential] == pRack
+				if potentialConsuming < leastConsuming ||
+					potentialConsuming == leastConsuming && rackMatch && !bestRackMatch {
 					leastConsumingPotential = potential
 					leastConsuming = potentialConsuming
+					bestRackMatch = rackMatch
 				}
 			}
 			b.plan[leastConsumingPotential].add(int32(partNum))
@@ -541,6 +648,10 @@ func (b *balancer) assignUnassignedAndInitGraph() {
 // unassignedPart is a fake member number that we use to track if a partition
 // is deleted or unassigned.
 const unassignedPart = math.MaxUint16 - 1
+
+// noRack is the sentinel for "no rack info" in memberRacks / partRacks.
+// Rack indices are 1-based so that zero-initialized slices default to noRack.
+const noRack = 0
 
 // tryRestickyStales is a pre-assigning step where, for all stale members,
 // we give partitions back to them if the partition is currently on an
@@ -577,6 +688,78 @@ func (b *balancer) tryRestickyStales(
 			currentOwnerPartitions.remove(staleNum)
 			lastOwnerPartitions.add(staleNum)
 		}
+	}
+}
+
+// assignRackAware pre-assigns unassigned partitions to members whose rack
+// matches the partition's leader rack, without exceeding the balanced
+// quota. Uses per-rack min-heaps for O(log M) per assignment. Only called
+// for the simple (uniform subscription) path; the complex path handles
+// rack preference inline via tie-breaking in the main assignment loop.
+func (b *balancer) assignRackAware(
+	partitionConsumers []partitionConsumer,
+	topicPotentials [][]uint16,
+) {
+	if len(topicPotentials) == 0 {
+		return
+	}
+	maxQuota := (cap(b.partOwners) + len(b.members) - 1) / len(b.members)
+
+	// Build per-rack heaps indexed by rack index. We track which
+	// indices are populated so setup is O(members) not O(nRacks).
+	type rackHeap struct {
+		mbp membersByPartitions
+	}
+	rackHeaps := make([]rackHeap, b.nRacks)
+	rackCount := make([]int, b.nRacks)
+	var populated []uint16
+	// Count members per rack and track which rack indices are populated.
+	for _, m := range topicPotentials[0] {
+		rack := b.memberRacks[m]
+		if rack != noRack {
+			ri := rack - 1
+			if rackCount[ri] == 0 {
+				populated = append(populated, ri)
+			}
+			rackCount[ri]++
+		}
+	}
+	// Preallocate each populated rack's member slice.
+	for _, i := range populated {
+		rackHeaps[i].mbp.members = make([]uint16, 0, rackCount[i])
+	}
+	// Place each member into its rack's heap.
+	for _, m := range topicPotentials[0] {
+		rack := b.memberRacks[m]
+		if rack != noRack {
+			rackHeaps[rack-1].mbp.members = append(rackHeaps[rack-1].mbp.members, m)
+		}
+	}
+	// Initialize each rack's min-heap by partition count.
+	for _, i := range populated {
+		rackHeaps[i].mbp.plan = b.plan
+		rackHeaps[i].mbp.init()
+	}
+	// Assign unassigned partitions to rack-matched members under quota.
+	for partNum, owner := range partitionConsumers {
+		if owner.memberNum != unassignedPart {
+			continue
+		}
+		pRack := b.partRacks[partNum]
+		if pRack == noRack {
+			continue
+		}
+		rh := &rackHeaps[pRack-1]
+		if len(rh.mbp.members) == 0 {
+			continue
+		}
+		candidate := rh.mbp.members[0]
+		if len(b.plan[candidate]) >= maxQuota {
+			continue
+		}
+		b.plan[candidate].add(int32(partNum))
+		rh.mbp.fix0()
+		partitionConsumers[partNum] = partitionConsumer{candidate, candidate}
 	}
 }
 

--- a/pkg/kgo/internal/sticky/sticky_test.go
+++ b/pkg/kgo/internal/sticky/sticky_test.go
@@ -3,9 +3,7 @@ package sticky
 import (
 	"fmt"
 	"math/rand"
-	"runtime"
 	"testing"
-	"time"
 )
 
 func Test_stickyBalanceStrategy_Plan(t *testing.T) {
@@ -1814,10 +1812,13 @@ const (
 	memberNum    = 100
 )
 
+var racks = []string{"rackA", "rackB", "rackC"}
+
 func makeLargeBalance(withImbalance bool) generatedInput {
 	rng := rand.New(rand.NewSource(0))
 	var allTopics []string
 	topics := make(map[string]int32)
+	partitionRacks := make(map[string][]string)
 	var totalPartitions int
 	for i := range topicNum {
 		n := rng.Intn(partitionNum * 5 / 2)
@@ -1825,6 +1826,11 @@ func makeLargeBalance(withImbalance bool) generatedInput {
 		topic := fmt.Sprintf("topic%d", i)
 		topics[topic] = int32(n)
 		allTopics = append(allTopics, topic)
+		tr := make([]string, n)
+		for j := range tr {
+			tr[j] = racks[j%len(racks)]
+		}
+		partitionRacks[topic] = tr
 	}
 
 	var members []GroupMember
@@ -1832,17 +1838,20 @@ func makeLargeBalance(withImbalance bool) generatedInput {
 		members = append(members, GroupMember{
 			ID:     fmt.Sprintf("consumer%d", i),
 			Topics: allTopics,
+			Rack:   racks[i%len(racks)],
 		})
 	}
 	if withImbalance {
 		members = append(members, GroupMember{
 			ID:     "imbalance",
 			Topics: []string{"topic0"},
+			Rack:   racks[0],
 		})
 	}
 	return generatedInput{
 		members,
 		topics,
+		partitionRacks,
 		totalPartitions,
 	}
 }
@@ -1858,6 +1867,7 @@ func makeLargeBalanceWithExisting(withImbalance bool) generatedInput {
 		input.members = append(input.members, GroupMember{
 			ID:       consumer,
 			Topics:   oldMembers[i].Topics, // evaluated before overwrite
+			Rack:     oldMembers[i].Rack,
 			UserData: udEncode(1, 1, plan[consumer]),
 		})
 	}
@@ -1873,42 +1883,45 @@ var (
 )
 
 func BenchmarkLarge(b *testing.B) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		Balance(large.members, large.topics)
-	}
-}
-
-func BenchmarkLargeWithExisting(b *testing.B) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		Balance(largeWithExisting.members[1:], largeWithExisting.topics)
-	}
-}
-
-func BenchmarkLargeImbalanced(b *testing.B) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		Balance(largeImbalanced.members, largeImbalanced.topics)
-	}
-}
-
-func BenchmarkLargeWithExistingImbalanced(b *testing.B) {
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		Balance(largeWithExistingImbalanced.members[1:], largeWithExistingImbalanced.topics)
+	for _, bench := range []struct {
+		name  string
+		input generatedInput
+	}{
+		{"fresh", large},
+		{"existing", largeWithExisting},
+		{"imbalanced", largeImbalanced},
+		{"existing_imbalanced", largeWithExistingImbalanced},
+	} {
+		members := bench.input.members
+		if bench.name == "existing" || bench.name == "existing_imbalanced" {
+			members = members[1:]
+		}
+		b.Run(bench.name+"/no_rack", func(b *testing.B) {
+			for b.Loop() {
+				Balance(members, bench.input.topics)
+			}
+		})
+		b.Run(bench.name+"/rack", func(b *testing.B) {
+			for b.Loop() {
+				BalanceWithRacks(members, bench.input.topics, bench.input.partitionRacks)
+			}
+		})
 	}
 }
 
 type generatedInput struct {
-	members []GroupMember
-	topics  map[string]int32
+	members        []GroupMember
+	topics         map[string]int32
+	partitionRacks map[string][]string
 
 	totalPartitions int
 }
 
 func makeJavaPlan(topicCount, partitionCount, consumerCount int, imbalanced bool) generatedInput {
-	p := generatedInput{topics: make(map[string]int32)}
+	p := generatedInput{
+		topics:         make(map[string]int32),
+		partitionRacks: make(map[string][]string),
+	}
 	var allTopics []string
 
 	for i := range topicCount {
@@ -1916,12 +1929,18 @@ func makeJavaPlan(topicCount, partitionCount, consumerCount int, imbalanced bool
 		allTopics = append(allTopics, topic)
 		p.topics[topic] = int32(partitionCount)
 		p.totalPartitions += partitionCount
+		tr := make([]string, partitionCount)
+		for j := range tr {
+			tr[j] = racks[j%len(racks)]
+		}
+		p.partitionRacks[topic] = tr
 	}
 
 	for i := range consumerCount {
 		p.members = append(p.members, GroupMember{
 			ID:     fmt.Sprintf("c%d", i),
 			Topics: allTopics,
+			Rack:   racks[i%len(racks)],
 		})
 	}
 
@@ -1929,6 +1948,7 @@ func makeJavaPlan(topicCount, partitionCount, consumerCount int, imbalanced bool
 		p.members = append(p.members, GroupMember{
 			ID:     fmt.Sprintf("c%d", consumerCount),
 			Topics: allTopics[:1],
+			Rack:   racks[0],
 		})
 	}
 
@@ -1958,19 +1978,635 @@ func BenchmarkJava(b *testing.B) {
 		{"small", javaSmall},
 		{"small_imbalance", javaSmallImbalance},
 	} {
-		b.Run(bench.name, func(b *testing.B) {
-			start := time.Now()
-			for n := 0; n < b.N; n++ {
+		b.Run(bench.name+"/no_rack", func(b *testing.B) {
+			for b.Loop() {
 				Balance(bench.input.members, bench.input.topics)
-				runtime.GC()
-				runtime.GC()
 			}
-			b.Logf("avg %v per %d balances of %d members and %d total partitions",
-				time.Since(start)/time.Duration(b.N),
-				b.N,
-				len(bench.input.members),
-				bench.input.totalPartitions,
-			)
 		})
+		b.Run(bench.name+"/rack", func(b *testing.B) {
+			for b.Loop() {
+				BalanceWithRacks(bench.input.members, bench.input.topics, bench.input.partitionRacks)
+			}
+		})
+	}
+}
+
+// countRackMatches counts how many assigned partitions are on the same
+// rack as the member consuming them.
+func countRackMatches(plan Plan, members []GroupMember, partitionRacks map[string][]string) int {
+	memberRack := make(map[string]string)
+	for _, m := range members {
+		memberRack[m.ID] = m.Rack
+	}
+	var matches int
+	for member, topics := range plan {
+		rack := memberRack[member]
+		if rack == "" {
+			continue
+		}
+		for topic, partitions := range topics {
+			racks := partitionRacks[topic]
+			for _, p := range partitions {
+				if int(p) < len(racks) && racks[p] == rack {
+					matches++
+				}
+			}
+		}
+	}
+	return matches
+}
+
+func TestRackAwareBasic(t *testing.T) {
+	t.Parallel()
+	// Two members in different racks, two topics with two partitions
+	// each. Partition leaders are split across racks.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1", "t2"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1", "t2"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 2, "t2": 2}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackB"},
+		"t2": {"rackA", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	if matches != 4 {
+		t.Errorf("expected 4 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareBalanceOverLocality(t *testing.T) {
+	t.Parallel()
+	// Three members: two in rackA, one in rackB. All partitions in
+	// rackA. Balance must still be maintained - we should not overload
+	// rackA members just because they match.
+	members := []GroupMember{
+		{ID: "A1", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "A2", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "B1", Topics: []string{"t1"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 6}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackA", "rackA", "rackA", "rackA", "rackA"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	// Each member should get exactly 2 partitions (6/3).
+	for member, memberTopics := range plan {
+		n := partitionsForMember(memberTopics)
+		if n != 2 {
+			t.Errorf("member %s has %d partitions, want 2", member, n)
+		}
+	}
+}
+
+func TestRackAwareNoRackInfo(t *testing.T) {
+	t.Parallel()
+	// Members have racks but no partition rack info - should behave
+	// identically to Balance().
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 4}
+
+	plan := BalanceWithRacks(members, topics, nil)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	planNoRack := Balance(members, topics)
+	testPlanUsage(t, planNoRack, topics, nil)
+	testEqualDivvy(t, planNoRack, 0, members)
+}
+
+func TestRackAwareNoMemberRack(t *testing.T) {
+	t.Parallel()
+	// Partition racks present but no member has a rack - should
+	// fall back to normal assignment.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1"}},
+		{ID: "B", Topics: []string{"t1"}},
+	}
+	topics := map[string]int32{"t1": 4}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackA", "rackB", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+}
+
+func TestRackAwareMixedRacks(t *testing.T) {
+	t.Parallel()
+	// Some members have racks, some don't. Members with racks should
+	// get rack-matched partitions; member without rack gets the rest.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"t1"}},
+	}
+	topics := map[string]int32{"t1": 6}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackA", "rackB", "rackB", "rackA", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	// Each member gets 2 partitions. A and B should have rack-matched
+	// partitions since there are enough.
+	matches := countRackMatches(plan, members, partitionRacks)
+	if matches < 4 {
+		t.Errorf("expected at least 4 rack matches (A and B each 2), got %d", matches)
+	}
+}
+
+func TestRackAwareComplex(t *testing.T) {
+	t.Parallel()
+	// Complex subscriptions: members subscribe to different topics.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1", "t2"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"t2"}, Rack: "rackA"},
+	}
+	topics := map[string]int32{"t1": 4, "t2": 4}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB"},
+		"t2": {"rackA", "rackB", "rackA", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+
+	// All 8 partitions should be assigned.
+	total := 0
+	for _, memberTopics := range plan {
+		total += partitionsForMember(memberTopics)
+	}
+	if total != 8 {
+		t.Errorf("expected 8 total partitions assigned, got %d", total)
+	}
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	if matches < 4 {
+		t.Errorf("expected at least 4 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareSticky(t *testing.T) {
+	t.Parallel()
+	// First balance assigns with rack awareness. Second balance
+	// (simulating a rebalance) should preserve sticky assignments.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 4}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackA", "rackB", "rackB"},
+	}
+
+	plan1 := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan1, topics, nil)
+	testEqualDivvy(t, plan1, 0, members)
+
+	// Build members with prior assignment for second balance.
+	members2 := make([]GroupMember, len(members))
+	for i, m := range members {
+		members2[i] = GroupMember{
+			ID:       m.ID,
+			Topics:   m.Topics,
+			Rack:     m.Rack,
+			UserData: newUD().setGeneration(1).assign("t1", plan1[m.ID]["t1"]...).encode(),
+		}
+	}
+
+	plan2 := BalanceWithRacks(members2, topics, partitionRacks)
+	testPlanUsage(t, plan2, topics, nil)
+	testEqualDivvy(t, plan2, 4, members2) // all 4 partitions should be sticky
+}
+
+func TestRackAwareNewMember(t *testing.T) {
+	t.Parallel()
+	// Start with 2 members, then add a third. The new member should
+	// preferentially get rack-matched partitions.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 6}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB", "rackA", "rackB"},
+	}
+
+	plan1 := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan1, topics, nil)
+
+	// Add a new member in rackA. Rebalance should give it rack-matched
+	// partitions where possible.
+	members2 := []GroupMember{
+		{
+			ID: "A", Topics: []string{"t1"}, Rack: "rackA",
+			UserData: newUD().setGeneration(1).assign("t1", plan1["A"]["t1"]...).encode(),
+		},
+		{
+			ID: "B", Topics: []string{"t1"}, Rack: "rackB",
+			UserData: newUD().setGeneration(1).assign("t1", plan1["B"]["t1"]...).encode(),
+		},
+		{ID: "C", Topics: []string{"t1"}, Rack: "rackA"},
+	}
+
+	plan2 := BalanceWithRacks(members2, topics, partitionRacks)
+	testPlanUsage(t, plan2, topics, nil)
+	testEqualDivvy(t, plan2, 4, members2) // 4 of 6 partitions should be sticky
+
+	// C is in rackA, verify at least one of its partitions matches rackA.
+	cParts := plan2["C"]["t1"]
+	rackAMatches := 0
+	for _, p := range cParts {
+		if partitionRacks["t1"][p] == "rackA" {
+			rackAMatches++
+		}
+	}
+	if rackAMatches == 0 {
+		t.Errorf("new member C in rackA got no rackA partitions: %v", cParts)
+	}
+}
+
+func TestRackAwareManyMembers(t *testing.T) {
+	t.Parallel()
+	// Larger scale test: 10 members across 3 racks, 30 partitions.
+	members := make([]GroupMember, 10)
+	racks := []string{"rackA", "rackB", "rackC"}
+	for i := range members {
+		members[i] = GroupMember{
+			ID:     fmt.Sprintf("M%d", i),
+			Topics: []string{"t1"},
+			Rack:   racks[i%3],
+		}
+	}
+	topics := map[string]int32{"t1": 30}
+	partitionRacks := map[string][]string{
+		"t1": make([]string, 30),
+	}
+	for i := range partitionRacks["t1"] {
+		partitionRacks["t1"][i] = racks[i%3]
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	// 4 members in rackA (i%3==0), 3 each in rackB/rackC. 10
+	// partitions per rack. rackA has 12 slots but only 10 matching
+	// partitions; rackB/rackC each have 9 slots but 10 matching
+	// partitions. Max rack matches = 10 + 9 + 9 = 28.
+	if matches != 28 {
+		t.Errorf("expected 28 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwarePyramidSubscriptions(t *testing.T) {
+	t.Parallel()
+	// Pyramid subscriptions where A subscribes broadly, others to
+	// subsets. Rack assignments alternate across partitions. The
+	// complex path must handle rack-aware pre-assignment across
+	// varying subscription widths without breaking balance.
+	//
+	// Subscriptions (pyramid shape):
+	//   1: A, B
+	//   2: A, B
+	//   3: A, B, C
+	//   4: A, B, C
+	//   5: A, B, C, D
+	//   6: A, B, C, D
+	//   7: A, C, D
+	//   8: A, C, D
+	//
+	// 8 partitions, 4 members, 2 each. Rack alternates A/B per topic.
+	// With 4 rackA partitions (1,3,5,7) and 4 rackB (2,4,6,8), the
+	// two rackA members (A,C) and two rackB members (B,D) should each
+	// get rack-matched partitions despite the subscription constraints.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"1", "2", "3", "4", "5", "6", "7", "8"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"1", "2", "3", "4", "5", "6"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"3", "4", "5", "6", "7", "8"}, Rack: "rackA"},
+		{ID: "D", Topics: []string{"5", "6", "7", "8"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{
+		"1": 1, "2": 1, "3": 1, "4": 1,
+		"5": 1, "6": 1, "7": 1, "8": 1,
+	}
+	partitionRacks := map[string][]string{
+		"1": {"rackA"}, "2": {"rackB"}, "3": {"rackA"}, "4": {"rackB"},
+		"5": {"rackA"}, "6": {"rackB"}, "7": {"rackA"}, "8": {"rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	if matches < 6 {
+		t.Errorf("expected at least 6 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareThreeRacksHomeTopics(t *testing.T) {
+	t.Parallel()
+	// Three racks, each member has a "home" topic (same rack as member)
+	// plus a shared topic with partitions spread across all racks.
+	// Each home topic can only be consumed by its member, so the member
+	// must get all 3 of its home partitions. The shared topic's 6
+	// partitions (2 per rack) should be rack-matched: each member gets
+	// the 2 shared partitions in their rack.
+	//
+	// 15 partitions, 3 members, 5 each.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"home_a", "shared"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"home_b", "shared"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"home_c", "shared"}, Rack: "rackC"},
+	}
+	topics := map[string]int32{"home_a": 3, "home_b": 3, "home_c": 3, "shared": 6}
+	partitionRacks := map[string][]string{
+		"home_a": {"rackA", "rackA", "rackA"},
+		"home_b": {"rackB", "rackB", "rackB"},
+		"home_c": {"rackC", "rackC", "rackC"},
+		"shared": {"rackA", "rackA", "rackB", "rackB", "rackC", "rackC"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	// Each member gets all 3 home partitions (rack-matched = 9 guaranteed).
+	// The 6 shared partitions are split by the complex path; map iteration
+	// order can cause some shared partitions to land on a mismatched rack.
+	if matches < 9 {
+		t.Errorf("expected at least 9 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareSimpleMultiPartition(t *testing.T) {
+	t.Parallel()
+	// Simple path: all members subscribe to all topics. Three
+	// multi-partition topics with rotated rack patterns so that
+	// each rack has exactly 6 partitions across all topics. One
+	// member per rack, 6 partitions each - perfect rack matching
+	// should be achievable.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1", "t2", "t3"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1", "t2", "t3"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"t1", "t2", "t3"}, Rack: "rackC"},
+	}
+	topics := map[string]int32{"t1": 6, "t2": 6, "t3": 6}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackA", "rackB", "rackB", "rackC", "rackC"},
+		"t2": {"rackB", "rackB", "rackC", "rackC", "rackA", "rackA"},
+		"t3": {"rackC", "rackC", "rackA", "rackA", "rackB", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	// 6 partitions per rack, one member per rack, 6 each. Perfect = 18.
+	if matches < 14 {
+		t.Errorf("expected at least 14 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareOverlappingTopics(t *testing.T) {
+	t.Parallel()
+	// Four members with overlapping subscriptions across three topics
+	// that have very different rack layouts:
+	//   t1 (4 partitions, all rackA) - only A,B subscribe
+	//   t2 (4 partitions, mixed)     - all four subscribe
+	//   t3 (4 partitions, all rackB) - only C,D subscribe
+	//
+	// The shared t2 creates tension: its rackA partitions should go to
+	// A or C (rackA members), its rackB to B or D. But subscription
+	// constraints force A,B to split t1 and C,D to split t3.
+	//
+	// 12 partitions, 4 members, 3 each.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1", "t2"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1", "t2"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"t2", "t3"}, Rack: "rackA"},
+		{ID: "D", Topics: []string{"t2", "t3"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 4, "t2": 4, "t3": 4}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackA", "rackA", "rackA"},
+		"t2": {"rackA", "rackB", "rackA", "rackB"},
+		"t3": {"rackB", "rackB", "rackB", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	// A(rackA) should get t1 rackA partitions + a t2 rackA partition.
+	// D(rackB) should get t3 rackB partitions + a t2 rackB partition.
+	// B gets some t1 (rackA, no match) + t2 rackB. C gets t2 rackA + t3 (no match).
+	// Max achievable: 8.
+	if matches < 6 {
+		t.Errorf("expected at least 6 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareMemberLeaves(t *testing.T) {
+	t.Parallel()
+	// Round 1: three members balanced with rack awareness.
+	// Round 2: one member leaves. Its partitions become unassigned and
+	// the rack-aware pre-assignment should place them on rack-matched
+	// remaining members.
+	//
+	// t1 has 6 partitions alternating rackA/rackB. In round 1,
+	// A(rackA) and C(rackA) share the rackA partitions, B(rackB) gets
+	// the rackB ones. When C leaves, its rackA partitions should flow
+	// to A (also rackA), and B keeps its rackB partitions.
+	members1 := []GroupMember{
+		{ID: "A", Topics: []string{"t1"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"t1"}, Rack: "rackA"},
+	}
+	topics := map[string]int32{"t1": 6}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB", "rackA", "rackB"},
+	}
+
+	plan1 := BalanceWithRacks(members1, topics, partitionRacks)
+	testPlanUsage(t, plan1, topics, nil)
+	testEqualDivvy(t, plan1, 0, members1)
+
+	// C leaves. A and B carry prior assignments.
+	members2 := []GroupMember{
+		{
+			ID: "A", Topics: []string{"t1"}, Rack: "rackA",
+			UserData: newUD().assign("t1", plan1["A"]["t1"]...).encode(),
+		},
+		{
+			ID: "B", Topics: []string{"t1"}, Rack: "rackB",
+			UserData: newUD().assign("t1", plan1["B"]["t1"]...).encode(),
+		},
+	}
+
+	plan2 := BalanceWithRacks(members2, topics, partitionRacks)
+	testPlanUsage(t, plan2, topics, nil)
+	testEqualDivvy(t, plan2, 4, members2) // A and B each keep their 2 from round 1
+
+	matches := countRackMatches(plan2, members2, partitionRacks)
+	// In round 1, the last rackB partition goes to A (rackA) via normal
+	// fallback since B hits maxQuota first. Stickiness preserves that
+	// mismatch in round 2, limiting rack matches to 4 instead of 6.
+	if matches < 4 {
+		t.Errorf("expected at least 4 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareTopicGrowth(t *testing.T) {
+	t.Parallel()
+	// Topic grows from 4 to 8 partitions. Prior assignments (already
+	// rack-matched) should stay sticky. New partitions should also
+	// be rack-matched via the rack-aware pre-assignment phase.
+	members := []GroupMember{
+		{
+			ID: "A", Topics: []string{"t1"}, Rack: "rackA",
+			UserData: newUD().assign("t1", 0, 2).encode(),
+		},
+		{
+			ID: "B", Topics: []string{"t1"}, Rack: "rackB",
+			UserData: newUD().assign("t1", 1, 3).encode(),
+		},
+	}
+	topics := map[string]int32{"t1": 8}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB", "rackA", "rackB", "rackA", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 4, members) // prior 4 partitions stay sticky
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	// Prior: A has p0(rackA),p2(rackA) = 2 matches. B has p1(rackB),p3(rackB) = 2.
+	// New: p4(rackA),p6(rackA) -> A; p5(rackB),p7(rackB) -> B.
+	// Total: 8 matches.
+	if matches < 6 {
+		t.Errorf("expected at least 6 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareImbalancedSubs(t *testing.T) {
+	t.Parallel()
+	// Members have constrained subscriptions: B can only consume t1,
+	// C can only consume t2. A bridges both topics. Rack-aware must
+	// work within these subscription constraints.
+	//
+	// t1: 4 partitions [rackA, rackB, rackA, rackB] - consumed by A,B
+	// t2: 2 partitions [rackA, rackB]                - consumed by A,C
+	//
+	// 6 partitions, 3 members, 2 each.
+	// B(rackB) should get rackB partitions from t1.
+	// A(rackA) should get rackA partitions from t1.
+	// C(rackA) should get rackA partition from t2 (plus one rackB).
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1", "t2"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1"}, Rack: "rackB"},
+		{ID: "C", Topics: []string{"t2"}, Rack: "rackA"},
+	}
+	topics := map[string]int32{"t1": 4, "t2": 2}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "rackB", "rackA", "rackB"},
+		"t2": {"rackA", "rackB"},
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	if matches < 4 {
+		t.Errorf("expected at least 4 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareSparseRacks(t *testing.T) {
+	t.Parallel()
+	// Some partitions have no rack info (empty string), some have a rack
+	// that no member matches, and partitionRacks references a topic not
+	// in the topics map. Tests defensive branches in initRacks and
+	// assignRackAware's simple path.
+	members := []GroupMember{
+		{ID: "A", Topics: []string{"t1", "t2"}, Rack: "rackA"},
+		{ID: "B", Topics: []string{"t1", "t2"}, Rack: "rackB"},
+	}
+	topics := map[string]int32{"t1": 4, "t2": 3}
+	partitionRacks := map[string][]string{
+		"t1":        {"rackA", "", "rackC", "rackB"},      // p1 empty, p2 unmatched rack
+		"t2":        {"rackA", "rackB", "rackA", "extra"}, // index 3 exceeds t2's 3 partitions
+		"no_such_t": {"rackA"},                            // topic not in topics map
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+	testEqualDivvy(t, plan, 0, members)
+
+	matches := countRackMatches(plan, members, partitionRacks)
+	if matches < 3 {
+		t.Errorf("expected at least 3 rack matches, got %d", matches)
+	}
+}
+
+func TestRackAwareSparseRacksComplex(t *testing.T) {
+	t.Parallel()
+	// Different subscriptions with sparse rack info and prior
+	// assignments. Exercises the complex path's skip-already-assigned
+	// branch, empty-rack branch, and unmatched-rack branch.
+	members := []GroupMember{
+		{
+			ID: "A", Topics: []string{"t1", "t2"}, Rack: "rackA",
+			UserData: newUD().assign("t1", 0).assign("t2", 1).encode(),
+		},
+		{
+			ID: "B", Topics: []string{"t1"}, Rack: "rackB",
+			UserData: newUD().assign("t1", 1).encode(),
+		},
+		{
+			ID: "C", Topics: []string{"t2"}, Rack: "rackA",
+			UserData: newUD().assign("t2", 0).encode(),
+		},
+	}
+	topics := map[string]int32{"t1": 4, "t2": 4}
+	partitionRacks := map[string][]string{
+		"t1": {"rackA", "", "rackC", "rackB"}, // p1 empty, p2 unmatched
+		"t2": {"", "rackA", "", "rackB"},      // p0,p2 empty
+
+	}
+
+	plan := BalanceWithRacks(members, topics, partitionRacks)
+	testPlanUsage(t, plan, topics, nil)
+
+	total := 0
+	for _, mt := range plan {
+		total += partitionsForMember(mt)
+	}
+	if total != 8 {
+		t.Errorf("total partitions %d, want 8", total)
 	}
 }


### PR DESCRIPTION
kgo: add rack-aware partition assignment (KIP-881)

Rack-aware assignment preferentially places partitions on consumers
whose rack matches the partition leader's rack, while preserving the
existing priority of balance over locality over stickiness.

The client now sends its configured rack in ConsumerMemberMetadata
(v3+) during JoinGroup, and the group leader builds a partition-rack
map from cached broker racks and partition leaders -- no extra metadata
fetch needed.

Both the range and sticky balancers are updated:
- Range: two-phase approach, rack-matched partitions first, then
  normal range assignment for the remainder.
- Sticky: simple path (uniform subscriptions) uses per-rack min-heaps
  for O(log M) rack-aware pre-assignment; complex path (mixed
  subscriptions) uses rack tie-breaking in the existing assignment
  loop to prefer rack-matched members among equally-loaded candidates.

ConsumerBalancer.PartitionRacks() is exposed so custom balancers using
the consumer protocol can implement their own rack-aware strategies.