### PR TITLE
kgo: retry transient dial errors for the configured retry budget

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -1486,28 +1486,30 @@ type retryable struct {
 }
 
 type failDial struct {
-	fails   int8
 	clearFn func()
 }
 
-// The controller and group/txn coordinators are cached. If dialing the
-// cached broker fails, we clear the cache immediately so that the next
-// retry does a fresh lookup, and we return errChosenBrokerDead to make
-// the retryable loop actually retry with backoff (dial errors are
-// otherwise not retryable by shouldRetry, and shouldRetryNext cannot
-// help because loadCoordinator returns the same stale cached broker).
+// handleDialErr converts transient dial errors into errChosenBrokerDead so
+// that the retryable loop retries with backoff. isRetryableBrokerErr excludes
+// dial errors by design, and shouldRetryNext cannot help because pinned broker
+// functions return the same broker every time.
 //
-// After 3 dial failures we give up and return the original error.
+// On every dial failure we call clearFn to drop cached controller and
+// coordinator entries pointing at the dead broker. We call it every time, not just
+// once, because between retries the cache may be repopulated with a different
+// broker that also fails. The clearFns are idempotent.
+//
+// Permanent dial errors (NXDOMAIN, EACCES, EPERM) still clear the cache but
+// are not retried. Retries are bounded by retryTimeout / ctx / RequestRetries.
 func (d *failDial) handleDialErr(err error) error {
 	if !isAnyDialErr(err) {
 		return err
 	}
 	d.clearFn()
-	d.fails++
-	if d.fails <= 3 {
-		return errChosenBrokerDead
+	if isPermanentDialErr(err) {
+		return err
 	}
-	return err
+	return errChosenBrokerDead
 }
 
 func (r *retryable) Request(ctx context.Context, req kmsg.Request) (kmsg.Response, error) {
@@ -2049,6 +2051,24 @@ func (cl *Client) deleteStaleCoordinator(name string, typ int8) {
 	}
 }
 
+// deleteStaleCoordinatorsByNode removes all cached coordinator entries
+// resolved to the given broker. Entries that are actively loading are
+// skipped.
+func (cl *Client) deleteStaleCoordinatorsByNode(node int32) {
+	cl.coordinatorsMu.Lock()
+	defer cl.coordinatorsMu.Unlock()
+	for k, v := range cl.coordinators {
+		if v == nil || v.node != node {
+			continue
+		}
+		select {
+		case <-v.loadWait:
+			delete(cl.coordinators, k)
+		default:
+		}
+	}
+}
+
 type brokerOrErr struct {
 	b   *broker
 	err error
@@ -2074,7 +2094,10 @@ func (cl *Client) handleAdminReq(ctx context.Context, req kmsg.Request) Response
 		cl.maybeDeleteCachedMeta(false, topics...)
 	}
 
-	d := failDial{clearFn: func() { cl.forgetControllerID(r.last.meta.NodeID) }}
+	d := failDial{clearFn: func() {
+		cl.forgetControllerID(r.last.meta.NodeID)
+		cl.deleteStaleCoordinatorsByNode(r.last.meta.NodeID)
+	}}
 	r.parseRetryErr = func(resp kmsg.Response, err error) error {
 		if err != nil {
 			return d.handleDialErr(err)
@@ -2215,7 +2238,10 @@ func (cl *Client) handleReqWithCoordinator(
 	req kmsg.Request,
 ) (*broker, kmsg.Response, error) {
 	r := cl.retryableBrokerFn(coordinator)
-	d := failDial{clearFn: func() { cl.deleteStaleCoordinator(name, typ) }}
+	d := failDial{clearFn: func() {
+		cl.forgetControllerID(r.last.meta.NodeID)
+		cl.deleteStaleCoordinatorsByNode(r.last.meta.NodeID)
+	}}
 	r.parseRetryErr = func(resp kmsg.Response, err error) error {
 		if err != nil {
 			return d.handleDialErr(err)
@@ -2381,9 +2407,24 @@ func (b *Broker) request(ctx context.Context, retry bool, req kmsg.Request) (kms
 				resp, err = br.waitResp(ctx, req)
 			}
 		} else {
-			resp, err = b.cl.retryableBrokerFn(func() (*broker, error) {
+			r := b.cl.retryableBrokerFn(func() (*broker, error) {
 				return b.cl.brokerOrErr(ctx, b.id, errUnknownBroker)
-			}).Request(ctx, req)
+			})
+			// Pinned by ID: on dial failure, retry with backoff to give
+			// the broker time to come back (e.g. rolling restart).
+			// Also clear cached controller/coordinator entries pointing
+			// at this broker so other code paths re-resolve.
+			d := failDial{clearFn: func() {
+				b.cl.forgetControllerID(b.id)
+				b.cl.deleteStaleCoordinatorsByNode(b.id)
+			}}
+			r.parseRetryErr = func(_ kmsg.Response, err error) error {
+				if err != nil {
+					return d.handleDialErr(err)
+				}
+				return nil
+			}
+			resp, err = r.Request(ctx, req)
 		}
 	}()
 

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"syscall"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 )
@@ -55,9 +56,26 @@ func isRetryableBrokerErr(err error) bool {
 	// implements Temporary, so if we test that first, it'll return false
 	// in many cases when we want to return true from os.SyscallError.
 	if se := (*os.SyscallError)(nil); errors.As(err, &se) {
-		// If a dial fails, potentially we could retry if the resolver
-		// had a temporary hiccup, but we will err on the side of this
-		// being a slightly less temporary error.
+		// Non-timeout dial errors are deliberately *not* retryable here.
+		// The carve-out forces every caller that wants dial-error retry
+		// behavior to opt in explicitly, because the right recovery
+		// strategy varies by call site:
+		//
+		//   - Single bad seed bootstrap: should fail fast so the user
+		//     finds out about the typo'd address.
+		//   - cl.broker() unpinned admin: should rotate to a different
+		//     broker via shouldRetryNext, which calls cl.broker()'s
+		//     built-in rotation.
+		//   - Cached controller/coordinator: should clear the cache and
+		//     re-resolve, then retry (handled by failDial).
+		//   - Broker pinned by ID (Broker.RetriableRequest): should retry
+		//     the same broker bounded by retryTimeout (also failDial).
+		//   - Sink (produce) and source (fetch): should refresh metadata
+		//     and remap to the new partition leader (handled at the
+		//     sink/source call sites).
+		//
+		// Returning true here would lump all of these into a generic
+		// retry loop and silently mask the call-site recovery behavior.
 		return !isDialNonTimeoutErr(err)
 	}
 	// EOF can be returned if a broker kills a connection unexpectedly, and
@@ -116,6 +134,32 @@ func isDialNonTimeoutErr(err error) bool {
 func isAnyDialErr(err error) bool {
 	var ne *net.OpError
 	return errors.As(err, &ne) && ne.Op == "dial"
+}
+
+// isPermanentDialErr reports whether a dial error is a hard configuration
+// problem that no amount of retrying will fix. We treat the following as
+// permanent:
+//
+//   - DNS NXDOMAIN: the host genuinely does not exist.
+//   - EACCES / EPERM: local socket permission denied.
+//
+// Everything else dial-shaped (ECONNREFUSED, EHOSTUNREACH, ENETUNREACH,
+// dial timeouts, ...) is considered transient. ECONNREFUSED in particular
+// is the canonical signal that a broker is mid-restart (the listener is
+// closed before the JVM exits, and not yet bound after it starts) and is
+// the most common dial error worth retrying.
+func isPermanentDialErr(err error) bool {
+	if !isAnyDialErr(err) {
+		return false
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		return true
+	}
+	if errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM) {
+		return true
+	}
+	return false
 }
 
 func isContextErr(err error) bool {


### PR DESCRIPTION
When a broker is mid-rolling-restart, dial attempts get ECONNREFUSED.
The failDial mechanism converted these into retryable errors, but capped
at 3 attempts (~1.5s with default backoff). Typical broker restarts last
5-30s, so the cap was an order of magnitude too short and silently
overrode the user-configured RetryTimeout.

Drop the cap. The retry loop is already bounded by RetryTimeout (default
30s), RequestRetries (default 20), and the caller's context. These are
the knobs users configure and expect to be respected.

Additionally:

- Distinguish permanent dial errors (NXDOMAIN, EACCES, EPERM) and
  surface them immediately rather than retrying. This preserves the
  fast-fail behavior for misconfigured seed addresses.

- On any dial failure, clear all cached roles pointing at the dead
  broker (controller ID, all group/txn coordinator entries), not just
  the narrow entry for the current request. A dead broker is a dead
  broker regardless of which code path discovered it; clearing
  everything lets concurrent and future requests discover role
  reassignments via fresh FindCoordinator / metadata lookups.

- Add failDial to Broker.RetriableRequest, which previously had no
  dial-error retry handling at all. A single ECONNREFUSED was surfaced
  directly to the caller despite the function promising to retry
  connection errors.

The 3-cap was introduced in e2e80bf (Dec 2022, #239) as a heuristic for
"transient blips," paired with coordinator cache invalidation. It was
effectively dead code until d922b88 (March 2026) fixed failDial to
actually retry. With the fix in place, 3 attempts is still far too few
for real-world restart windows.