### PR TITLE
kgo: send ApiVersions on every new broker connection

### DIFF
--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2752,3 +2752,109 @@ func TestIssue1281(t *testing.T) {
 		t.Fatalf("expected success for correct seq, got: %v", kerr.ErrorForCode(errCode))
 	}
 }
+
+// TestIssue1296 verifies that ClientSoftwareName/Version is sent on every new
+// broker connection, not only the first. Without the fix, the per-broker
+// version cache let kgo skip ApiVersions on subsequent connections, so any
+// non-first connection (e.g. fetch/produce/group when a different typed
+// connection already opened to the same broker) registered as "unknown"
+// software on the broker side. This breaks KIP-714 client-metric matching.
+func TestIssue1296(t *testing.T) {
+	t.Parallel()
+
+	const (
+		topic       = "t1296"
+		softwareNm  = "issue1296-client"
+		softwareVer = "v9.9.9"
+	)
+
+	c, err := NewCluster(NumBrokers(1), SeedTopics(1, topic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	type seen struct {
+		name    string
+		version string
+	}
+	var (
+		mu   sync.Mutex
+		reqs []seen
+	)
+	c.ControlKey(int16(kmsg.ApiVersions), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		req := kreq.(*kmsg.ApiVersionsRequest)
+		mu.Lock()
+		reqs = append(reqs, seen{req.ClientSoftwareName, req.ClientSoftwareVersion})
+		mu.Unlock()
+		return nil, nil, false // observe only; let the cluster respond normally
+	})
+
+	// Count broker connections so we can assert that ApiVersions was sent
+	// on every connection (not just the first to each broker).
+	connects := new(atomic.Int32)
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.SoftwareNameAndVersion(softwareNm, softwareVer),
+		kgo.ConsumerGroup("g1296"),
+		kgo.ConsumeTopics(topic),
+		kgo.DefaultProduceTopic(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.FetchMaxWait(250*time.Millisecond),
+		kgo.WithHooks(&connCountHook{connects}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	// Produce a record to force a produce connection to the (sole) broker.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("v")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Poll fetches to force a fetch connection to the same broker, and to
+	// drive group-coordinator traffic (FindCoordinator on cxnNormal,
+	// JoinGroup/SyncGroup/Heartbeat on cxnGroup).
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer pollCancel()
+	for {
+		fs := cl.PollFetches(pollCtx)
+		if pollCtx.Err() != nil {
+			t.Fatal("timed out waiting for records")
+		}
+		if errs := fs.Errors(); len(errs) > 0 {
+			t.Fatalf("poll errors: %v", errs)
+		}
+		if fs.NumRecords() > 0 {
+			break
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Every connection setup sends ApiVersions, and each must carry our
+	// configured software name and version. Reusing the same broker via a
+	// different typed connection (cxnNormal/cxnProduce/cxnFetch/cxnGroup)
+	// must not skip the request -- otherwise the broker registers that
+	// connection as software=unknown and KIP-714 metric matching breaks.
+	gotConnects := int(connects.Load())
+	if len(reqs) != gotConnects {
+		t.Fatalf("ApiVersions sent %d times across %d broker connections; expected one per connection. Reqs: %+v",
+			len(reqs), gotConnects, reqs)
+	}
+	if len(reqs) < 2 {
+		t.Fatalf("expected at least 2 ApiVersions requests across multiple connections, got %d", len(reqs))
+	}
+	for i, r := range reqs {
+		if r.name != softwareNm || r.version != softwareVer {
+			t.Errorf("ApiVersions #%d: got SoftwareName=%q SoftwareVersion=%q; want %q/%q",
+				i, r.name, r.version, softwareNm, softwareVer)
+		}
+	}
+}

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -770,20 +770,25 @@ type brokerCxn struct {
 }
 
 func (cxn *brokerCxn) init(isProduceCxn bool, tries int) error {
-	hasVersions := cxn.b.loadVersions() != nil
-	if !hasVersions {
-		if cxn.b.cl.cfg.maxVersions == nil || cxn.b.cl.cfg.maxVersions.HasKey(18) {
-			if err := cxn.requestAPIVersions(tries); err != nil {
-				if !errors.Is(err, ErrClientClosed) && !isRetryableBrokerErr(err) {
-					cxn.cl.cfg.logger.Log(LogLevelError, "unable to request api versions", "broker", logID(cxn.b.meta.NodeID), "err", err)
-				}
-				return err
+	// We always send ApiVersions on every new connection, even if we have
+	// already cached the broker's versions from a previous connection.
+	// ApiVersions is how we advertise our ClientSoftwareName/Version to the
+	// broker for the lifetime of this connection (KIP-714 client metrics
+	// match on these). If we skip it on a reused-broker connection, that
+	// connection registers as "unknown" software on the broker side, and
+	// any broker-side metric subscriptions scoped to our software name
+	// silently miss it. See twmb/franz-go#1296.
+	if cxn.b.cl.cfg.maxVersions == nil || cxn.b.cl.cfg.maxVersions.HasKey(18) {
+		if err := cxn.requestAPIVersions(tries); err != nil {
+			if !errors.Is(err, ErrClientClosed) && !isRetryableBrokerErr(err) {
+				cxn.cl.cfg.logger.Log(LogLevelError, "unable to request api versions", "broker", logID(cxn.b.meta.NodeID), "err", err)
 			}
-		} else {
-			// We have a max versions, and it indicates no support
-			// for ApiVersions. We just store a default empty map.
-			cxn.b.storeVersions(newBrokerVersions(0))
+			return err
 		}
+	} else if cxn.b.loadVersions() == nil {
+		// We have a max versions, and it indicates no support for
+		// ApiVersions. We just store a default empty map (once).
+		cxn.b.storeVersions(newBrokerVersions(0))
 	}
 
 	if err := cxn.sasl(); err != nil {


### PR DESCRIPTION
The broker identifies a connection's client software from the
ClientSoftwareName/Version on its ApiVersions request. We cached
the response per broker and skipped ApiVersions on subsequent
connections, so any non-first connection (e.g. fetch when
group/produce already opened) registered as software=unknown.

This breaks KIP-714: broker-side metric subscriptions scoped to
software name/version silently miss those connections, and one
kgo.Client appears as two software entities to the broker.

Versions are still cached for request-version selection.

Closes #1296