### PR TITLE
Update my github username in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ type HookPollStart interface {
 * `kfake.VirtualNetwork` plus a new `kgo` xsync package enable full
   `testing/synctest` support against an in-process kfake cluster. See
   `examples/testing_with_kfake_and_synctest`. Thanks
-  [@manuc-conf](https://github.com/manuc-conf)!
+  [@cupcicm](https://github.com/cupcicm)!
 
 ## Behavior changes
 


### PR DESCRIPTION
Confluent has some process that hides my username when creating pull requests against open source repositories, which means the link in the changelog is a 404.