### PR TITLE
add support for custom AWS MSK dns names

### DIFF
--- a/pkg/sasl/aws/aws.go
+++ b/pkg/sasl/aws/aws.go
@@ -125,7 +125,6 @@ func challenge(auth Auth, host string) ([]byte, error) {
 		if region == "" {
 			return nil, err
 		}
-		log.Printf("MSK IAM: host %q does not contain a valid AWS region, using %q from environment", host, region)
 	}
 
 	var (

--- a/pkg/sasl/aws/aws.go
+++ b/pkg/sasl/aws/aws.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -117,7 +118,14 @@ func challenge(auth Auth, host string) ([]byte, error) {
 	}
 	region, err := identifyRegion(host)
 	if err != nil {
-		return nil, err
+		region = os.Getenv("AWS_REGION")
+		if region == "" {
+			region = os.Getenv("AWS_DEFAULT_REGION")
+		}
+		if region == "" {
+			return nil, err
+		}
+		log.Printf("MSK IAM: host %q does not contain a valid AWS region, using %q from environment", host, region)
 	}
 
 	var (

--- a/pkg/sasl/aws/aws.go
+++ b/pkg/sasl/aws/aws.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"os"


### PR DESCRIPTION
when working with custom DNS Names for AWS MSK, the identifyRegion function fails as the URL format is different. Therefore this library is currently not usable when working with custom DNS names, as described for example here (https://aws.amazon.com/de/blogs/big-data/configure-a-custom-domain-name-for-your-amazon-msk-cluster/). This approach uses the env var to determine the region when the region can't be determined using the url instead of failing. To avoid confusion a log message was added whenever the env variable is used