### PR TITLE
kprom, kvictoria: Add `BrokerLabels` Opt for fine-tuning broker metric labels

### DIFF
--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -21,6 +21,7 @@ type cfg struct {
 	histograms       map[Histogram][]float64
 	defBuckets       []float64
 	fetchProduceOpts fetchProduceOpts
+	brokerLabels     []string
 
 	handlerOpts  promhttp.HandlerOpts
 	goCollectors bool
@@ -38,6 +39,7 @@ func newCfg(namespace string, opts ...Opt) cfg {
 			uncompressedBytes: true,
 			labels:            []string{"node_id", "topic"},
 		},
+		brokerLabels: []string{"node_id"},
 	}
 
 	for _, opt := range opts {
@@ -196,7 +198,7 @@ func Histograms(hs ...Histogram) Opt {
 	return HistogramsFromOpts(hos...)
 }
 
-// A Detail is a label that can be set on fetch/produce metrics
+// A Detail is a label that can be set on fetch/produce metrics.
 type Detail uint8
 
 const (
@@ -250,4 +252,20 @@ func FetchAndProduceDetail(details ...Detail) Opt {
 			c.fetchProduceOpts.labels = labels
 		},
 	}
+}
+
+// BrokerNodeLabel controls whether the "node_id" label is included on
+// broker-level connection, read, write, and request metrics. By default
+// node_id is included. Passing false removes the label, aggregating
+// broker-level metrics across all brokers. This is useful for reducing
+// metrics cardinality in environments with many or frequently changing
+// broker IDs.
+func BrokerNodeLabel(include bool) Opt {
+	return opt{func(c *cfg) {
+		if include {
+			c.brokerLabels = []string{"node_id"}
+		} else {
+			c.brokerLabels = nil
+		}
+	}}
 }

--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -254,18 +254,38 @@ func FetchAndProduceDetail(details ...Detail) Opt {
 	}
 }
 
-// BrokerNodeLabel controls whether the "node_id" label is included on
-// broker-level connection, read, write, and request metrics. By default
-// node_id is included. Passing false removes the label, aggregating
-// broker-level metrics across all brokers. This is useful for reducing
-// metrics cardinality in environments with many or frequently changing
-// broker IDs.
-func BrokerNodeLabel(include bool) Opt {
+// A BrokerLabel is a label that can be set on broker-level metrics.
+type BrokerLabel uint8
+
+const (
+	BrokerNodeID BrokerLabel = iota // Include "node_id" label on broker metrics.
+	BrokerHost                      // Include "host" label on broker metrics.
+	BrokerRack                      // Include "rack" label on broker metrics.
+)
+
+// BrokerLabels configures which labels are included on broker-level
+// connection, read, write, and request metrics, overriding the default
+// of (BrokerNodeID). Calling with no arguments removes all broker-level
+// labels, aggregating metrics across all brokers. This is useful for
+// reducing metrics cardinality in environments with many or frequently
+// changing broker IDs.
+func BrokerLabels(labels ...BrokerLabel) Opt {
 	return opt{func(c *cfg) {
-		if include {
-			c.brokerLabels = []string{"node_id"}
-		} else {
-			c.brokerLabels = nil
+		seen := make(map[BrokerLabel]bool)
+		c.brokerLabels = nil
+		for _, l := range labels {
+			if seen[l] {
+				continue
+			}
+			seen[l] = true
+			switch l {
+			case BrokerNodeID:
+				c.brokerLabels = append(c.brokerLabels, "node_id")
+			case BrokerHost:
+				c.brokerLabels = append(c.brokerLabels, "host")
+			case BrokerRack:
+				c.brokerLabels = append(c.brokerLabels, "rack")
+			}
 		}
 	}}
 }

--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -265,10 +265,14 @@ const (
 
 // BrokerLabels configures which labels are included on broker-level
 // connection, read, write, and request metrics, overriding the default
-// of (BrokerNodeID). Calling with no arguments removes all broker-level
-// labels, aggregating metrics across all brokers. This is useful for
-// reducing metrics cardinality in environments with many or frequently
-// changing broker IDs.
+// of (BrokerNodeID).
+// Calling with no arguments removes all broker-level labels, aggregating
+// metrics across all brokers:
+//
+//	kprom.BrokerLabels( /* none */ )
+//
+// This is useful for reducing metrics cardinality in environments with many or
+// frequently changing broker IDs.
 func BrokerLabels(labels ...BrokerLabel) Opt {
 	return opt{func(c *cfg) {
 		seen := make(map[BrokerLabel]bool)

--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -19,6 +19,9 @@
 // The above metrics can be expanded considerably with options in this package,
 // allowing timings, uncompressed and compressed bytes, and different labels.
 //
+// The node_id label on broker-level metrics can be removed with the
+// BrokerNodeLabel option to reduce cardinality.
+//
 // This can be used in a client like so:
 //
 //	m := kprom.NewMetrics("my_namespace")
@@ -160,7 +163,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "connects_total",
 		Help:        "Total number of connections opened",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.connConnectErrorsTotal = factory.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   namespace,
@@ -168,7 +171,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "connect_errors_total",
 		Help:        "Total number of connection errors",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.connDisconnectsTotal = factory.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   namespace,
@@ -176,7 +179,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "disconnects_total",
 		Help:        "Total number of connections closed",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	// Write
 
@@ -186,7 +189,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "write_bytes_total",
 		Help:        "Total number of bytes written to the TCP connection. The bytes count is tracked after compression (when used).",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.writeErrorsTotal = factory.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   namespace,
@@ -194,7 +197,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "write_errors_total",
 		Help:        "Total number of write errors",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.writeWaitSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   namespace,
@@ -203,7 +206,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Name:        "write_wait_seconds",
 		Help:        "Time spent waiting to write to Kafka",
 		Buckets:     getHistogramBuckets(WriteWait),
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.writeTimeSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   namespace,
@@ -212,7 +215,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Name:        "write_time_seconds",
 		Help:        "Time spent writing to Kafka",
 		Buckets:     getHistogramBuckets(WriteTime),
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	// Read
 
@@ -222,7 +225,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "read_bytes_total",
 		Help:        "Total number of bytes read from the TCP connection. The bytes count is tracked before uncompression (when used).",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.readErrorsTotal = factory.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   namespace,
@@ -230,7 +233,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		ConstLabels: constLabels,
 		Name:        "read_errors_total",
 		Help:        "Total number of read errors",
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.readWaitSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   namespace,
@@ -239,7 +242,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Name:        "read_wait_seconds",
 		Help:        "Time spent waiting to read from Kafka",
 		Buckets:     getHistogramBuckets(ReadWait),
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.readTimeSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   namespace,
@@ -248,7 +251,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Name:        "read_time_seconds",
 		Help:        "Time spent reading from Kafka",
 		Buckets:     getHistogramBuckets(ReadTime),
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	// Request E2E duration & Throttle
 
@@ -259,7 +262,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Name:        "request_duration_e2e_seconds",
 		Help:        "Time from the start of when a request is written to the end of when the response for that request was fully read",
 		Buckets:     getHistogramBuckets(RequestDurationE2E),
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	m.requestThrottledSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:   namespace,
@@ -268,7 +271,7 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Name:        "request_throttled_seconds",
 		Help:        "Time the request was throttled",
 		Buckets:     getHistogramBuckets(RequestThrottled),
-	}, []string{"node_id"})
+	}, m.cfg.brokerLabels)
 
 	// Produce
 
@@ -434,20 +437,19 @@ func (m *Metrics) OnClientClosed(*kgo.Client) {
 // gathering.
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
-	nodeId := kgo.NodeName(meta.NodeID)
+	labels := m.brokerLabelValues(kgo.NodeName(meta.NodeID))
 	if err != nil {
-		m.connConnectErrorsTotal.WithLabelValues(nodeId).Inc()
+		m.connConnectErrorsTotal.WithLabelValues(labels...).Inc()
 		return
 	}
-	m.connConnectsTotal.WithLabelValues(nodeId).Inc()
+	m.connConnectsTotal.WithLabelValues(labels...).Inc()
 }
 
 // OnBrokerDisconnect implements the HookBrokerDisconnect interface for metrics
 // gathering.
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
-	nodeId := kgo.NodeName(meta.NodeID)
-	m.connDisconnectsTotal.WithLabelValues(nodeId).Inc()
+	m.connDisconnectsTotal.WithLabelValues(m.brokerLabelValues(kgo.NodeName(meta.NodeID))...).Inc()
 }
 
 // OnBrokerThrottle implements the HookBrokerThrottle interface for metrics
@@ -455,8 +457,7 @@ func (m *Metrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
 	if _, ok := m.cfg.histograms[RequestThrottled]; ok {
-		nodeId := kgo.NodeName(meta.NodeID)
-		m.requestThrottledSeconds.WithLabelValues(nodeId).Observe(throttleInterval.Seconds())
+		m.requestThrottledSeconds.WithLabelValues(m.brokerLabelValues(kgo.NodeName(meta.NodeID))...).Observe(throttleInterval.Seconds())
 	}
 }
 
@@ -509,31 +510,31 @@ func (m *Metrics) OnBrokerWrite(meta kgo.BrokerMetadata, _ int16, bytesWritten i
 // OnBrokerE2E implements the HookBrokerE2E interface for metrics gathering
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerE2E(meta kgo.BrokerMetadata, _ int16, e2e kgo.BrokerE2E) {
-	nodeId := kgo.NodeName(meta.NodeID)
+	labels := m.brokerLabelValues(kgo.NodeName(meta.NodeID))
 	if e2e.WriteErr != nil {
-		m.writeErrorsTotal.WithLabelValues(nodeId).Inc()
+		m.writeErrorsTotal.WithLabelValues(labels...).Inc()
 		return
 	}
-	m.writeBytesTotal.WithLabelValues(nodeId).Add(float64(e2e.BytesWritten))
+	m.writeBytesTotal.WithLabelValues(labels...).Add(float64(e2e.BytesWritten))
 	if _, ok := m.cfg.histograms[WriteWait]; ok {
-		m.writeWaitSeconds.WithLabelValues(nodeId).Observe(e2e.WriteWait.Seconds())
+		m.writeWaitSeconds.WithLabelValues(labels...).Observe(e2e.WriteWait.Seconds())
 	}
 	if _, ok := m.cfg.histograms[WriteTime]; ok {
-		m.writeTimeSeconds.WithLabelValues(nodeId).Observe(e2e.TimeToWrite.Seconds())
+		m.writeTimeSeconds.WithLabelValues(labels...).Observe(e2e.TimeToWrite.Seconds())
 	}
 	if e2e.ReadErr != nil {
-		m.readErrorsTotal.WithLabelValues(nodeId).Inc()
+		m.readErrorsTotal.WithLabelValues(labels...).Inc()
 		return
 	}
-	m.readBytesTotal.WithLabelValues(nodeId).Add(float64(e2e.BytesRead))
+	m.readBytesTotal.WithLabelValues(labels...).Add(float64(e2e.BytesRead))
 	if _, ok := m.cfg.histograms[ReadWait]; ok {
-		m.readWaitSeconds.WithLabelValues(nodeId).Observe(e2e.ReadWait.Seconds())
+		m.readWaitSeconds.WithLabelValues(labels...).Observe(e2e.ReadWait.Seconds())
 	}
 	if _, ok := m.cfg.histograms[ReadTime]; ok {
-		m.readTimeSeconds.WithLabelValues(nodeId).Observe(e2e.TimeToRead.Seconds())
+		m.readTimeSeconds.WithLabelValues(labels...).Observe(e2e.TimeToRead.Seconds())
 	}
 	if _, ok := m.cfg.histograms[RequestDurationE2E]; ok {
-		m.requestDurationE2ESeconds.WithLabelValues(nodeId).Observe(e2e.DurationE2E().Seconds())
+		m.requestDurationE2ESeconds.WithLabelValues(labels...).Observe(e2e.DurationE2E().Seconds())
 	}
 }
 
@@ -553,6 +554,13 @@ func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	for _, c := range m.allMetricCollectors {
 		c.Describe(ch)
 	}
+}
+
+func (m *Metrics) brokerLabelValues(nodeId string) []string {
+	if len(m.cfg.brokerLabels) > 0 {
+		return []string{nodeId}
+	}
+	return nil
 }
 
 func (m *Metrics) fetchProducerLabels(nodeId, topic string) prometheus.Labels {

--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -19,8 +19,9 @@
 // The above metrics can be expanded considerably with options in this package,
 // allowing timings, uncompressed and compressed bytes, and different labels.
 //
-// The node_id label on broker-level metrics can be removed with the
-// BrokerNodeLabel option to reduce cardinality.
+// The labels on broker-level metrics can be configured with the
+// BrokerLabels option to reduce cardinality or add dimensions like host
+// or rack.
 //
 // This can be used in a client like so:
 //
@@ -437,7 +438,7 @@ func (m *Metrics) OnClientClosed(*kgo.Client) {
 // gathering.
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
-	labels := m.brokerLabelValues(kgo.NodeName(meta.NodeID))
+	labels := m.brokerLabelValues(meta)
 	if err != nil {
 		m.connConnectErrorsTotal.WithLabelValues(labels...).Inc()
 		return
@@ -449,7 +450,7 @@ func (m *Metrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ ne
 // gathering.
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
-	m.connDisconnectsTotal.WithLabelValues(m.brokerLabelValues(kgo.NodeName(meta.NodeID))...).Inc()
+	m.connDisconnectsTotal.WithLabelValues(m.brokerLabelValues(meta)...).Inc()
 }
 
 // OnBrokerThrottle implements the HookBrokerThrottle interface for metrics
@@ -457,7 +458,7 @@ func (m *Metrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
 	if _, ok := m.cfg.histograms[RequestThrottled]; ok {
-		m.requestThrottledSeconds.WithLabelValues(m.brokerLabelValues(kgo.NodeName(meta.NodeID))...).Observe(throttleInterval.Seconds())
+		m.requestThrottledSeconds.WithLabelValues(m.brokerLabelValues(meta)...).Observe(throttleInterval.Seconds())
 	}
 }
 
@@ -510,7 +511,7 @@ func (m *Metrics) OnBrokerWrite(meta kgo.BrokerMetadata, _ int16, bytesWritten i
 // OnBrokerE2E implements the HookBrokerE2E interface for metrics gathering
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerE2E(meta kgo.BrokerMetadata, _ int16, e2e kgo.BrokerE2E) {
-	labels := m.brokerLabelValues(kgo.NodeName(meta.NodeID))
+	labels := m.brokerLabelValues(meta)
 	if e2e.WriteErr != nil {
 		m.writeErrorsTotal.WithLabelValues(labels...).Inc()
 		return
@@ -556,11 +557,24 @@ func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (m *Metrics) brokerLabelValues(nodeId string) []string {
-	if len(m.cfg.brokerLabels) > 0 {
-		return []string{nodeId}
+func (m *Metrics) brokerLabelValues(meta kgo.BrokerMetadata) []string {
+	if len(m.cfg.brokerLabels) == 0 {
+		return nil
 	}
-	return nil
+	values := make([]string, len(m.cfg.brokerLabels))
+	for i, l := range m.cfg.brokerLabels {
+		switch l {
+		case "node_id":
+			values[i] = kgo.NodeName(meta.NodeID)
+		case "host":
+			values[i] = meta.Host
+		case "rack":
+			if meta.Rack != nil {
+				values[i] = *meta.Rack
+			}
+		}
+	}
+	return values
 }
 
 func (m *Metrics) fetchProducerLabels(nodeId, topic string) prometheus.Labels {

--- a/plugin/kprom/kprom_test.go
+++ b/plugin/kprom/kprom_test.go
@@ -11,12 +11,15 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-func TestBrokerNodeLabel(t *testing.T) {
-	t.Run("without_node_id", func(t *testing.T) {
+func TestBrokerLabels(t *testing.T) {
+	rack := "us-east-1a"
+	meta := kgo.BrokerMetadata{NodeID: 1, Host: "broker1.example.com", Port: 9092, Rack: &rack}
+
+	t.Run("no_labels", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		m := NewMetrics("test",
 			Registry(reg),
-			BrokerNodeLabel(false),
+			BrokerLabels(),
 		)
 
 		cl, err := kgo.NewClient(
@@ -28,7 +31,6 @@ func TestBrokerNodeLabel(t *testing.T) {
 		}
 		defer cl.Close()
 
-		meta := kgo.BrokerMetadata{NodeID: 1, Host: "localhost", Port: 9092}
 		m.OnBrokerConnect(meta, time.Millisecond, &net.TCPConn{}, nil)
 		m.OnBrokerE2E(meta, 0, kgo.BrokerE2E{
 			BytesWritten: 100,
@@ -43,8 +45,9 @@ func TestBrokerNodeLabel(t *testing.T) {
 		for _, mf := range mfs {
 			for _, metric := range mf.GetMetric() {
 				for _, lp := range metric.GetLabel() {
-					if lp.GetName() == "node_id" {
-						t.Errorf("unexpected node_id label on metric %s", mf.GetName())
+					switch lp.GetName() {
+					case "node_id", "host", "rack":
+						t.Errorf("unexpected label %s on metric %s", lp.GetName(), mf.GetName())
 					}
 				}
 			}
@@ -55,7 +58,61 @@ func TestBrokerNodeLabel(t *testing.T) {
 		assertMetricValue(t, mfs, "test_read_bytes_total", 200)
 	})
 
-	t.Run("with_node_id_default", func(t *testing.T) {
+	t.Run("host_only", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetrics("test",
+			Registry(reg),
+			BrokerLabels(BrokerHost),
+		)
+
+		cl, err := kgo.NewClient(
+			kgo.SeedBrokers("localhost:19092"),
+			kgo.WithHooks(m),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cl.Close()
+
+		m.OnBrokerConnect(meta, time.Millisecond, &net.TCPConn{}, nil)
+
+		mfs, err := reg.Gather()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertLabel(t, mfs, "test_connects_total", "host", "broker1.example.com")
+		assertNoLabel(t, mfs, "test_connects_total", "node_id")
+	})
+
+	t.Run("node_id_and_rack", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetrics("test",
+			Registry(reg),
+			BrokerLabels(BrokerNodeID, BrokerRack),
+		)
+
+		cl, err := kgo.NewClient(
+			kgo.SeedBrokers("localhost:19092"),
+			kgo.WithHooks(m),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cl.Close()
+
+		m.OnBrokerConnect(meta, time.Millisecond, &net.TCPConn{}, nil)
+
+		mfs, err := reg.Gather()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertLabel(t, mfs, "test_connects_total", "node_id", "1")
+		assertLabel(t, mfs, "test_connects_total", "rack", "us-east-1a")
+	})
+
+	t.Run("default_node_id", func(t *testing.T) {
 		reg := prometheus.NewRegistry()
 		m := NewMetrics("test",
 			Registry(reg),
@@ -70,7 +127,6 @@ func TestBrokerNodeLabel(t *testing.T) {
 		}
 		defer cl.Close()
 
-		meta := kgo.BrokerMetadata{NodeID: 1, Host: "localhost", Port: 9092}
 		m.OnBrokerConnect(meta, time.Millisecond, &net.TCPConn{}, nil)
 		m.OnBrokerE2E(meta, 0, kgo.BrokerE2E{
 			BytesWritten: 100,
@@ -82,23 +138,9 @@ func TestBrokerNodeLabel(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		foundNodeID := false
-		for _, mf := range mfs {
-			for _, metric := range mf.GetMetric() {
-				for _, lp := range metric.GetLabel() {
-					if lp.GetName() == "node_id" {
-						foundNodeID = true
-						if lp.GetValue() != "1" {
-							t.Errorf("expected node_id=1, got node_id=%s", lp.GetValue())
-						}
-					}
-				}
-			}
-		}
-		if !foundNodeID {
-			t.Error("expected node_id label on broker-level metrics")
-		}
-
+		assertLabel(t, mfs, "test_connects_total", "node_id", "1")
+		assertNoLabel(t, mfs, "test_connects_total", "host")
+		assertNoLabel(t, mfs, "test_connects_total", "rack")
 		assertMetricValue(t, mfs, "test_connects_total", 1)
 		assertMetricValue(t, mfs, "test_write_bytes_total", 100)
 		assertMetricValue(t, mfs, "test_read_bytes_total", 200)
@@ -120,4 +162,42 @@ func assertMetricValue(t *testing.T, mfs []*dto.MetricFamily, name string, expec
 		}
 	}
 	t.Errorf("metric %s not found", name)
+}
+
+func assertLabel(t *testing.T, mfs []*dto.MetricFamily, metricName, labelName, labelValue string) {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() == metricName {
+			for _, metric := range mf.GetMetric() {
+				for _, lp := range metric.GetLabel() {
+					if lp.GetName() == labelName {
+						if lp.GetValue() != labelValue {
+							t.Errorf("metric %s label %s: expected %q, got %q", metricName, labelName, labelValue, lp.GetValue())
+						}
+						return
+					}
+				}
+			}
+			t.Errorf("metric %s: label %s not found", metricName, labelName)
+			return
+		}
+	}
+	t.Errorf("metric %s not found", metricName)
+}
+
+func assertNoLabel(t *testing.T, mfs []*dto.MetricFamily, metricName, labelName string) {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() == metricName {
+			for _, metric := range mf.GetMetric() {
+				for _, lp := range metric.GetLabel() {
+					if lp.GetName() == labelName {
+						t.Errorf("metric %s: unexpected label %s=%s", metricName, labelName, lp.GetValue())
+						return
+					}
+				}
+			}
+			return
+		}
+	}
 }

--- a/plugin/kprom/kprom_test.go
+++ b/plugin/kprom/kprom_test.go
@@ -1,0 +1,123 @@
+package kprom
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestBrokerNodeLabel(t *testing.T) {
+	t.Run("without_node_id", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetrics("test",
+			Registry(reg),
+			BrokerNodeLabel(false),
+		)
+
+		cl, err := kgo.NewClient(
+			kgo.SeedBrokers("localhost:19092"),
+			kgo.WithHooks(m),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cl.Close()
+
+		meta := kgo.BrokerMetadata{NodeID: 1, Host: "localhost", Port: 9092}
+		m.OnBrokerConnect(meta, time.Millisecond, &net.TCPConn{}, nil)
+		m.OnBrokerE2E(meta, 0, kgo.BrokerE2E{
+			BytesWritten: 100,
+			BytesRead:    200,
+		})
+
+		mfs, err := reg.Gather()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, mf := range mfs {
+			for _, metric := range mf.GetMetric() {
+				for _, lp := range metric.GetLabel() {
+					if lp.GetName() == "node_id" {
+						t.Errorf("unexpected node_id label on metric %s", mf.GetName())
+					}
+				}
+			}
+		}
+
+		assertMetricValue(t, mfs, "test_connects_total", 1)
+		assertMetricValue(t, mfs, "test_write_bytes_total", 100)
+		assertMetricValue(t, mfs, "test_read_bytes_total", 200)
+	})
+
+	t.Run("with_node_id_default", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetrics("test",
+			Registry(reg),
+		)
+
+		cl, err := kgo.NewClient(
+			kgo.SeedBrokers("localhost:19092"),
+			kgo.WithHooks(m),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cl.Close()
+
+		meta := kgo.BrokerMetadata{NodeID: 1, Host: "localhost", Port: 9092}
+		m.OnBrokerConnect(meta, time.Millisecond, &net.TCPConn{}, nil)
+		m.OnBrokerE2E(meta, 0, kgo.BrokerE2E{
+			BytesWritten: 100,
+			BytesRead:    200,
+		})
+
+		mfs, err := reg.Gather()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		foundNodeID := false
+		for _, mf := range mfs {
+			for _, metric := range mf.GetMetric() {
+				for _, lp := range metric.GetLabel() {
+					if lp.GetName() == "node_id" {
+						foundNodeID = true
+						if lp.GetValue() != "1" {
+							t.Errorf("expected node_id=1, got node_id=%s", lp.GetValue())
+						}
+					}
+				}
+			}
+		}
+		if !foundNodeID {
+			t.Error("expected node_id label on broker-level metrics")
+		}
+
+		assertMetricValue(t, mfs, "test_connects_total", 1)
+		assertMetricValue(t, mfs, "test_write_bytes_total", 100)
+		assertMetricValue(t, mfs, "test_read_bytes_total", 200)
+	})
+}
+
+func assertMetricValue(t *testing.T, mfs []*dto.MetricFamily, name string, expected float64) {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			for _, metric := range mf.GetMetric() {
+				if c := metric.GetCounter(); c != nil {
+					if c.GetValue() != expected {
+						t.Errorf("metric %s: expected %v, got %v", name, expected, c.GetValue())
+					}
+					return
+				}
+			}
+		}
+	}
+	t.Errorf("metric %s not found", name)
+}

--- a/plugin/kvictoria/config.go
+++ b/plugin/kvictoria/config.go
@@ -42,11 +42,14 @@ const (
 	BrokerRack                      // Include "rack" label on broker metrics.
 )
 
-// BrokerLabels configures which labels are included on broker-level
-// connection, read, write, request, and batch metrics, overriding the
-// default of (BrokerNodeID). Calling with no arguments removes all
-// broker-level labels, aggregating metrics across all brokers. This is
-// useful for reducing metrics cardinality in environments with many or
+// BrokerLabels configures which labels are included on broker-level connection,
+// read, write, request, and batch metrics, overriding the default of (BrokerNodeID).
+// Calling with no arguments removes all broker-level labels, aggregating
+// metrics across all brokers:
+//
+//	kvictoria.BrokerLabels( /* none */ )
+//
+// This is useful for reducing metrics cardinality in environments with many or
 // frequently changing broker IDs.
 func BrokerLabels(labels ...BrokerLabel) Opt {
 	return opt{func(c *cfg) {

--- a/plugin/kvictoria/config.go
+++ b/plugin/kvictoria/config.go
@@ -1,13 +1,15 @@
 package kvictoria
 
 type cfg struct {
-	namespace string
-	subsystem string
+	namespace      string
+	subsystem      string
+	brokerNodeLabel bool
 }
 
 func newCfg(namespace string, opts ...Opt) cfg {
 	cfg := cfg{
-		namespace: namespace,
+		namespace:      namespace,
+		brokerNodeLabel: true,
 	}
 
 	for _, opt := range opts {
@@ -29,4 +31,13 @@ func (o opt) apply(c *cfg) { o.fn(c) }
 // Subsystem sets the subsystem for the metrics, overriding the default empty string.
 func Subsystem(ss string) Opt {
 	return opt{func(c *cfg) { c.subsystem = ss }}
+}
+
+// BrokerNodeLabel controls whether the "node_id" label is included on
+// broker-level and batch metrics. By default node_id is included. Passing
+// false removes the label, aggregating metrics across all brokers. This is
+// useful for reducing metrics cardinality in environments with many or
+// frequently changing broker IDs.
+func BrokerNodeLabel(include bool) Opt {
+	return opt{func(c *cfg) { c.brokerNodeLabel = include }}
 }

--- a/plugin/kvictoria/config.go
+++ b/plugin/kvictoria/config.go
@@ -3,13 +3,13 @@ package kvictoria
 type cfg struct {
 	namespace      string
 	subsystem      string
-	brokerNodeLabel bool
+	brokerLabelSet map[BrokerLabel]bool
 }
 
 func newCfg(namespace string, opts ...Opt) cfg {
 	cfg := cfg{
 		namespace:      namespace,
-		brokerNodeLabel: true,
+		brokerLabelSet: map[BrokerLabel]bool{BrokerNodeID: true},
 	}
 
 	for _, opt := range opts {
@@ -33,11 +33,26 @@ func Subsystem(ss string) Opt {
 	return opt{func(c *cfg) { c.subsystem = ss }}
 }
 
-// BrokerNodeLabel controls whether the "node_id" label is included on
-// broker-level and batch metrics. By default node_id is included. Passing
-// false removes the label, aggregating metrics across all brokers. This is
+// A BrokerLabel is a label that can be set on broker-level metrics.
+type BrokerLabel uint8
+
+const (
+	BrokerNodeID BrokerLabel = iota // Include "node_id" label on broker metrics.
+	BrokerHost                      // Include "host" label on broker metrics.
+	BrokerRack                      // Include "rack" label on broker metrics.
+)
+
+// BrokerLabels configures which labels are included on broker-level
+// connection, read, write, request, and batch metrics, overriding the
+// default of (BrokerNodeID). Calling with no arguments removes all
+// broker-level labels, aggregating metrics across all brokers. This is
 // useful for reducing metrics cardinality in environments with many or
 // frequently changing broker IDs.
-func BrokerNodeLabel(include bool) Opt {
-	return opt{func(c *cfg) { c.brokerNodeLabel = include }}
+func BrokerLabels(labels ...BrokerLabel) Opt {
+	return opt{func(c *cfg) {
+		c.brokerLabelSet = make(map[BrokerLabel]bool)
+		for _, l := range labels {
+			c.brokerLabelSet[l] = true
+		}
+	}}
 }

--- a/plugin/kvictoria/kvictoria.go
+++ b/plugin/kvictoria/kvictoria.go
@@ -252,8 +252,12 @@ func (m *Metrics) brokerLabels(meta kgo.BrokerMetadata) map[string]string {
 	if m.cfg.brokerLabelSet[BrokerHost] {
 		labels["host"] = meta.Host
 	}
-	if m.cfg.brokerLabelSet[BrokerRack] && meta.Rack != nil {
-		labels["rack"] = *meta.Rack
+	if m.cfg.brokerLabelSet[BrokerRack] {
+		rack := ""
+		if meta.Rack != nil {
+			rack = *meta.Rack
+		}
+		labels["rack"] = rack
 	}
 	return labels
 }

--- a/plugin/kvictoria/kvictoria.go
+++ b/plugin/kvictoria/kvictoria.go
@@ -58,6 +58,9 @@
 // Note that you MUST use a new [Metrics] instance per client: you'll get a panic if you don't.
 // This is necessary to avoid unexpected behaviour.
 //
+// The node_id label can be removed with the BrokerNodeLabel option to reduce
+// cardinality.
+//
 // Note that seed brokers use broker IDs prefixed with "seed_", with the number
 // corresponding to which seed it is.
 package kvictoria
@@ -151,10 +154,7 @@ func (m *Metrics) OnClientClosed(client *kgo.Client) {
 // OnBrokerConnect implements the [kgo.HookBrokerConnect] interface for metrics gathering.
 // This method is meant to be called by the hook system and not by the user.
 func (m *Metrics) OnBrokerConnect(meta kgo.BrokerMetadata, dialTime time.Duration, _ net.Conn, err error) {
-	labels := map[string]string{
-		"client_id": m.clientID,
-		"node_id":   kgo.NodeName(meta.NodeID),
-	}
+	labels := m.brokerLabels(meta)
 
 	if err != nil {
 		m.set.GetOrCreateCounter(m.buildName("connect_errors_total", labels)).Inc()
@@ -168,21 +168,13 @@ func (m *Metrics) OnBrokerConnect(meta kgo.BrokerMetadata, dialTime time.Duratio
 // OnBrokerDisconnect implements the [kgo.HookBrokerDisconnect] interface for metrics gathering.
 // This method is meant to be called by the hook system and not by the user
 func (m *Metrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
-	labels := map[string]string{
-		"client_id": m.clientID,
-		"node_id":   kgo.NodeName(meta.NodeID),
-	}
-
-	m.set.GetOrCreateCounter(m.buildName("disconnects_total", labels)).Inc()
+	m.set.GetOrCreateCounter(m.buildName("disconnects_total", m.brokerLabels(meta))).Inc()
 }
 
 // OnBrokerE2E implements the [kgo.HookBrokerE2E] interface for metrics gathering
 // This method is meant to be called by the hook system and not by the user.
 func (m *Metrics) OnBrokerE2E(meta kgo.BrokerMetadata, _ int16, e2e kgo.BrokerE2E) {
-	labels := map[string]string{
-		"client_id": m.clientID,
-		"node_id":   kgo.NodeName(meta.NodeID),
-	}
+	labels := m.brokerLabels(meta)
 
 	if e2e.WriteErr != nil {
 		m.set.GetOrCreateCounter(m.buildName("write_errors_total", labels)).Inc()
@@ -208,12 +200,7 @@ func (m *Metrics) OnBrokerE2E(meta kgo.BrokerMetadata, _ int16, e2e kgo.BrokerE2
 // OnBrokerThrottle implements the [kgo.HookBrokerThrottle] interface for metrics gathering.
 // This method is meant to be called by the hook system and not by the user.
 func (m *Metrics) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
-	labels := map[string]string{
-		"client_id": m.clientID,
-		"node_id":   kgo.NodeName(meta.NodeID),
-	}
-
-	m.set.GetOrCreateHistogram(m.buildName("request_throttled_seconds", labels)).Update(throttleInterval.Seconds())
+	m.set.GetOrCreateHistogram(m.buildName("request_throttled_seconds", m.brokerLabels(meta))).Update(throttleInterval.Seconds())
 }
 
 // OnGroupManageError implements the [kgo.HookBrokerThrottle] interface for metrics gathering.
@@ -234,12 +221,9 @@ func (m *Metrics) OnGroupManageError(err error) {
 // OnProduceBatchWritten implements the [kgo.HookProduceBatchWritten] interface for metrics gathering.
 // This method is meant to be called by the hook system and not by the user.
 func (m *Metrics) OnProduceBatchWritten(meta kgo.BrokerMetadata, topic string, partition int32, metrics kgo.ProduceBatchMetrics) {
-	labels := map[string]string{
-		"client_id": m.clientID,
-		"node_id":   kgo.NodeName(meta.NodeID),
-		"topic":     topic,
-		"partition": strconv.FormatInt(int64(partition), 10),
-	}
+	labels := m.brokerLabels(meta)
+	labels["topic"] = topic
+	labels["partition"] = strconv.FormatInt(int64(partition), 10)
 
 	m.set.GetOrCreateCounter(m.buildName("produce_uncompressed_bytes_total", labels)).Add(metrics.UncompressedBytes)
 	m.set.GetOrCreateCounter(m.buildName("produce_compressed_bytes_total", labels)).Add(metrics.CompressedBytes)
@@ -250,17 +234,22 @@ func (m *Metrics) OnProduceBatchWritten(meta kgo.BrokerMetadata, topic string, p
 // OnFetchBatchRead implements the [kgo.HookFetchBatchRead] interface for metrics gathering.
 // This method is meant to be called by the hook system and not by the user.
 func (m *Metrics) OnFetchBatchRead(meta kgo.BrokerMetadata, topic string, partition int32, metrics kgo.FetchBatchMetrics) {
-	labels := map[string]string{
-		"client_id": m.clientID,
-		"node_id":   kgo.NodeName(meta.NodeID),
-		"topic":     topic,
-		"partition": strconv.FormatInt(int64(partition), 10),
-	}
+	labels := m.brokerLabels(meta)
+	labels["topic"] = topic
+	labels["partition"] = strconv.FormatInt(int64(partition), 10)
 
 	m.set.GetOrCreateCounter(m.buildName("fetch_uncompressed_bytes_total", labels)).Add(metrics.UncompressedBytes)
 	m.set.GetOrCreateCounter(m.buildName("fetch_compressed_bytes_total", labels)).Add(metrics.CompressedBytes)
 	m.set.GetOrCreateCounter(m.buildName("fetch_batches_total", labels)).Inc()
 	m.set.GetOrCreateCounter(m.buildName("fetch_records_total", labels)).Add(metrics.NumRecords)
+}
+
+func (m *Metrics) brokerLabels(meta kgo.BrokerMetadata) map[string]string {
+	labels := map[string]string{"client_id": m.clientID}
+	if m.cfg.brokerNodeLabel {
+		labels["node_id"] = kgo.NodeName(meta.NodeID)
+	}
+	return labels
 }
 
 // buildName constructs a metric name for the VictoriaMetrics metrics library.

--- a/plugin/kvictoria/kvictoria.go
+++ b/plugin/kvictoria/kvictoria.go
@@ -58,8 +58,8 @@
 // Note that you MUST use a new [Metrics] instance per client: you'll get a panic if you don't.
 // This is necessary to avoid unexpected behaviour.
 //
-// The node_id label can be removed with the BrokerNodeLabel option to reduce
-// cardinality.
+// The labels on broker-level metrics can be configured with the BrokerLabels
+// option to reduce cardinality or add dimensions like host or rack.
 //
 // Note that seed brokers use broker IDs prefixed with "seed_", with the number
 // corresponding to which seed it is.
@@ -246,8 +246,14 @@ func (m *Metrics) OnFetchBatchRead(meta kgo.BrokerMetadata, topic string, partit
 
 func (m *Metrics) brokerLabels(meta kgo.BrokerMetadata) map[string]string {
 	labels := map[string]string{"client_id": m.clientID}
-	if m.cfg.brokerNodeLabel {
+	if m.cfg.brokerLabelSet[BrokerNodeID] {
 		labels["node_id"] = kgo.NodeName(meta.NodeID)
+	}
+	if m.cfg.brokerLabelSet[BrokerHost] {
+		labels["host"] = meta.Host
+	}
+	if m.cfg.brokerLabelSet[BrokerRack] && meta.Rack != nil {
+		labels["rack"] = *meta.Rack
 	}
 	return labels
 }

--- a/plugin/kvictoria/kvictoria_test.go
+++ b/plugin/kvictoria/kvictoria_test.go
@@ -1,6 +1,11 @@
 package kvictoria
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
 
 func TestMetricsBuildName(t *testing.T) {
 	testCases := []struct {
@@ -85,4 +90,45 @@ func TestMetricsBuildName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBrokerNodeLabel(t *testing.T) {
+	meta := kgo.BrokerMetadata{NodeID: 1, Host: "localhost", Port: 9092}
+
+	t.Run("without_node_id", func(t *testing.T) {
+		m := &Metrics{
+			cfg:      newCfg("test", BrokerNodeLabel(false)),
+			clientID: "kgo",
+		}
+
+		labels := m.brokerLabels(meta)
+		if _, ok := labels["node_id"]; ok {
+			t.Error("expected no node_id label")
+		}
+		if labels["client_id"] != "kgo" {
+			t.Errorf("expected client_id=kgo, got %s", labels["client_id"])
+		}
+
+		name := m.buildName("read_errors_total", labels)
+		if strings.Contains(name, "node_id") {
+			t.Errorf("expected no node_id in metric name, got %s", name)
+		}
+	})
+
+	t.Run("with_node_id_default", func(t *testing.T) {
+		m := &Metrics{
+			cfg:      newCfg("test"),
+			clientID: "kgo",
+		}
+
+		labels := m.brokerLabels(meta)
+		if labels["node_id"] != "1" {
+			t.Errorf("expected node_id=1, got %s", labels["node_id"])
+		}
+
+		name := m.buildName("read_errors_total", labels)
+		if !strings.Contains(name, `node_id="1"`) {
+			t.Errorf("expected node_id in metric name, got %s", name)
+		}
+	})
 }

--- a/plugin/kvictoria/kvictoria_test.go
+++ b/plugin/kvictoria/kvictoria_test.go
@@ -92,30 +92,66 @@ func TestMetricsBuildName(t *testing.T) {
 	}
 }
 
-func TestBrokerNodeLabel(t *testing.T) {
-	meta := kgo.BrokerMetadata{NodeID: 1, Host: "localhost", Port: 9092}
+func TestBrokerLabels(t *testing.T) {
+	rack := "us-east-1a"
+	meta := kgo.BrokerMetadata{NodeID: 1, Host: "broker1.example.com", Port: 9092, Rack: &rack}
 
-	t.Run("without_node_id", func(t *testing.T) {
+	t.Run("no_labels", func(t *testing.T) {
 		m := &Metrics{
-			cfg:      newCfg("test", BrokerNodeLabel(false)),
+			cfg:      newCfg("test", BrokerLabels()),
 			clientID: "kgo",
 		}
 
 		labels := m.brokerLabels(meta)
-		if _, ok := labels["node_id"]; ok {
-			t.Error("expected no node_id label")
+		for _, key := range []string{"node_id", "host", "rack"} {
+			if _, ok := labels[key]; ok {
+				t.Errorf("unexpected label %s", key)
+			}
 		}
 		if labels["client_id"] != "kgo" {
 			t.Errorf("expected client_id=kgo, got %s", labels["client_id"])
 		}
 
 		name := m.buildName("read_errors_total", labels)
-		if strings.Contains(name, "node_id") {
-			t.Errorf("expected no node_id in metric name, got %s", name)
+		if strings.Contains(name, "node_id") || strings.Contains(name, "host") || strings.Contains(name, "rack") {
+			t.Errorf("expected no broker labels in metric name, got %s", name)
 		}
 	})
 
-	t.Run("with_node_id_default", func(t *testing.T) {
+	t.Run("host_only", func(t *testing.T) {
+		m := &Metrics{
+			cfg:      newCfg("test", BrokerLabels(BrokerHost)),
+			clientID: "kgo",
+		}
+
+		labels := m.brokerLabels(meta)
+		if labels["host"] != "broker1.example.com" {
+			t.Errorf("expected host=broker1.example.com, got %s", labels["host"])
+		}
+		if _, ok := labels["node_id"]; ok {
+			t.Error("unexpected node_id label")
+		}
+	})
+
+	t.Run("node_id_and_rack", func(t *testing.T) {
+		m := &Metrics{
+			cfg:      newCfg("test", BrokerLabels(BrokerNodeID, BrokerRack)),
+			clientID: "kgo",
+		}
+
+		labels := m.brokerLabels(meta)
+		if labels["node_id"] != "1" {
+			t.Errorf("expected node_id=1, got %s", labels["node_id"])
+		}
+		if labels["rack"] != "us-east-1a" {
+			t.Errorf("expected rack=us-east-1a, got %s", labels["rack"])
+		}
+		if _, ok := labels["host"]; ok {
+			t.Error("unexpected host label")
+		}
+	})
+
+	t.Run("default_node_id", func(t *testing.T) {
 		m := &Metrics{
 			cfg:      newCfg("test"),
 			clientID: "kgo",
@@ -124,6 +160,12 @@ func TestBrokerNodeLabel(t *testing.T) {
 		labels := m.brokerLabels(meta)
 		if labels["node_id"] != "1" {
 			t.Errorf("expected node_id=1, got %s", labels["node_id"])
+		}
+		if _, ok := labels["host"]; ok {
+			t.Error("unexpected host label")
+		}
+		if _, ok := labels["rack"]; ok {
+			t.Error("unexpected rack label")
 		}
 
 		name := m.buildName("read_errors_total", labels)


### PR DESCRIPTION
fixes: https://github.com/twmb/franz-go/issues/1284

* Several labels can be emitted on the broker metrics. This PR adds a config `Opt` to allow control over which labels are emitted.
* Add the same option to `kvictoria` since it has the same label.
* Added some basic tests.