### PR TITLE
Create an internal "xsync" package that reimplements mutexes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - exhaustive
     - exptostd
     - fatcontext
+    - forbidigo
     - gocheckcompilerdirectives
     - gochecksumtype
     - gocritic
@@ -53,6 +54,17 @@ linters:
 
     exhaustive:
       default-signifies-exhaustive: true
+
+    forbidigo:
+      # In pkg/kgo non-test files we require xsync.Mutex / xsync.RWMutex.
+      # This lets testing/synctest treat mutex blocking as durably blocked;
+      # see pkg/kgo/internal/xsync.
+      forbid:
+        - pattern: ^sync\.Mutex$
+          msg: use xsync.Mutex in pkg/kgo so testing/synctest treats mutex waits as durably blocked
+        - pattern: ^sync\.RWMutex$
+          msg: use xsync.RWMutex in pkg/kgo so testing/synctest treats mutex waits as durably blocked
+      analyze-types: true
 
     gocritic:
       disabled-checks:
@@ -175,6 +187,13 @@ linters:
         path: _test\.go$
       - linters: [revive]
         text: "context-keys-type" # 848 opt-in uses deliberate string key
+        path: _test\.go$
+      # forbidigo (sync.Mutex/RWMutex ban) only applies to non-test pkg/kgo
+      # files directly in pkg/kgo/. The xsync package itself wraps sync, and
+      # kgo tests can still use sync.Mutex.
+      - linters: [forbidigo]
+        path-except: ^pkg/kgo/[^/]+\.go$
+      - linters: [forbidigo]
         path: _test\.go$
 
 issues:

--- a/examples/testing_with_kfake_and_synctest/go.mod
+++ b/examples/testing_with_kfake_and_synctest/go.mod
@@ -1,0 +1,21 @@
+module testing_with_kfake
+
+go 1.26.0
+
+require (
+	github.com/twmb/franz-go v1.20.6
+	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260218055430-fc72d8313608
+)
+
+require (
+	github.com/klauspost/compress v1.18.4 // indirect
+	github.com/pierrec/lz4/v4 v4.1.25 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
+	golang.org/x/crypto v0.48.0 // indirect
+)
+
+replace github.com/twmb/franz-go => ../..
+
+replace github.com/twmb/franz-go/pkg/kfake => ../../pkg/kfake
+
+replace github.com/twmb/franz-go/pkg/kmsg => ../../pkg/kmsg

--- a/examples/testing_with_kfake_and_synctest/go.sum
+++ b/examples/testing_with_kfake_and_synctest/go.sum
@@ -1,0 +1,8 @@
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/pierrec/lz4/v4 v4.1.25 h1:kocOqRffaIbU5djlIBr7Wh+cx82C0vtFb0fOurZHqD0=
+github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/twmb/franz-go/pkg/kadm v1.17.1 h1:Bt02Y/RLgnFO2NP2HVP1kd2TFtGRiJZx+fSArjZDtpw=
+github.com/twmb/franz-go/pkg/kadm v1.17.1/go.mod h1:s4duQmrDbloVW9QTMXhs6mViTepze7JLG43xwPcAeTg=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=

--- a/examples/testing_with_kfake_and_synctest/main_test.go
+++ b/examples/testing_with_kfake_and_synctest/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestProduceMultipleRecordsWithVirtualNetwork(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var stack kfake.VirtualNetwork
+
+		cluster, err := kfake.NewCluster(
+			kfake.NumBrokers(1),
+			kfake.Ports(9093),
+			kfake.SeedTopics(3, "multi-topic"),
+			kfake.ListenFn(stack.Listen),
+		)
+		if err != nil {
+			t.Fatalf("NewCluster: %v", err)
+		}
+		defer cluster.Close()
+
+		client, err := kgo.NewClient(
+			kgo.SeedBrokers(cluster.ListenAddrs()...),
+			kgo.DefaultProduceTopic("multi-topic"),
+			kgo.ConsumeTopics("multi-topic"),
+			kgo.Dialer(stack.DialContext),
+		)
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		defer client.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		const numRecords = 10
+		for i := range numRecords {
+			record := &kgo.Record{Value: []byte{byte(i)}}
+			if err := client.ProduceSync(ctx, record).FirstErr(); err != nil {
+				t.Fatalf("produce %d failed: %v", i, err)
+			}
+		}
+
+		var consumed int
+		for consumed < numRecords {
+			fetches := client.PollFetches(ctx)
+			consumed += fetches.NumRecords()
+		}
+		if consumed != numRecords {
+			t.Errorf("expected %d records, got %d", numRecords, consumed)
+		}
+	})
+}
+
+func TestTimeoutWithVirtualNetwork(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var stack kfake.VirtualNetwork
+
+		cluster, err := kfake.NewCluster(
+			kfake.NumBrokers(1),
+			kfake.Ports(9094),
+			kfake.SeedTopics(1, "timeout-topic"),
+			kfake.ListenFn(stack.Listen),
+		)
+		if err != nil {
+			t.Fatalf("NewCluster: %v", err)
+		}
+		defer cluster.Close()
+
+		consumer, err := kgo.NewClient(
+			kgo.SeedBrokers(cluster.ListenAddrs()...),
+			kgo.ConsumeTopics("timeout-topic"),
+			kgo.Dialer(stack.DialContext),
+			kgo.FetchMaxWait(100*time.Millisecond),
+		)
+		if err != nil {
+			t.Fatalf("NewClient: %v", err)
+		}
+		defer consumer.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		fetches := consumer.PollFetches(ctx)
+		if fetches.NumRecords() != 0 {
+			t.Errorf("expected 0 records from empty topic, got %d", fetches.NumRecords())
+		}
+	})
+}

--- a/pkg/kfake/virtual.go
+++ b/pkg/kfake/virtual.go
@@ -1,0 +1,152 @@
+package kfake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+)
+
+// VirtualNetwork is an in-memory networking stack for use with
+// testing/synctest. A synctest bubble can only advance its fake clock while
+// every goroutine is "durably blocked"; a goroutine blocked on real TCP I/O is
+// not durably blocked, so tests that use the real network stack will deadlock.
+// VirtualNetwork replaces TCP with in-process net.Pipe connections, which
+// synctest treats as durably blocked.
+//
+// A zero VirtualNetwork is usable; the listener map is lazy-initialized on
+// first Listen or DialContext. Pass Listen to kfake via ListenFn and pass
+// DialContext to kgo via the Dialer option.
+//
+// A VirtualNetwork must not be copied after first use.
+type VirtualNetwork struct {
+	once      sync.Once
+	mu        sync.RWMutex
+	listeners map[int]*virtualListener
+}
+
+func (s *VirtualNetwork) lazyinit() {
+	s.once.Do(func() {
+		s.listeners = make(map[int]*virtualListener)
+	})
+}
+
+// virtualListener implements net.Listener using channels.
+type virtualListener struct {
+	port        int
+	stack       *VirtualNetwork
+	connections chan net.Conn
+	closed      chan struct{}
+	closeOnce   sync.Once
+}
+
+// fakeAddr implements net.Addr.
+type fakeAddr struct {
+	port int
+}
+
+func (*fakeAddr) Network() string  { return "fake" }
+func (a *fakeAddr) String() string { return fmt.Sprintf("localhost:%d", a.port) }
+
+func (s *VirtualNetwork) Listen(_, address string) (net.Listener, error) {
+	s.lazyinit()
+	host, portS, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split host and port: %w", err)
+	}
+	if host != "localhost" && host != "127.0.0.1" && host != "" {
+		return nil, fmt.Errorf("the virtual network works only on localhost")
+	}
+	port, err := strconv.Atoi(portS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert port to int: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.listeners[port]; ok {
+		return nil, fmt.Errorf("port %d already in use", port)
+	}
+
+	listener := &virtualListener{
+		port:        port,
+		stack:       s,
+		connections: make(chan net.Conn),
+		closed:      make(chan struct{}),
+	}
+
+	s.listeners[port] = listener
+	return listener, nil
+}
+
+func (s *VirtualNetwork) DialContext(ctx context.Context, _, address string) (net.Conn, error) {
+	s.lazyinit()
+	host, portS, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split host and port: %w", err)
+	}
+	if host != "localhost" && host != "127.0.0.1" {
+		return nil, fmt.Errorf("the virtual network works only on localhost")
+	}
+	port, err := strconv.Atoi(portS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert port to int: %w", err)
+	}
+	s.mu.RLock()
+	listener, exists := s.listeners[port]
+	s.mu.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("no listener on port %d", port)
+	}
+
+	select {
+	case <-listener.closed:
+		return nil, fmt.Errorf("listener on port %d is closed", port)
+	default:
+	}
+
+	serverConn, clientConn := net.Pipe()
+
+	select {
+	case listener.connections <- serverConn:
+		return clientConn, nil
+	case <-listener.closed:
+		serverConn.Close()
+		clientConn.Close()
+		return nil, fmt.Errorf("listener on port %d is closed", port)
+	case <-ctx.Done():
+		serverConn.Close()
+		clientConn.Close()
+		return nil, ctx.Err()
+	}
+}
+
+func (s *VirtualNetwork) deregister(l *virtualListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.listeners, l.port)
+}
+
+func (l *virtualListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.connections:
+		return conn, nil
+	case <-l.closed:
+		return nil, errors.New("listener closed")
+	}
+}
+
+func (l *virtualListener) Close() error {
+	l.closeOnce.Do(func() {
+		close(l.closed)
+		l.stack.deregister(l)
+	})
+	return nil
+}
+
+func (l *virtualListener) Addr() net.Addr {
+	return &fakeAddr{port: l.port}
+}

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
 )
@@ -157,7 +158,7 @@ type broker struct {
 	cxnGroup   *brokerCxn
 	cxnSlow    *brokerCxn
 
-	reapMu sync.Mutex // held when modifying a brokerCxn
+	reapMu xsync.Mutex // held when modifying a brokerCxn
 
 	// reqs manages incoming message requests.
 	reqs ring[promisedReq]
@@ -1465,7 +1466,7 @@ func (cxn *brokerCxn) discard() {
 			err        error
 			timeToRead time.Duration
 
-			deadlineMu  sync.Mutex
+			deadlineMu  xsync.Mutex
 			deadlineSet bool
 
 			readDone = make(chan struct{})

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
 )
@@ -44,7 +45,7 @@ type Client struct {
 
 	rng func(func(*rand.Rand))
 
-	brokersMu    sync.RWMutex
+	brokersMu    xsync.RWMutex
 	brokers      []*broker    // ordered by broker ID
 	seeds        atomic.Value // []*broker, seed brokers, also ordered by ID
 	anyBrokerOrd []int32      // shuffled brokers, for random ordering
@@ -57,7 +58,7 @@ type Client struct {
 	// The mutex only exists to allow consumer session stopping to read
 	// sources to notify when starting a session; all writes happen in the
 	// metadata loop.
-	sinksAndSourcesMu sync.Mutex
+	sinksAndSourcesMu xsync.Mutex
 	sinksAndSources   map[int32]sinkAndSource
 
 	reqFormatter  *kmsg.RequestFormatter
@@ -66,14 +67,14 @@ type Client struct {
 	bufPool bufPool // for to brokers to share underlying reusable request buffers
 	prsPool prsPool // for sinks to reuse []promisedNumberedRecord
 
-	controllerIDMu sync.Mutex
+	controllerIDMu xsync.Mutex
 	controllerID   int32
 	clusterID      *string // we piggy back updating clusterID
 
 	// The following two ensure that we only have one fetchBrokerMetadata
 	// at once. This avoids unnecessary broker metadata requests and
 	// metadata trampling.
-	fetchingBrokersMu sync.Mutex
+	fetchingBrokersMu xsync.Mutex
 	fetchingBrokers   *struct {
 		done chan struct{}
 		err  error
@@ -85,7 +86,7 @@ type Client struct {
 
 	metrics metrics
 
-	coordinatorsMu sync.Mutex
+	coordinatorsMu xsync.Mutex
 	coordinators   map[coordinatorKey]*coordinatorLoad
 
 	updateMetadataCh     chan string
@@ -95,7 +96,7 @@ type Client struct {
 	metadone             chan struct{}
 
 	metaCache struct {
-		mu     sync.Mutex
+		mu     xsync.Mutex
 		topics map[string]cachedMetaTopic
 		byID   map[[16]byte]string // TopicID => topic name
 		allAt  time.Time           // when last all-topics fetch completed
@@ -540,7 +541,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 		ctxCancel: cancel,
 
 		rng: func() func(func(*rand.Rand)) {
-			var mu sync.Mutex
+			var mu xsync.Mutex
 			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 			return func(fn func(*rand.Rand)) {
 				mu.Lock()
@@ -801,7 +802,7 @@ func parseBrokerAddr(addr string) (hostport, error) {
 
 type connTimeouter struct {
 	def                  time.Duration
-	joinMu               sync.Mutex
+	joinMu               xsync.Mutex
 	lastRebalanceTimeout time.Duration
 }
 
@@ -2647,7 +2648,7 @@ func (cl *Client) handleShardedReq(ctx context.Context, req kmsg.Request) ([]Res
 	}
 
 	var (
-		shardsMu sync.Mutex
+		shardsMu xsync.Mutex
 		shards   []ResponseShard
 
 		addShard = func(shard ResponseShard) {

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -11,9 +11,9 @@ import (
 	"net"
 	"regexp"
 	"runtime/debug"
-	"sync"
 	"time"
 
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
@@ -559,7 +559,7 @@ func defaultCfg() cfg {
 		maxVersions: kversion.Stable(), // kversion bumps what is returned from Stable on the same release we add support for new features to kgo
 
 		retryBackoff: func() func(int) time.Duration {
-			var rngMu sync.Mutex
+			var rngMu xsync.Mutex
 			rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 			return func(fails int) time.Duration {
 				const (

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -184,13 +185,13 @@ type consumer struct {
 
 	cl *Client
 
-	pausedMu sync.Mutex   // grabbed when updating paused
+	pausedMu xsync.Mutex  // grabbed when updating paused
 	paused   atomic.Value // loaded when issuing fetches
 
 	// mu is grabbed when
 	//  - polling fetches, for quickly draining sources / updating group uncommitted
 	//  - calling assignPartitions (group / direct updates)
-	mu sync.Mutex
+	mu xsync.Mutex
 	d  *directConsumer // if non-nil, we are consuming partitions directly
 	g  *groupConsumer  // if non-nil, we are consuming as a group member
 	s  *shareConsumer  // if non-nil, we are consuming as a share group member
@@ -219,19 +220,19 @@ type consumer struct {
 	// sessionChangeMu is grabbed when a session is stopped and held through
 	// when a session can be started again. The sole purpose is to block an
 	// assignment change running concurrently with a metadata update.
-	sessionChangeMu sync.Mutex
+	sessionChangeMu xsync.Mutex
 
 	session atomic.Value // *consumerSession
 	kill    atomic.Bool
 
 	usingCursors usedCursors
 
-	sourcesReadyMu          sync.Mutex
+	sourcesReadyMu          xsync.Mutex
 	sourcesReadyCond        *sync.Cond
 	sourcesReadyForDraining []*source
 	fakeReadyForDraining    []Fetch
 
-	pollWaitMu    sync.Mutex
+	pollWaitMu    xsync.Mutex
 	pollWaitC     *sync.Cond
 	pollWaitState uint64 // 0 == nothing, low 32 bits: # pollers, high 32: # waiting rebalances
 }
@@ -1700,14 +1701,14 @@ type consumerSession struct {
 	// Workers signify the number of fetch and list / epoch goroutines that
 	// are currently running within the context of this consumer session.
 	// Stopping a session only returns once workers hits zero.
-	workersMu   sync.Mutex
+	workersMu   xsync.Mutex
 	workersCond *sync.Cond
 	workers     int
 
 	// listOrEpochMu largely guards the below. It is a sub-mutex of the
 	// consumer mutex to guard one concurrent data access (see below in
 	// assignPartitions).
-	listOrEpochMu           sync.Mutex
+	listOrEpochMu           xsync.Mutex
 	listOrEpochLoadsWaiting listOrEpochLoads
 	listOrEpochMetaCh       chan struct{} // non-nil if Loads is non-nil, signalled on meta update
 	listOrEpochLoadsLoading listOrEpochLoads

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -9,11 +9,11 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -46,7 +46,7 @@ type groupConsumer struct {
 	// CommitOffsets, this lock ensures that only one sync commit can
 	// happen at once, and if it is happening, no other commit can be
 	// happening.
-	syncCommitMu sync.RWMutex
+	syncCommitMu xsync.RWMutex
 
 	rejoinCh chan string // cap 1; sent to if subscription changes (regex)
 
@@ -86,7 +86,7 @@ type groupConsumer struct {
 	// locations fetch callbacks are called. We only have to worry about
 	// onRevoked because fetching offsets occurs after onAssigned, and
 	// onLost happens after fetching offsets is done.
-	onFetchedMu sync.Mutex
+	onFetchedMu xsync.Mutex
 
 	// leader is whether we are the leader right now. This is set to false
 	//
@@ -111,12 +111,12 @@ type groupConsumer struct {
 	// join&sync, we occasionally see RebalanceInProgress or
 	// IllegalGeneration errors while cooperative consuming.
 	// Not relevant if using KIP-848.
-	noCommitDuringJoinAndSync sync.RWMutex
+	noCommitDuringJoinAndSync xsync.RWMutex
 
 	//////////////
 	// mu block //
 	//////////////
-	mu sync.Mutex
+	mu xsync.Mutex
 
 	// using is updated when finding new assignments, we always add to this
 	// if we want to consume a topic (or see there are more potential
@@ -2862,7 +2862,7 @@ func (g *groupConsumer) waitJoinSyncMu(ctx context.Context) error {
 
 	var (
 		blockJoinSyncCh = make(chan struct{})
-		mu              sync.Mutex
+		mu              xsync.Mutex
 		returned        bool
 		maybeRUnlock    = func() {
 			mu.Lock()

--- a/pkg/kgo/consumer_share.go
+++ b/pkg/kgo/consumer_share.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -52,7 +53,7 @@ type (
 		// FlushAcks waiters (broadcast happens under mu only
 		// when pendingAcks reaches 0, to keep the cond
 		// broadcast and the wait-loop's Load consistent).
-		ackMu       sync.Mutex
+		ackMu       xsync.Mutex
 		ackC        *sync.Cond
 		pendingAcks atomic.Int64
 
@@ -74,7 +75,7 @@ type (
 		// mu block //
 		//////////////
 
-		mu       sync.Mutex
+		mu       xsync.Mutex
 		cond     *sync.Cond
 		dying    bool // single-shot leave guard + incWorker gate
 		workers  int  // active goroutines (manage + source loops)
@@ -107,7 +108,7 @@ type (
 		// a similar flow actually makes the code worse.
 		assigned atomic.Bool
 
-		ackMu       sync.Mutex
+		ackMu       xsync.Mutex
 		pendingAcks []shareAckEntry // user acks (r.Ack, finalizePreviousPoll, batchAckRecords)
 		pendingGaps []shareAckRange // internal acks (gap acks, release-undeliverable)
 		closed      bool            // set to reject user-side acks arriving after shutdown

--- a/pkg/kgo/internal/xsync/mutex_test.go
+++ b/pkg/kgo/internal/xsync/mutex_test.go
@@ -1,0 +1,222 @@
+package xsync
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// This test is copied from the standard library's sync package.
+func HammerMutex(m *Mutex, loops int, cdone chan bool) {
+	for i := 0; i < loops; i++ {
+		if i%3 == 0 {
+			if m.TryLock() {
+				m.Unlock()
+			}
+			continue
+		}
+		m.Lock()
+		//nolint:staticcheck
+		m.Unlock()
+	}
+	cdone <- true
+}
+
+// This test is copied from the standard library's sync package.
+func TestMutex(t *testing.T) {
+	m := new(Mutex)
+
+	m.Lock()
+	if m.TryLock() {
+		t.Fatalf("TryLock succeeded with mutex locked")
+	}
+	m.Unlock()
+	if !m.TryLock() {
+		t.Fatalf("TryLock failed with mutex unlocked")
+	}
+	m.Unlock()
+
+	c := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go HammerMutex(m, 1000, c)
+	}
+	for i := 0; i < 10; i++ {
+		<-c
+	}
+}
+
+func parallelReader(m *RWMutex, clocked, cunlock, cdone chan bool) {
+	m.RLock()
+	clocked <- true
+	<-cunlock
+	m.RUnlock()
+	cdone <- true
+}
+
+func doTestParallelReaders(numReaders, gomaxprocs int) {
+	runtime.GOMAXPROCS(gomaxprocs)
+	var m RWMutex
+	clocked := make(chan bool)
+	cunlock := make(chan bool)
+	cdone := make(chan bool)
+	for i := 0; i < numReaders; i++ {
+		go parallelReader(&m, clocked, cunlock, cdone)
+	}
+	// Wait for all parallel RLock()s to succeed.
+	for i := 0; i < numReaders; i++ {
+		<-clocked
+	}
+	for i := 0; i < numReaders; i++ {
+		cunlock <- true
+	}
+	// Wait for the goroutines to finish.
+	for i := 0; i < numReaders; i++ {
+		<-cdone
+	}
+}
+
+// This test is copied from the standard library's sync package.
+func TestParallelReaders(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	doTestParallelReaders(1, 4)
+	doTestParallelReaders(3, 4)
+	doTestParallelReaders(4, 2)
+}
+
+func reader(rwm *RWMutex, numIterations int, activity *int32, cdone chan bool) {
+	for i := 0; i < numIterations; i++ {
+		rwm.RLock()
+		n := atomic.AddInt32(activity, 1)
+		if n < 1 || n >= 10000 {
+			rwm.RUnlock()
+			panic(fmt.Sprintf("wlock(%d)\n", n))
+		}
+		for i := 0; i < 100; i++ {
+		}
+		atomic.AddInt32(activity, -1)
+		rwm.RUnlock()
+	}
+	cdone <- true
+}
+
+func writer(rwm *RWMutex, numIterations int, activity *int32, cdone chan bool) {
+	for i := 0; i < numIterations; i++ {
+		rwm.Lock()
+		n := atomic.AddInt32(activity, 10000)
+		if n != 10000 {
+			rwm.Unlock()
+			panic(fmt.Sprintf("wlock(%d)\n", n))
+		}
+		for i := 0; i < 100; i++ {
+		}
+		atomic.AddInt32(activity, -10000)
+		rwm.Unlock()
+	}
+	cdone <- true
+}
+
+func HammerRWMutex(gomaxprocs, numReaders, numIterations int) {
+	runtime.GOMAXPROCS(gomaxprocs)
+	// Number of active readers + 10000 * number of active writers.
+	var activity int32
+	var rwm RWMutex
+	cdone := make(chan bool)
+	go writer(&rwm, numIterations, &activity, cdone)
+	var i int
+	for i = 0; i < numReaders/2; i++ {
+		go reader(&rwm, numIterations, &activity, cdone)
+	}
+	go writer(&rwm, numIterations, &activity, cdone)
+	for ; i < numReaders; i++ {
+		go reader(&rwm, numIterations, &activity, cdone)
+	}
+	// Wait for the 2 writers and all readers to finish.
+	for i := 0; i < 2+numReaders; i++ {
+		<-cdone
+	}
+}
+
+// This test is copied from the standard library's sync package.
+func TestRWMutex(t *testing.T) {
+	var m RWMutex
+
+	m.Lock()
+	if m.TryLock() {
+		t.Fatalf("TryLock succeeded with mutex locked")
+	}
+	if m.TryRLock() {
+		t.Fatalf("TryRLock succeeded with mutex locked")
+	}
+	m.Unlock()
+
+	if !m.TryLock() {
+		t.Fatalf("TryLock failed with mutex unlocked")
+	}
+	m.Unlock()
+
+	if !m.TryRLock() {
+		t.Fatalf("TryRLock failed with mutex unlocked")
+	}
+	if !m.TryRLock() {
+		t.Fatalf("TryRLock failed with mutex rlocked")
+	}
+	if m.TryLock() {
+		t.Fatalf("TryLock succeeded with mutex rlocked")
+	}
+	m.RUnlock()
+	m.RUnlock()
+
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	n := 1000
+	if testing.Short() {
+		n = 5
+	}
+	HammerRWMutex(1, 1, n)
+	HammerRWMutex(1, 3, n)
+	HammerRWMutex(1, 10, n)
+	HammerRWMutex(4, 1, n)
+	HammerRWMutex(4, 3, n)
+	HammerRWMutex(4, 10, n)
+	HammerRWMutex(10, 1, n)
+	HammerRWMutex(10, 3, n)
+	HammerRWMutex(10, 10, n)
+	HammerRWMutex(10, 5, n)
+}
+
+// This test is copied from the standard library's sync package.
+func TestRLocker(t *testing.T) {
+	var wl RWMutex
+	var rl sync.Locker
+	wlocked := make(chan bool, 1)
+	rlocked := make(chan bool, 1)
+	rl = wl.RLocker()
+	n := 10
+	go func() {
+		for i := 0; i < n; i++ {
+			rl.Lock()
+			rl.Lock()
+			rlocked <- true
+			wl.Lock()
+			wlocked <- true
+		}
+	}()
+	for i := 0; i < n; i++ {
+		<-rlocked
+		rl.Unlock()
+		select {
+		case <-wlocked:
+			t.Fatal("RLocker() didn't read-lock it")
+		default:
+		}
+		rl.Unlock()
+		<-wlocked
+		select {
+		case <-rlocked:
+			t.Fatal("RLocker() didn't respect the write lock")
+		default:
+		}
+		wl.Unlock()
+	}
+}

--- a/pkg/kgo/internal/xsync/mutex_test.go
+++ b/pkg/kgo/internal/xsync/mutex_test.go
@@ -18,7 +18,7 @@ func HammerMutex(m *Mutex, loops int, cdone chan bool) {
 			continue
 		}
 		m.Lock()
-		//nolint:staticcheck
+		//nolint:staticcheck,gocritic // hammer test copied from stdlib; deliberate immediate unlock to exercise Lock/Unlock pairing
 		m.Unlock()
 	}
 	cdone <- true
@@ -93,6 +93,7 @@ func reader(rwm *RWMutex, numIterations int, activity *int32, cdone chan bool) {
 			rwm.RUnlock()
 			panic(fmt.Sprintf("wlock(%d)\n", n))
 		}
+		//nolint:revive // busy-wait inside read lock; copied from stdlib test
 		for i := 0; i < 100; i++ {
 		}
 		atomic.AddInt32(activity, -1)
@@ -109,6 +110,7 @@ func writer(rwm *RWMutex, numIterations int, activity *int32, cdone chan bool) {
 			rwm.Unlock()
 			panic(fmt.Sprintf("wlock(%d)\n", n))
 		}
+		//nolint:revive // busy-wait inside write lock; copied from stdlib test
 		for i := 0; i < 100; i++ {
 		}
 		atomic.AddInt32(activity, -10000)

--- a/pkg/kgo/internal/xsync/sync_mutex.go
+++ b/pkg/kgo/internal/xsync/sync_mutex.go
@@ -1,0 +1,8 @@
+//go:build !synctests
+
+package xsync
+
+import "sync"
+
+type Mutex = sync.Mutex
+type RWMutex = sync.RWMutex

--- a/pkg/kgo/internal/xsync/sync_mutex.go
+++ b/pkg/kgo/internal/xsync/sync_mutex.go
@@ -1,5 +1,10 @@
 //go:build !synctests
 
+// Package xsync provides Mutex and RWMutex types that are aliases for
+// sync.Mutex / sync.RWMutex in normal builds and channel-backed
+// reimplementations under the "synctests" build tag. The channel-backed
+// versions let testing/synctest treat mutex waits as durably blocked so the
+// bubble's virtual clock can advance.
 package xsync
 
 import "sync"

--- a/pkg/kgo/internal/xsync/synctest_mutex.go
+++ b/pkg/kgo/internal/xsync/synctest_mutex.go
@@ -1,0 +1,169 @@
+//go:build synctests
+
+package xsync
+
+import "sync"
+
+// Mutex is a channel-based mutex for use with synctest.
+// A goroutine blocked on a sync.Mutex is not "durably
+// blocked" from synctest's perspective, which prevents time
+// from advancing. Channel-based blocking is durably blocked.
+type Mutex struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+func (m *Mutex) init() {
+	m.once.Do(func() {
+		m.ch = make(chan struct{}, 1)
+		m.ch <- struct{}{}
+	})
+}
+
+func (m *Mutex) Lock() {
+	m.init()
+	<-m.ch
+}
+
+func (m *Mutex) TryLock() bool {
+	m.init()
+	select {
+	case <-m.ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Mutex) Unlock() {
+	m.init()
+	select {
+	case m.ch <- struct{}{}:
+	default:
+		panic("sync: unlock of unlocked mutex")
+	}
+}
+
+// RWMutex is a channel-based readers-writer mutex with
+// writer priority.
+//
+// The design uses a "gate token" pattern: a buffered-1
+// channel holds a single token. Readers take the token and
+// immediately return it (passing through the gate). Writers
+// take the token and hold it, which blocks all new readers
+// until the writer unlocks. This provides writer priority
+// naturally — the moment a writer calls Lock, new RLock
+// calls block on the gate.
+//
+// A separate writerSignal channel (buffered 1) is used by
+// the last active reader to wake a waiting writer. A stale
+// signal can accumulate if readers drain while no writer is
+// waiting; Lock drains any stale signal before checking the
+// reader count.
+type RWMutex struct {
+	once         sync.Once
+	mu           Mutex
+	gate         chan struct{}
+	readerCount  int
+	writerSignal chan struct{}
+}
+
+func (rw *RWMutex) init() {
+	rw.once.Do(func() {
+		rw.gate = make(chan struct{}, 1)
+		rw.gate <- struct{}{}
+		rw.writerSignal = make(chan struct{}, 1)
+		rw.mu.init()
+	})
+}
+
+func (rw *RWMutex) RLock() {
+	rw.init()
+	<-rw.gate
+	rw.mu.Lock()
+	rw.readerCount++
+	rw.mu.Unlock()
+	rw.gate <- struct{}{}
+}
+
+func (rw *RWMutex) TryRLock() bool {
+	rw.init()
+	select {
+	case <-rw.gate:
+	default:
+		return false
+	}
+	rw.mu.Lock()
+	rw.readerCount++
+	rw.mu.Unlock()
+	rw.gate <- struct{}{}
+	return true
+}
+
+func (rw *RWMutex) RUnlock() {
+	rw.mu.Lock()
+	rw.readerCount--
+	if rw.readerCount < 0 {
+		rw.mu.Unlock()
+		panic("sync: RUnlock of unlocked RWMutex")
+	}
+	if rw.readerCount == 0 {
+		select {
+		case rw.writerSignal <- struct{}{}:
+		default:
+		}
+	}
+	rw.mu.Unlock()
+}
+
+func (rw *RWMutex) Lock() {
+	rw.init()
+	<-rw.gate
+	select {
+	case <-rw.writerSignal:
+	default:
+	}
+	rw.mu.Lock()
+	if rw.readerCount > 0 {
+		rw.mu.Unlock()
+		<-rw.writerSignal
+	} else {
+		rw.mu.Unlock()
+	}
+}
+
+func (rw *RWMutex) TryLock() bool {
+	rw.init()
+	select {
+	case <-rw.gate:
+	default:
+		return false
+	}
+	select {
+	case <-rw.writerSignal:
+	default:
+	}
+	rw.mu.Lock()
+	if rw.readerCount > 0 {
+		rw.mu.Unlock()
+		rw.gate <- struct{}{}
+		return false
+	}
+	rw.mu.Unlock()
+	return true
+}
+
+func (rw *RWMutex) Unlock() {
+	select {
+	case rw.gate <- struct{}{}:
+	default:
+		panic("sync: Unlock of unlocked RWMutex")
+	}
+}
+
+func (rw *RWMutex) RLocker() sync.Locker { return (*rlocker)(rw) }
+
+type rlocker RWMutex
+
+func (r *rlocker) Lock()   { (*RWMutex)(r).RLock() }
+func (r *rlocker) Unlock() { (*RWMutex)(r).RUnlock() }

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -12,10 +12,11 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 )
 
 type metawait struct {
-	mu         sync.Mutex
+	mu         xsync.Mutex
 	c          *sync.Cond
 	lastUpdate time.Time
 }

--- a/pkg/kgo/metrics_714.go
+++ b/pkg/kgo/metrics_714.go
@@ -9,11 +9,11 @@ import (
 	"math"
 	"math/rand"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -313,7 +313,7 @@ type (
 		closedFirstObserve atomic.Bool
 
 		// mu is grabbed when accessing the map fields.
-		mu          sync.Mutex
+		mu          xsync.Mutex
 		unsupported atomic.Bool // set to true if the broker does not support client metrics; guards nil-ing the maps
 
 		pConnCreation metricRate

--- a/pkg/kgo/produce_request_test.go
+++ b/pkg/kgo/produce_request_test.go
@@ -778,5 +778,4 @@ func TestClient_ProduceLargeMessages(t *testing.T) {
 			t.Errorf("expected error message to contain compressed_bytes=%d but got: %v", recordSize, err)
 		}
 	})
-
 }

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -10,13 +10,14 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type producer struct {
 	// mu and c are used for flush and drain notifications; mu is used for
 	// a few other tight locks.
-	mu sync.Mutex
+	mu xsync.Mutex
 	c  *sync.Cond
 
 	bufferedRecords int64
@@ -24,7 +25,7 @@ type producer struct {
 
 	cl *Client
 
-	topicsMu sync.Mutex // locked to prevent concurrent updates; reads are always atomic
+	topicsMu xsync.Mutex // locked to prevent concurrent updates; reads are always atomic
 	topics   *topicsPartitions
 
 	// Hooks exist behind a pointer because likely they are not used.
@@ -38,7 +39,7 @@ type producer struct {
 	// unknownTopics buffers all records for topics that are not loaded.
 	// The map is to a pointer to a slice for reasons documented in
 	// waitUnknownTopic.
-	unknownTopicsMu sync.Mutex
+	unknownTopicsMu xsync.Mutex
 	unknownTopics   map[string]*unknownTopicProduces
 
 	id           atomic.Value
@@ -53,12 +54,12 @@ type producer struct {
 
 	aborting atomic.Int32 // >0 if aborting, can abort many times concurrently
 
-	idMu      sync.Mutex
+	idMu      xsync.Mutex
 	idVersion int16
 
 	batchPromises ring[batchPromise] // we never call die() on it
 
-	txnMu   sync.Mutex
+	txnMu   xsync.Mutex
 	inTxn   bool
 	tx890p2 bool
 }
@@ -100,7 +101,7 @@ func (cl *Client) EnsureProduceConnectionIsOpen(ctx context.Context, brokers ...
 		keep = brokers[:0]
 		all  bool
 		wg   sync.WaitGroup
-		mu   sync.Mutex
+		mu   xsync.Mutex
 		errs []error
 	)
 	for _, b := range brokers {

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -555,7 +555,7 @@ func (cl *Client) produce(
 	if cl.cfg.maxBufferedBytes > 0 && userSize > cl.cfg.maxBufferedBytes {
 		p.promiseRecordBeforeBuf(
 			promisedRec{ctx, promise, r},
-			fmt.Errorf("%w (uncompressed_bytes=%d).", kerr.MessageTooLarge, userSize),
+			fmt.Errorf("%w (uncompressed_bytes=%d)", kerr.MessageTooLarge, userSize),
 		)
 		return
 	}

--- a/pkg/kgo/ring.go
+++ b/pkg/kgo/ring.go
@@ -2,6 +2,8 @@ package kgo
 
 import (
 	"sync"
+
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 )
 
 // The ring type is a dynamically-sized circular buffer with optional blocking
@@ -35,7 +37,7 @@ import (
 const minRingCap = 8
 
 type ring[T any] struct {
-	mu sync.Mutex
+	mu xsync.Mutex
 
 	elems []T // circular buffer, min capacity minRingCap
 	head  int // index of first element

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -47,8 +47,8 @@ type sink struct {
 	consecutiveFailures atomic.Uint32
 
 	recBufsMu    xsync.Mutex // guards the following
-	recBufs      []*recBuf  // contains all partition records for batch building
-	recBufsStart int        // incremented every req to avoid large batch starvation
+	recBufs      []*recBuf   // contains all partition records for batch building
+	recBufsStart int         // incremented every req to avoid large batch starvation
 }
 
 type seqResp struct {
@@ -944,7 +944,7 @@ func (s *sink) handleReqRespBatch(
 
 	err := kerr.ErrorForCode(rp.ErrorCode)
 	if errors.Is(err, kerr.MessageTooLarge) {
-		err = fmt.Errorf("%w (uncompressed_bytes=%d, compressed_bytes=%d).", err, batchMetrics.UncompressedBytes, batchMetrics.CompressedBytes)
+		err = fmt.Errorf("%w (uncompressed_bytes=%d, compressed_bytes=%d)", err, batchMetrics.UncompressedBytes, batchMetrics.CompressedBytes)
 	}
 	failUnknown := batch.owner.checkUnknownFailLimit(err)
 	switch {
@@ -1496,7 +1496,7 @@ func (recBuf *recBuf) bufferRecord(pr promisedRec, abortOnNewBatch bool) bool {
 		default: // processed as failure
 			recBuf.cl.prsPool.put(newBatch.records)
 			recBuf.cl.producer.promiseRecord(pr,
-				fmt.Errorf("%w (uncompressed_bytes=%d).", kerr.MessageTooLarge, pr.userSize()),
+				fmt.Errorf("%w (uncompressed_bytes=%d)", kerr.MessageTooLarge, pr.userSize()),
 			)
 			return true
 		}
@@ -2087,13 +2087,13 @@ func (cl *Client) baseProduceRequestLength() int32 {
 		2 + // int16 version
 		4 + // int32 correlation ID
 		2 // int16 client ID len (always non flexible)
-	    // empty tag section skipped; see below
+		// empty tag section skipped; see below
 
 	const produceRequestBaseOverhead int32 = 2 + // int16 transactional ID len (flexible or not, since we cap at 16382)
 		2 + // int16 acks
 		4 + // int32 timeout
 		4 // int32 topics non-flexible array length
-	    // empty tag section skipped; see below
+		// empty tag section skipped; see below
 
 	baseLength := messageRequestOverhead + produceRequestBaseOverhead
 	if cl.cfg.id != nil {
@@ -2311,8 +2311,7 @@ func (p *produceRequest) AppendTo(dst []byte) []byte {
 			dst = kbin.AppendArrayLen(dst, len(partitions))
 		}
 
-		var tmetrics map[int32]ProduceBatchMetrics
-		tmetrics = make(map[int32]ProduceBatchMetrics)
+		tmetrics := make(map[int32]ProduceBatchMetrics)
 		p.metrics[topic] = tmetrics
 
 		for partition, batch := range partitions {

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -35,7 +36,7 @@ type sink struct {
 	// but sequentially.
 	seqResps ring[*seqResp] // we never call die() on it
 
-	backoffMu   sync.Mutex // guards the following
+	backoffMu   xsync.Mutex // guards the following
 	needBackoff bool
 	backoffSeq  uint32 // prevents pile on failures
 
@@ -45,7 +46,7 @@ type sink struct {
 	// occurs, the backoff is not cleared.
 	consecutiveFailures atomic.Uint32
 
-	recBufsMu    sync.Mutex // guards the following
+	recBufsMu    xsync.Mutex // guards the following
 	recBufs      []*recBuf  // contains all partition records for batch building
 	recBufsStart int        // incremented every req to avoid large batch starvation
 }
@@ -338,7 +339,7 @@ func (s *sink) produce(sem <-chan struct{}) bool {
 	// context.Canceled error is from *that* context rather than the client
 	// context or something else. So, we go through some special care to
 	// track setting the ctx / looking up if it is canceled.
-	var holCtxMu sync.Mutex
+	var holCtxMu xsync.Mutex
 	var holCtx context.Context
 	ctxFn := func() context.Context {
 		holCtxMu.Lock()
@@ -1344,7 +1345,7 @@ type recBuf struct {
 	// of records buffered in total on this recBuf.
 	buffered atomic.Int64
 
-	mu sync.Mutex // guards r/w access to all fields below
+	mu xsync.Mutex // guards r/w access to all fields below
 
 	// sink is who is currently draining us. This can be modified
 	// concurrently during a metadata update.
@@ -1736,7 +1737,7 @@ type recBatch struct {
 	firstTimestamp    int64 // since unix epoch, in millis
 	maxTimestampDelta int64
 
-	mu      sync.Mutex    // guards appendTo's reading of records against failAllRecords emptying it
+	mu      xsync.Mutex   // guards appendTo's reading of records against failAllRecords emptying it
 	records []promisedRec // record w/ length, ts calculated
 }
 

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -8,12 +8,12 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kbin"
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -41,7 +41,7 @@ type source struct {
 
 	session fetchSession // supports fetch sessions as per KIP-227
 
-	cursorsMu    sync.Mutex
+	cursorsMu    xsync.Mutex
 	cursors      []*cursor // contains all partitions being consumed on this source
 	cursorsStart int       // incremented every fetch req to ensure all partitions are fetched
 
@@ -52,7 +52,7 @@ type sourceShare struct {
 	s  *source // back-pointer for hook, sem, maybeShareConsume
 	sc *shareConsumer
 
-	mu           sync.Mutex
+	mu           xsync.Mutex
 	cursors      []*shareCursor
 	cursorsStart int
 	sessionEpoch int32              // 0=new, incremented on success, -1=close

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -8,10 +8,10 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -293,7 +293,7 @@ func newTopicPartitions() *topicPartitions {
 type topicPartitions struct {
 	v atomic.Value // *topicPartitionsData
 
-	partsMu     sync.Mutex
+	partsMu     xsync.Mutex
 	partitioner TopicPartitioner
 	lb          *leastBackupInput // for partitioning if the partitioner is a LoadTopicPartitioner
 }

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
-	"github.com/twmb/franz-go/pkg/kmsg"
-
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func ctx2fn(ctx context.Context) func() context.Context { return func() context.Context { return ctx } }
@@ -35,7 +34,7 @@ const (
 type GroupTransactSession struct {
 	cl *Client
 
-	failMu sync.Mutex
+	failMu xsync.Mutex
 
 	revoked   bool
 	revokedCh chan struct{} // closed once when revoked is set; reset after End


### PR DESCRIPTION
When using synctests to test code that uses franzgo, it is possible to get deadlock, as described in #1250.

When build with `GOFLAGS=-tags=synctests`, the tests will use the reimplemented mutexes, which are channel-based so that synctests can track whether they are durably blocked or not.

(original PR [here](https://github.com/twmb/franz-go/pull/1268), adding a few follow ups before releasing kgo 1.21)