### PR TITLE
kgo: add HookPollStart hook

### DIFF
--- a/pkg/kgo/client_test.go
+++ b/pkg/kgo/client_test.go
@@ -209,12 +209,12 @@ type someHook struct {
 
 type pollStartHook struct{}
 
-func (*pollStartHook) OnPollRecordsStart() {}
+func (*pollStartHook) OnPollStart(_ context.Context) {}
 
-func TestHookPollRecordsStartRecognized(t *testing.T) {
+func TestHookPollStartRecognized(t *testing.T) {
 	h := &pollStartHook{}
 	if !implementsAnyHook(h) {
-		t.Fatal("HookPollRecordsStart implementor not recognized by implementsAnyHook")
+		t.Fatal("HookPollStart implementor not recognized by implementsAnyHook")
 	}
 	hooks, err := processHooks([]Hook{h})
 	if err != nil {

--- a/pkg/kgo/client_test.go
+++ b/pkg/kgo/client_test.go
@@ -207,6 +207,24 @@ type someHook struct {
 	index int
 }
 
+type pollStartHook struct{}
+
+func (*pollStartHook) OnPollRecordsStart() {}
+
+func TestHookPollRecordsStartRecognized(t *testing.T) {
+	h := &pollStartHook{}
+	if !implementsAnyHook(h) {
+		t.Fatal("HookPollRecordsStart implementor not recognized by implementsAnyHook")
+	}
+	hooks, err := processHooks([]Hook{h})
+	if err != nil {
+		t.Fatal("unexpected error from processHooks:", err)
+	}
+	if len(hooks) != 1 || hooks[0] != h {
+		t.Fatalf("expected hook to pass through processHooks unchanged, got %+v", hooks)
+	}
+}
+
 func (*someHook) OnNewClient(*Client) {
 	// ignore
 }

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -435,8 +435,8 @@ func (cl *Client) PollFetches(ctx context.Context) Fetches {
 // See the documentation on BlockRebalanceOnPoll for more information.
 func (cl *Client) PollRecords(ctx context.Context, maxPollRecords int) Fetches {
 	cl.cfg.hooks.each(func(h Hook) {
-		if hh, ok := h.(HookPollRecordsStart); ok {
-			hh.OnPollRecordsStart()
+		if hh, ok := h.(HookPollStart); ok {
+			hh.OnPollStart(ctx)
 		}
 	})
 

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -434,6 +434,12 @@ func (cl *Client) PollFetches(ctx context.Context) Fetches {
 // this by using BlockRebalanceOnPoll, but this comes with different tradeoffs.
 // See the documentation on BlockRebalanceOnPoll for more information.
 func (cl *Client) PollRecords(ctx context.Context, maxPollRecords int) Fetches {
+	cl.cfg.hooks.each(func(h Hook) {
+		if hh, ok := h.(HookPollRecordsStart); ok {
+			hh.OnPollRecordsStart()
+		}
+	})
+
 	if maxPollRecords == 0 {
 		maxPollRecords = -1
 	}

--- a/pkg/kgo/consumer_test.go
+++ b/pkg/kgo/consumer_test.go
@@ -917,9 +917,9 @@ type pollStartCountHook struct {
 	n atomic.Int64
 }
 
-func (h *pollStartCountHook) OnPollRecordsStart() { h.n.Add(1) }
+func (h *pollStartCountHook) OnPollStart(_ context.Context) { h.n.Add(1) }
 
-func TestHookPollRecordsStart(t *testing.T) {
+func TestHookPollStart(t *testing.T) {
 	t.Parallel()
 
 	const nRecords = 5
@@ -971,7 +971,7 @@ func TestHookPollRecordsStart(t *testing.T) {
 			}
 
 			if n := hook.n.Load(); n != pollCalls {
-				t.Fatalf("expected OnPollRecordsStart called %d times (one per poll call), got %d", pollCalls, n)
+				t.Fatalf("expected OnPollStart called %d times (one per poll call), got %d", pollCalls, n)
 			}
 		})
 	}

--- a/pkg/kgo/consumer_test.go
+++ b/pkg/kgo/consumer_test.go
@@ -912,3 +912,67 @@ func TestGroupSimple(t *testing.T) {
 		})
 	}
 }
+
+type pollStartCountHook struct {
+	n atomic.Int64
+}
+
+func (h *pollStartCountHook) OnPollRecordsStart() { h.n.Add(1) }
+
+func TestHookPollRecordsStart(t *testing.T) {
+	t.Parallel()
+
+	const nRecords = 5
+
+	for _, tc := range []struct {
+		name string
+		poll func(*Client, context.Context) Fetches
+	}{
+		{"PollRecords", func(cl *Client, ctx context.Context) Fetches { return cl.PollRecords(ctx, nRecords) }},
+		{"PollFetches", func(cl *Client, ctx context.Context) Fetches { return cl.PollFetches(ctx) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			topic, cleanup := tmpTopicPartitions(t, 1)
+			defer cleanup()
+
+			hook := &pollStartCountHook{}
+			cl, _ := newTestClient(
+				DefaultProduceTopic(topic),
+				UnknownTopicRetries(-1),
+				ConsumePartitions(map[string]map[int32]Offset{
+					topic: {0: NewOffset().At(0)},
+				}),
+				WithHooks(hook),
+			)
+			defer cl.Close()
+
+			recs := make([]*Record, nRecords)
+			for i := range recs {
+				recs[i] = StringRecord(strconv.Itoa(i))
+			}
+			if err := cl.ProduceSync(context.Background(), recs...).FirstErr(); err != nil {
+				t.Fatal(err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			var pollCalls int64
+			var got int
+			for got < nRecords {
+				if ctx.Err() != nil {
+					t.Fatal("timed out waiting for records")
+				}
+				pollCalls++
+				fs := tc.poll(cl, ctx)
+				got += len(fs.Records())
+			}
+
+			if n := hook.n.Load(); n != pollCalls {
+				t.Fatalf("expected OnPollRecordsStart called %d times (one per poll call), got %d", pollCalls, n)
+			}
+		})
+	}
+}

--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -1,6 +1,7 @@
 package kgo
 
 import (
+	"context"
 	"net"
 	"time"
 )
@@ -394,7 +395,7 @@ type HookFetchRecordUnbuffered interface {
 	OnFetchRecordUnbuffered(r *Record, polled bool)
 }
 
-// HookPollRecordsStart is called at the beginning of every PollFetches or
+// HookPollStart is called at the beginning of every PollFetches or
 // PollRecords call, before any records are drained from internal buffers and
 // before any HookFetchRecordUnbuffered hooks fire for the same poll.
 //
@@ -402,10 +403,10 @@ type HookFetchRecordUnbuffered interface {
 // tracing integration that opens a span per record via HookFetchRecordUnbuffered
 // can implement this hook to finish the previous poll's spans before new ones
 // are created.
-type HookPollRecordsStart interface {
-	// OnPollRecordsStart is called at the start of every PollFetches or
-	// PollRecords call.
-	OnPollRecordsStart()
+type HookPollStart interface {
+	// OnPollStart is called at the start of every PollFetches or
+	// PollRecords call with the context passed by the caller.
+	OnPollStart(ctx context.Context)
 }
 
 /////////////
@@ -431,7 +432,7 @@ func implementsAnyHook(h Hook) bool {
 		HookProduceRecordUnbuffered,
 		HookFetchRecordBuffered,
 		HookFetchRecordUnbuffered,
-		HookPollRecordsStart:
+		HookPollStart:
 		return true
 	}
 	return false

--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -394,6 +394,20 @@ type HookFetchRecordUnbuffered interface {
 	OnFetchRecordUnbuffered(r *Record, polled bool)
 }
 
+// HookPollRecordsStart is called at the beginning of every PollFetches or
+// PollRecords call, before any records are drained from internal buffers and
+// before any HookFetchRecordUnbuffered hooks fire for the same poll.
+//
+// This hook is useful for instrumenting the poll boundary: for example, a
+// tracing integration that opens a span per record via HookFetchRecordUnbuffered
+// can implement this hook to finish the previous poll's spans before new ones
+// are created.
+type HookPollRecordsStart interface {
+	// OnPollRecordsStart is called at the start of every PollFetches or
+	// PollRecords call.
+	OnPollRecordsStart()
+}
+
 /////////////
 // HELPERS //
 /////////////
@@ -416,7 +430,8 @@ func implementsAnyHook(h Hook) bool {
 		HookProduceRecordPartitioned,
 		HookProduceRecordUnbuffered,
 		HookFetchRecordBuffered,
-		HookFetchRecordUnbuffered:
+		HookFetchRecordUnbuffered,
+		HookPollRecordsStart:
 		return true
 	}
 	return false


### PR DESCRIPTION
As part of the franz-go [dd-trace-go integration](https://github.com/DataDog/dd-trace-go/pull/4623), we need a way to finish consumer spans. In other Kafka integrations we follow the convention of closing the previous poll's spans when the next fetch begins, but franz-go had no hook for that boundary.

This PR adds `HookPollStart `, which fires at the top of every `PollFetches`/`PollRecords` call before any records are drained, giving integrations a clean place to finish spans opened during the previous poll.