### PR TITLE
kgo: isolate metadata cache from broker response

### DIFF
--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -3207,3 +3207,104 @@ func TestIssue1330(t *testing.T) {
 		}
 	}
 }
+
+// TestIssue1328 reproduces a data race in the metadata cache.
+//
+// Sequence of events:
+//   - The metadata loop calls fetchMetadata, which caches the broker
+//     response by storing a reference to topic.Partitions in metaCache.
+//   - fetchMetadata returns; fetchTopicMetadata then sort.Slice's the
+//     response's Partitions in place to validate strictly-increasing
+//     partition IDs.
+//   - Concurrently, a caller (kadm.Metadata => RequestCachedMetadata)
+//     reads the cached topic. resolveTopicMeta copies the cached entry
+//     under metaCache.mu, but the copy still shares the underlying
+//     Partitions slice. The caller then iterates that slice without the
+//     lock, racing the in-flight sort.
+//
+// The fix is to clone Partitions when storing into the cache so that
+// later mutations of the broker response do not touch the cached slice.
+func TestIssue1328(t *testing.T) {
+	t.Parallel()
+	const (
+		topic         = "test-topic"
+		numPartitions = 10
+	)
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(numPartitions, topic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ti := c.TopicInfo(topic)
+	host, portStr, _ := net.SplitHostPort(c.ListenAddrs()[0])
+	port, _ := strconv.Atoi(portStr)
+
+	// Build partitions in reverse order so sort.Slice in fetchTopicMetadata
+	// actually swaps elements -- already-sorted input sorts without writes,
+	// and without a write there is no race to detect.
+	c.ControlKey(int16(kmsg.Metadata), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+
+		resp := kreq.(*kmsg.MetadataRequest).ResponseKind().(*kmsg.MetadataResponse)
+		sb := kmsg.NewMetadataResponseBroker()
+		sb.NodeID = 0
+		sb.Host = host
+		sb.Port = int32(port)
+		resp.Brokers = append(resp.Brokers, sb)
+		resp.ControllerID = 0
+
+		st := kmsg.NewMetadataResponseTopic()
+		st.Topic = kmsg.StringPtr(topic)
+		st.TopicID = ti.TopicID
+		for p := int32(numPartitions - 1); p >= 0; p-- {
+			sp := kmsg.NewMetadataResponseTopicPartition()
+			sp.Partition = p
+			sp.Leader = -1
+			sp.Replicas = []int32{0}
+			sp.ISR = []int32{0}
+			st.Partitions = append(st.Partitions, sp)
+		}
+		resp.Topics = append(resp.Topics, st)
+		return resp, nil, true
+	})
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.MetadataMinAge(10*time.Millisecond),
+		kgo.MetadataMaxAge(50*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	adm := kadm.NewClient(cl)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				adm.Metadata(ctx, topic) //nolint:errcheck // best-effort racer
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			cl.ForceMetadataRefresh()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -222,6 +222,17 @@ func unknownSeedID(seedNum int) int32 {
 }
 
 func (cl *Client) newBroker(nodeID int32, host string, port int32, rack *string) *broker {
+	// Clone the Rack *string so the broker owns its own pointer. A
+	// user-issued cl.Request(MetadataRequest) is hijacked through
+	// fetchMetadata, which builds brokers from the response and then
+	// returns that same response to the user: a user writing *Rack
+	// through their response would race every internal deref of
+	// b.meta.Rack (brokerRacks, dups in RequestCachedMetadata,
+	// meta.equals on a later metadata update).
+	if rack != nil {
+		r := *rack
+		rack = &r
+	}
 	return &broker{
 		cl: cl,
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -100,7 +100,6 @@ type Client struct {
 		topics map[string]cachedMetaTopic
 		byID   map[[16]byte]string // TopicID => topic name
 		allAt  time.Time           // when last all-topics fetch completed
-		anyAt  time.Time           // when any cached metadata was last stored
 	}
 }
 
@@ -1106,7 +1105,15 @@ func (cl *Client) updateMetadataBrokers(resp *kmsg.MetadataResponse) {
 	if resp.ControllerID >= 0 {
 		cl.controllerID = resp.ControllerID
 	}
-	cl.clusterID = resp.ClusterID
+	// Clone ClusterID so cl.clusterID owns its own *string, independent
+	// of the broker response. Readers (dups in RequestCachedMetadata)
+	// would otherwise race a user mutating *resp.ClusterID on a
+	// previously-returned cl.Request(MetadataRequest) response.
+	cl.clusterID = nil
+	if resp.ClusterID != nil {
+		s := *resp.ClusterID
+		cl.clusterID = &s
+	}
 	cl.controllerIDMu.Unlock()
 	cl.updateBrokers(resp.Brokers)
 }
@@ -1511,7 +1518,7 @@ func (cl *Client) RequestCachedMetadata(ctx context.Context, req *kmsg.MetadataR
 			NodeID: b.meta.NodeID,
 			Host:   b.meta.Host,
 			Port:   b.meta.Port,
-			Rack:   b.meta.Rack,
+			Rack:   dups(b.meta.Rack),
 		})
 	}
 	cl.brokersMu.RUnlock()
@@ -3021,7 +3028,6 @@ func (cl *Client) storeCachedMeta(meta *kmsg.MetadataResponse, all bool, results
 		cl.metaCache.byID = make(map[[16]byte]string)
 	}
 	when := time.Now()
-	cl.metaCache.anyAt = when
 	var zeroID [16]byte
 	var stored int
 	for _, topic := range meta.Topics {
@@ -3031,22 +3037,43 @@ func (cl *Client) storeCachedMeta(meta *kmsg.MetadataResponse, all bool, results
 			continue
 		}
 		stored++
+		// Deep-clone the topic name, Partitions, and each partition's
+		// inner slices so the cache owns fully independent state. The
+		// broker response is shared with whoever consumed it:
+		// fetchTopicMetadata sort.Slice's the outer Partitions slice
+		// in place to validate ordering (issue #1328), and
+		// cl.Request(MetadataRequest) hands the response back to user
+		// code that may mutate the inner slices or write through the
+		// Topic *string. Without these clones, readers via
+		// RequestCachedMetadata or sharded request paths (which read
+		// ps[part].Replicas) would race those writers. dupt on the
+		// GET side clones separately: that isolates returned responses
+		// from the cache, this isolates the cache from the response.
+		topicName := *topic.Topic
+		topic.Topic = &topicName
+		topic.Partitions = slices.Clone(topic.Partitions)
+		for i := range topic.Partitions {
+			p := &topic.Partitions[i]
+			p.Replicas = slices.Clone(p.Replicas)
+			p.ISR = slices.Clone(p.ISR)
+			p.OfflineReplicas = slices.Clone(p.OfflineReplicas)
+		}
 		t := cachedMetaTopic{
 			id:   topic.TopicID,
 			t:    topic,
 			ps:   make(map[int32]kmsg.MetadataResponseTopicPartition),
 			when: when,
 		}
-		cl.metaCache.topics[*topic.Topic] = t
+		cl.metaCache.topics[topicName] = t
 		for _, partition := range topic.Partitions {
 			t.ps[partition.Partition] = partition
 		}
 		if topic.TopicID != zeroID {
-			cl.metaCache.byID[topic.TopicID] = *topic.Topic
+			cl.metaCache.byID[topic.TopicID] = topicName
 		}
 
 		if results != nil {
-			results[*t.t.Topic] = t
+			results[topicName] = t
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fixes the data race reported in #1328: `storeCachedMeta` cached slice and `*string` references from the broker response, so the in-place `sort.Slice(topicMeta.Partitions, ...)` in `fetchTopicMetadata` (metadata.go:710) raced concurrent readers iterating the cached entry via `kadm.Metadata` => `RequestCachedMetadata` (`dupt` at client.go:1493).
- Deep-clones on PUT so the cache owns fully independent state: `storeCachedMeta` clones `Topic *string`, `Partitions`, and each partition's `Replicas`/`ISR`/`OfflineReplicas`; `newBroker` clones `Rack *string`; `updateMetadataBrokers` clones `ClusterID *string`.
- Extends `dups(b.meta.Rack)` so the GET-side broker loop in `RequestCachedMetadata` is symmetric with the rest of `dupp`/`dupt`. `UnknownTags` is intentionally left shared - no idiomatic write path exists for it.

## Test plan

- [x] `TestIssue1328` in `pkg/kfake` reproduces the exact race the issue reports: without the fix, `-race` fires on `RequestCachedMetadata.func3` reading `t.Partitions` vs `sort.Slice` writing it.
- [x] With the fix applied, `TestIssue1328` passes 10x under `-race`.
- [x] `TestIssue1328`, `TestRequestCachedMetadata`, `TestKadmCachedMetadata`, `TestFirstMetadataPartitionErrors`, `TestIssue1142`, `TestIssue1167`: 3x under `-race`, all pass.
- [x] `go build`, `go vet`, `gofmt` clean across `pkg/kgo` and `pkg/kfake`.

Closes #1328