### PR TITLE
kgo: skip BlockRebalanceOnPoll gate on assign with no OnPartitionsAssigned

### DIFF
--- a/pkg/kgo/CLAUDE.md
+++ b/pkg/kgo/CLAUDE.md
@@ -11,6 +11,16 @@ franz-go is a pure Go Kafka client library. The `kgo` package is the main client
 - Internal comments should explain WHY we are doing something, not just WHAT we are doing. WHAT comments are almost never useful, unless the block that follows is complex.
 - Comments around subtle race conditions (logic or data) should contain a walkthrough of how the race is encountered. Don't JUST say what the race is, but also how a sequence of events can encounter the race.
 
+## Context keys: NEVER use empty struct as a key
+
+Per the Go spec, two distinct zero-size variables may share the same address. That means `type myKey struct{}` is unsafe as a `context.WithValue` key - it can collide with any other package using the same pattern. Use the project's pointer-to-string idiom instead:
+
+```go
+var myKey = func() *string { s := "my_key"; return &s }()
+```
+
+The string body is for debugging; the pointer's identity is what makes the key unique. Examples in this package: `ctxPinReq` (broker.go), `noShardRetryCtx` (client.go), `commitContextFn` / `txnCommitContextFn` (consumer_group.go), `ctxRecRecycle` (pools.go).
+
 ## Commit Style
 
 - Format: `kgo: <description>` (lowercase, no period)

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -187,11 +187,12 @@ type cfg struct {
 	rebalanceTimeout  time.Duration
 	heartbeatInterval time.Duration
 
-	onAssigned func(context.Context, *Client, map[string][]int32)
-	onRevoked  func(context.Context, *Client, map[string][]int32)
-	onLost     func(context.Context, *Client, map[string][]int32)
-	onBlocked  func(context.Context, *Client)
-	onFetched  func(context.Context, *Client, *kmsg.OffsetFetchResponse) error
+	onAssigned      func(context.Context, *Client, map[string][]int32)
+	onRevoked       func(context.Context, *Client, map[string][]int32)
+	onLost          func(context.Context, *Client, map[string][]int32)
+	onBlocked       func(context.Context, *Client)
+	onFetched       func(context.Context, *Client, *kmsg.OffsetFetchResponse) error
+	userHasOnAssign bool // captured before initGroup wraps onAssigned non-nil
 
 	adjustOffsetsBeforeAssign func(ctx context.Context, offsets map[string]map[int32]Offset) (map[string]map[int32]Offset, error)
 
@@ -1768,10 +1769,14 @@ func RequireStableFetchOffsets() GroupOpt {
 // fast. If your record processing may be slow, it is recommended you also use
 // PollRecords rather than PollFetches so that you can bound how many records
 // you process at once. You must always AllowRebalances when you are done
-// processing the records you received. Only rebalances that lose partitions
-// are blocked; rebalances that are strictly net additions or non-modifications
-// do not block (the On callbacks are always blocked so that you can ensure
-// their serialization).
+// processing the records you received.
+//
+// Polls and rebalance callbacks gate each other so that you cannot commit
+// offsets across a rebalance: polls block while a callback is running, and
+// callbacks wait for in-flight polls to release via AllowRebalance before
+// running. The assign phase is gated only when you registered
+// [OnPartitionsAssigned]; otherwise it runs concurrent with poll because
+// adding partitions cannot cause a wrong-ownership commit.
 //
 // You can use [OnPartitionsCallbackBlocked] as a signal that a rebalance WANTS
 // to happen, but you are currently blocking it, and that you need to either

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -272,6 +272,18 @@ func (c *consumer) allowRebalance() {
 }
 
 func (c *consumer) waitAndAddRebalance() {
+	c.waitAndAddRebalanceMaybeSignal(true)
+}
+
+// waitAndAddRebalanceSilent is waitAndAddRebalance without the
+// OnPartitionsCallbackBlocked signal. Used by LeaveGroup: the gate guards
+// assignPartitions invalidation rather than a user callback, so signaling
+// "your callback is blocked" would be misleading.
+func (c *consumer) waitAndAddRebalanceSilent() {
+	c.waitAndAddRebalanceMaybeSignal(false)
+}
+
+func (c *consumer) waitAndAddRebalanceMaybeSignal(signal bool) {
 	if !c.cl.cfg.blockRebalanceOnPoll {
 		return
 	}
@@ -280,7 +292,7 @@ func (c *consumer) waitAndAddRebalance() {
 	defer c.pollWaitMu.Unlock()
 	c.pollWaitState += 1 << 32
 	for c.pollWaitState&math.MaxUint32 != 0 {
-		if !blockedCalled {
+		if signal && !blockedCalled {
 			if c.cl.cfg.onBlocked != nil {
 				go c.cl.cfg.onBlocked(c.cl.ctx, c.cl)
 			}

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -263,7 +263,7 @@ func (cl *Client) LeaveGroupContext(ctx context.Context) error {
 	}
 
 	go func() {
-		c.waitAndAddRebalance()
+		c.waitAndAddRebalanceSilent()
 		c.mu.Lock() // lock for assign
 		c.assignPartitions(nil, assignInvalidateAll, nil, "invalidating all assignments in LeaveGroup")
 		c.g.leave(ctx)
@@ -333,6 +333,15 @@ func (c *consumer) initGroup() {
 		g.cfg.autocommitDisable = true
 	}
 
+	// Capture whether the user actually registered onAssigned before the
+	// wrapper below replaces it with a non-nil entry-logger. assign() uses
+	// this to decide whether the BlockRebalanceOnPoll gate applies.
+	g.cfg.userHasOnAssign = g.cfg.onAssigned != nil
+
+	// INVARIANT: after this loop, on{Assigned,Revoked,Lost} are all non-nil.
+	// The wrapper unconditionally replaces each callback so we can log entry
+	// even when the user did not provide one. Downstream callers rely on this
+	// and skip nil-checks.
 	for _, logOn := range []struct {
 		name string
 		set  *func(context.Context, *Client, map[string][]int32)
@@ -391,7 +400,7 @@ func (g *groupConsumer) manageFailWait(consecutiveErrors int, err error) (ctxCan
 	// block around the onLost and assigning.
 	g.c.waitAndAddRebalance()
 
-	if errors.Is(err, context.Canceled) && g.cfg.onRevoked != nil {
+	if errors.Is(err, context.Canceled) {
 		// The cooperative consumer does not revoke everything
 		// while rebalancing, meaning if our context is
 		// canceled, we may have uncommitted data. Rather than
@@ -409,9 +418,7 @@ func (g *groupConsumer) manageFailWait(consecutiveErrors int, err error) (ctxCan
 	} else {
 		// Any other error is perceived as a fatal error,
 		// and we go into onLost as appropriate.
-		if g.cfg.onLost != nil {
-			g.cfg.onLost(g.cl.ctx, g.cl, g.nowAssigned.read())
-		}
+		g.cfg.onLost(g.cl.ctx, g.cl, g.nowAssigned.read())
 		g.cfg.hooks.each(func(h Hook) {
 			if h, ok := h.(HookGroupManageError); ok {
 				h.OnGroupManageError(err)
@@ -676,9 +683,7 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 		} else {
 			g.cfg.logger.Log(LogLevelInfo, "cooperative consumer revoking prior assigned partitions because leaving group", "group", g.cfg.group, "revoking", g.nowAssigned.read())
 		}
-		if g.cfg.onRevoked != nil {
-			g.cfg.onRevoked(g.cl.ctx, g.cl, g.nowAssigned.read())
-		}
+		g.cfg.onRevoked(g.cl.ctx, g.cl, g.nowAssigned.read())
 		g.nowAssigned.store(nil)
 		g.lastAssigned = nil
 
@@ -755,9 +760,7 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 		} else {
 			g.cfg.logger.Log(LogLevelInfo, "calling onRevoke at the end of a session", "group", g.cfg.group, "lost", lost, "stage", stage)
 		}
-		if g.cfg.onRevoked != nil {
-			g.cfg.onRevoked(g.cl.ctx, g.cl, lost)
-		}
+		g.cfg.onRevoked(g.cl.ctx, g.cl, lost)
 	}
 
 	if len(lost) == 0 { // if we lost nothing, do nothing
@@ -839,16 +842,25 @@ func (s *assignRevokeSession) assign(g *groupConsumer, newAssigned map[string][]
 	go func() {
 		defer close(s.assignDone)
 		<-s.prerevokeDone
-		if g.cfg.onAssigned != nil {
-			// We always call on assigned, even if nothing new is
-			// assigned. This allows consumers to know that
-			// assignment is done and do setup logic.
-			//
-			// If configured, we have to block polling.
+		// We always call onAssigned, even if nothing new is assigned.
+		// This allows consumers to know that assignment is done and do
+		// setup logic.
+		//
+		// The BlockRebalanceOnPoll gate exists to prevent a poll loop
+		// from committing offsets across a rebalance for partitions it
+		// no longer owns. Assign only adds partitions, so the user's
+		// in-flight commit cannot reference anything they don't still
+		// own. We therefore gate only when the user registered an
+		// OnPartitionsAssigned callback and needs it serialized with
+		// poll; the entry-log wrapper alone is fine to run concurrent
+		// with poll. If you ever add internal work here that races
+		// with poll (e.g., touching nowAssigned or commit state),
+		// remove this conditional.
+		if g.cfg.userHasOnAssign {
 			g.c.waitAndAddRebalance()
 			defer g.c.unaddRebalance()
-			g.cfg.onAssigned(g.cl.ctx, g.cl, newAssigned)
 		}
+		g.cfg.onAssigned(g.cl.ctx, g.cl, newAssigned)
 	}()
 	return s.assignDone
 }


### PR DESCRIPTION
The `BlockRebalanceOnPoll` gate exists to prevent a poll loop from committing offsets across a rebalance for partitions it no longer owns. Assign only adds partitions — the in-flight commit can't reference anything the user doesn't still own — so gating during assign is only needed to serialize a user-registered `OnPartitionsAssigned` callback with poll. This PR captures whether the user actually registered `OnPartitionsAssigned` (before `initGroup` wraps it non-nil for entry logging) and skips the gate at the `assign()` callsite when they did not.

Fixes the surprise reported in #1294: users who only register `OnPartitionsRevoked` get spurious `OnPartitionsCallbackBlocked` fires on every assign and an artificial pause in their poll loop, even though there is no user callback to serialize against.

## Behavior change

Mild but real:

- Users who registered `OnPartitionsAssigned`: identical behavior.
- Users who did not register `OnPartitionsAssigned`: assign no longer blocks poll, and `OnPartitionsCallbackBlocked` no longer fires for the assign phase. Revoke and lost are unchanged.

The gate's invariant — "you cannot commit offsets across a rebalance for partitions you no longer own" — is preserved, because assign cannot remove ownership.

## Also in this PR

- `LeaveGroup` runs a poll-blocking wait without any user callback. A new `waitAndAddRebalanceSilent` variant skips the `OnPartitionsCallbackBlocked` signal so "your callback is blocked" doesn't fire when nothing is.
- Drop dead nil-checks on `on{Assigned,Revoked,Lost}` in `revoke`/`assign`/`manageFailWait`: 1eb651c4 removed the tracking bools, and the `initGroup` wrapper keeps all three non-nil. Invariant documented at the wrap site.
- Update `BlockRebalanceOnPoll` docs: drop the inaccurate "non-modifications do not block" claim (cooperative revoke gates even with empty losses), correct "polls block" rather than return empty, and document the assign-without-callback exception.

Closes #1294.