### PR TITLE
kgo: fix delTopics not writing back modified pausedPartitions struct

### DIFF
--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -216,6 +216,7 @@ func (m pausedTopics) delTopics(topics ...string) {
 			continue
 		}
 		pps.all = false
+		m[topic] = pps
 		if !pps.all && len(pps.m) == 0 {
 			delete(m, topic)
 		}

--- a/pkg/kgo/topics_and_partitions_test.go
+++ b/pkg/kgo/topics_and_partitions_test.go
@@ -1,0 +1,33 @@
+package kgo
+
+import (
+	"testing"
+)
+
+func TestDelTopicsWithCoexistingPartitionPauses(t *testing.T) {
+	// delTopics must clear all=true even when partition-level pauses exist for
+	// the same topic. Previously the modified pausedPartitions struct was never
+	// written back, leaving all=true in the map when len(pps.m) > 0.
+	m := make(pausedTopics)
+
+	// Add a topic-level pause and a partition-level pause for the same topic.
+	m.addTopics("topic-a")
+	m.addPartitions(map[string][]int32{"topic-a": {0}})
+
+	if !m["topic-a"].all {
+		t.Fatal("expected topic-a to be topic-paused after addTopics")
+	}
+
+	// Removing the topic-level pause must clear all=true even though partition
+	// pauses still exist.
+	m.delTopics("topic-a")
+
+	if pps, ok := m["topic-a"]; ok && pps.all {
+		t.Fatal("delTopics did not clear all=true when partition-level pauses coexist")
+	}
+
+	// The partition-level pause must still be present.
+	if _, ok := m["topic-a"].m[0]; !ok {
+		t.Fatal("delTopics unexpectedly removed the partition-level pause")
+	}
+}


### PR DESCRIPTION
## Bug

`delTopics` reads the `pausedPartitions` value from the map into a local copy, sets `all=false` on the copy, but never writes it back to the map. When partition-level pauses exist for the topic (`len(pps.m) > 0`), the `delete` branch is skipped and the modified copy is discarded — leaving `all=true` in the map. The topic remains permanently paused after `ResumeFetchTopics`.

```go
// before — pps is a copy; m[topic] is never updated
pps.all = false
if !pps.all && len(pps.m) == 0 {
    delete(m, topic)
}
```

## Fix

Write `pps` back to the map after clearing `all`, consistent with `addTopics`, `addPartitions`, and every other mutating function in this file.

```go
pps.all = false
m[topic] = pps  // write back
if !pps.all && len(pps.m) == 0 {
    delete(m, topic)
}
```

## Test

Added `TestDelTopicsWithCoexistingPartitionPauses` in `topics_and_partitions_test.go` covering the coexistence case.