### PR TITLE
kfake: accept first idempotent batch with any sequence number

### DIFF
--- a/pkg/kfake/00_produce.go
+++ b/pkg/kfake/00_produce.go
@@ -196,30 +196,30 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 				}
 				pidinf, window := c.pids.get(b.ProducerID, rt.Topic, rp.Partition, implicit)
 
-				// Reject non-transactional produce during an
-				// active transaction.
-				if pidinf != nil && pidinf.inTx && !txnal {
-					errCode = kerr.InvalidTxnState.Code
+				// For non-transactional idempotent produce with no
+				// existing producer state, implicitly create it.
+				// Apache Kafka and Redpanda accept the first batch
+				// for an unknown (PID, epoch) with any sequence
+				// number; this seeds producer state on demand.
+				// See twmb/franz-go#1281.
+				if !txnal && pidinf == nil && b.ProducerEpoch != -1 {
+					pidinf, window = c.pids.getOrCreateNonTx(b.ProducerID, b.ProducerEpoch, rt.Topic, rp.Partition)
 				}
 
-				if txnal && window == nil {
+				switch {
+				case pidinf != nil && pidinf.inTx && !txnal:
 					errCode = kerr.InvalidTxnState.Code
-				}
-
-				if errCode == 0 {
-					switch {
-					case window == nil && b.ProducerEpoch != -1:
-						errCode = kerr.InvalidTxnState.Code
-					case window != nil && b.ProducerEpoch < pidinf.epoch:
-						errCode = kerr.InvalidProducerEpoch.Code
-					case window != nil && b.ProducerEpoch > pidinf.epoch:
-						errCode = kerr.InvalidProducerEpoch.Code
-					default:
-						var seqOk bool
-						seqOk, dup, baseOffset = window.pushAndValidate(b.ProducerEpoch, b.FirstSequence, b.NumRecords, pd.highWatermark)
-						if !seqOk {
-							errCode = kerr.OutOfOrderSequenceNumber.Code
-						}
+				case window == nil && b.ProducerEpoch != -1:
+					// Tx batch on an unregistered partition for
+					// pre-KIP-890 (v<12), or no pidinf at all.
+					errCode = kerr.InvalidTxnState.Code
+				case window != nil && b.ProducerEpoch != pidinf.epoch:
+					errCode = kerr.InvalidProducerEpoch.Code
+				default:
+					var seqOk bool
+					seqOk, dup, baseOffset = window.pushAndValidate(b.ProducerEpoch, b.FirstSequence, b.NumRecords, pd.highWatermark)
+					if !seqOk {
+						errCode = kerr.OutOfOrderSequenceNumber.Code
 					}
 				}
 				if errCode == 0 && !dup {

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2,6 +2,7 @@ package kfake
 
 import (
 	"context"
+	"hash/crc32"
 	"net"
 	"strconv"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/kversion"
 )
 
 func TestIssue885(t *testing.T) {
@@ -2620,6 +2622,87 @@ func TestDeleteRecordsThenProduce(t *testing.T) {
 		if err := cl.ProduceSync(ctx, kgo.StringRecord("v")).FirstErr(); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+// TestIssue1281 verifies that kfake accepts an idempotent (non-tx)
+// produce request for an unknown PID/epoch with any sequence number,
+// matching Apache Kafka and Redpanda. Before the fix, kfake returned
+// INVALID_TXN_STATE when no producer state existed for the PID.
+func TestIssue1281(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCluster(NumBrokers(1), SeedTopics(1, "t"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.MaxVersions(kversion.V3_6_0()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	makeBatch := func(pid int64, epoch int16, firstSeq int32) []byte {
+		rec := kmsg.Record{Value: []byte("v")}
+		rec.Length = int32(len(rec.AppendTo(nil)) - 1)
+		batch := kmsg.RecordBatch{
+			Magic:         2,
+			ProducerID:    pid,
+			ProducerEpoch: epoch,
+			FirstSequence: firstSeq,
+			NumRecords:    1,
+			Records:       rec.AppendTo(nil),
+		}
+		raw := batch.AppendTo(nil)
+		batch.Length = int32(len(raw) - 12)
+		raw = batch.AppendTo(nil)
+		batch.CRC = int32(crc32.Checksum(raw[21:], crc32.MakeTable(crc32.Castagnoli)))
+		return batch.AppendTo(nil)
+	}
+
+	produce := func(pid int64, epoch int16, firstSeq int32) int16 {
+		t.Helper()
+		req := kmsg.NewProduceRequest()
+		req.Acks = -1
+		req.TimeoutMillis = 5000
+		req.Topics = []kmsg.ProduceRequestTopic{{
+			Topic: "t",
+			Partitions: []kmsg.ProduceRequestTopicPartition{{
+				Partition: 0,
+				Records:   makeBatch(pid, epoch, firstSeq),
+			}},
+		}}
+		resp, err := req.RequestWith(context.Background(), cl)
+		if err != nil {
+			t.Fatalf("produce: %v", err)
+		}
+		return resp.Topics[0].Partitions[0].ErrorCode
+	}
+
+	// Unknown PID with non-zero firstSeq and non-zero epoch must be
+	// accepted; this seeds producer state on demand.
+	if code := produce(1000, 2, 10); code != 0 {
+		t.Fatalf("expected first batch to be accepted, got %v", kerr.ErrorForCode(code))
+	}
+
+	// A subsequent batch on the seeded state must follow normal
+	// sequence rules: the next firstSeq is 11, and a different value
+	// is rejected as out-of-order.
+	if code := produce(1000, 2, 99); code != kerr.OutOfOrderSequenceNumber.Code {
+		t.Fatalf("expected OutOfOrderSequenceNumber for second batch, got %v", kerr.ErrorForCode(code))
+	}
+	if code := produce(1000, 2, 11); code != 0 {
+		t.Fatalf("expected in-order second batch to be accepted, got %v", kerr.ErrorForCode(code))
+	}
+
+	// A different unknown PID is also accepted with any firstSeq.
+	if code := produce(2000, 0, 42); code != 0 {
+		t.Fatalf("expected new PID batch to be accepted, got %v", kerr.ErrorForCode(code))
 	}
 }
 

--- a/pkg/kfake/persist.go
+++ b/pkg/kfake/persist.go
@@ -1730,6 +1730,7 @@ func (c *Cluster) loadSeqWindows(fsys fs, dir string) error {
 			offsets: w.Offsets,
 			at:      w.At,
 			epoch:   w.Epoch,
+			seen:    true,
 		}
 		pidinf.windows.set(w.Topic, w.Part, pw)
 	}

--- a/pkg/kfake/txns.go
+++ b/pkg/kfake/txns.go
@@ -85,6 +85,11 @@ type (
 		offsets [5]int64 // base offsets corresponding to each seq entry, for dup detection
 		at      uint8
 		epoch   int16 // last seen epoch; when epoch changes, seq 0 is accepted
+		// seen is false until the first batch is pushed. While false,
+		// any (epoch, firstSeq) is accepted - matching Apache Kafka's
+		// behavior of accepting the first batch for a PID/epoch with
+		// any sequence number when no producer state exists yet.
+		seen bool
 	}
 )
 
@@ -586,6 +591,25 @@ func (pids *pids) get(id int64, t string, p int32, pd *partData) (*pidinfo, *pid
 	return pidinf, pidinf.windows.mkpDefault(t, p)
 }
 
+// getOrCreateNonTx returns the pidinfo and window for a
+// non-transactional idempotent producer, implicitly creating the
+// pidinfo if it does not already exist. This matches Apache Kafka,
+// which accepts the first produce request for an unknown
+// (PID, epoch) and seeds the producer state on demand.
+func (pids *pids) getOrCreateNonTx(id int64, epoch int16, t string, p int32) (*pidinfo, *pidwindow) {
+	pidinf := pids.ids[id]
+	if pidinf == nil {
+		pidinf = &pidinfo{
+			pids:       pids,
+			id:         id,
+			epoch:      epoch,
+			lastActive: time.Now(),
+		}
+		pids.ids[id] = pidinf
+	}
+	return pidinf, pidinf.windows.mkpDefault(t, p)
+}
+
 func (pids *pids) randomID() int64 {
 	for {
 		id := int64(rand.Uint64()) & math.MaxInt64
@@ -783,18 +807,20 @@ func (s *pidwindow) pushAndValidate(epoch int16, firstSeq, numRecs int32, baseOf
 		return true, false, 0
 	}
 
-	// If epoch changed, client has reset sequences.
-	if epoch != s.epoch {
-		if firstSeq != 0 {
+	// Reset window state on either:
+	//   - first batch ever (!s.seen): accept any (epoch, firstSeq);
+	//     matches Apache Kafka, which accepts the first batch for
+	//     an unknown PID/epoch with any sequence number.
+	//   - epoch change: the client has restarted; firstSeq must be 0.
+	if !s.seen || epoch != s.epoch {
+		if s.seen && firstSeq != 0 {
 			return false, false, 0
 		}
+		next := (int64(firstSeq) + int64(numRecs)) % math.MaxInt32
+		s.seen = true
 		s.epoch = epoch
-		s.at = 0
-		s.seq = [5]int32{}
-		s.offsets = [5]int64{}
-		s.seq[0] = 0
-		s.seq[1] = numRecs
-		s.offsets[0] = baseOffset
+		s.seq = [5]int32{firstSeq, int32(next)}
+		s.offsets = [5]int64{baseOffset}
 		s.at = 1
 		return true, false, 0
 	}


### PR DESCRIPTION
Apache Kafka and Redpanda implicitly create producer state on the
first produce request for an unknown (PID, epoch), accepting any
firstSeq. kfake instead returned INVALID_TXN_STATE, diverging from
real broker behavior and making it harder to test the okOnSink
recovery path in kgo.

Seed pidinfo on demand for non-transactional idempotent produce
when no producer state exists, and add a "seen" flag to pidwindow
so the first push to a fresh window accepts any (epoch, firstSeq).

Closes #1281