### PR TITLE
kgo: do not treat the -1 "no leader" sentinel as a leader-epoch rewind

### DIFF
--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -1810,6 +1810,181 @@ func TestFirstMetadataPartitionErrors(t *testing.T) {
 	}
 }
 
+// TestIssue1331 verifies that the leaderEpoch=-1 "no leader" sentinel is never
+// accepted as a partition's leader epoch, even when the leaderless window spans
+// more than maxEpochRewinds (5) metadata refreshes.
+//
+// When a partition briefly loses its leader (e.g. every replica restarts in a
+// full cluster bounce), the broker advertises leaderEpoch=-1. franz-go used to
+// treat -1 < oldEpoch as a leader-epoch rewind and count it toward the
+// maxEpochRewinds=5 valve; after 5 leaderless refreshes it would "keep the
+// metadata to allow forward progress" and accept -1 as the partition's epoch.
+// That clobbers the cursor's real epoch: a cursor at epoch -1 opts out of
+// KIP-320 fencing, so migrateCursorTo skips OffsetForLeaderEpoch validation (a
+// real truncation goes undetected) and the consumer fetches with
+// currentLeaderEpoch -1 (never fenced) and stalls. The client must instead keep
+// its last known real epoch and wait for a real leader to reappear.
+func TestIssue1331(t *testing.T) {
+	t.Parallel()
+	const (
+		testTopic = "foo"
+		nrecs     = 5
+	)
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ti := c.TopicInfo(testTopic)
+	pi := c.PartitionInfo(testTopic, 0)
+	host, portStr, _ := net.SplitHostPort(c.ListenAddrs()[0])
+	port, _ := strconv.Atoi(portStr)
+
+	// Produce a few records so the partition has a real, non-negative leader
+	// epoch for the consumer to consume and validate against.
+	func() {
+		cl, err := kgo.NewClient(
+			kgo.DefaultProduceTopic(testTopic),
+			kgo.SeedBrokers(c.ListenAddrs()...),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cl.Close()
+		for i := 0; i < nrecs; i++ {
+			if err := cl.ProduceSync(context.Background(), kgo.StringRecord(strconv.Itoa(i))).FirstErr(); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	// Once armed, every metadata refresh for our topic reports the partition
+	// as leaderless (leaderEpoch=-1) while keeping the leader reachable. We
+	// count the refreshes so we can wait until the leaderless window has
+	// clearly spanned past maxEpochRewinds (5).
+	var (
+		armed atomic.Bool
+		fires atomic.Int64
+	)
+	c.ControlKey(int16(kmsg.Metadata), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		if !armed.Load() {
+			return nil, nil, false
+		}
+		req := kreq.(*kmsg.MetadataRequest)
+		wants := len(req.Topics) == 0
+		for _, rt := range req.Topics {
+			if (rt.Topic != nil && *rt.Topic == testTopic) || rt.TopicID == ti.TopicID {
+				wants = true
+			}
+		}
+		if !wants {
+			return nil, nil, false
+		}
+		fires.Add(1)
+
+		resp := req.ResponseKind().(*kmsg.MetadataResponse)
+		sb := kmsg.NewMetadataResponseBroker()
+		sb.NodeID = pi.Leader
+		sb.Host = host
+		sb.Port = int32(port)
+		resp.Brokers = append(resp.Brokers, sb)
+		resp.ControllerID = pi.Leader
+
+		st := kmsg.NewMetadataResponseTopic()
+		st.Topic = kmsg.StringPtr(testTopic)
+		st.TopicID = ti.TopicID
+		sp := kmsg.NewMetadataResponseTopicPartition()
+		sp.Partition = 0
+		sp.Leader = pi.Leader
+		sp.LeaderEpoch = -1 // the "no leader" sentinel
+		sp.Replicas = []int32{pi.Leader}
+		sp.ISR = []int32{pi.Leader}
+		st.Partitions = append(st.Partitions, sp)
+		resp.Topics = append(resp.Topics, st)
+		return resp, nil, true
+	})
+
+	// Refresh metadata frequently so the leaderless window spans many
+	// refreshes quickly.
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.ConsumeTopics(testTopic),
+		kgo.MetadataMaxAge(100*time.Millisecond),
+		kgo.MetadataMinAge(20*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Consume the seeded records so the cursor has a real consumed epoch.
+	for consumed := 0; consumed < nrecs; {
+		fs := cl.PollFetches(ctx)
+		if errs := fs.Errors(); errs != nil {
+			t.Fatalf("consume error: %v", errs)
+		}
+		consumed += fs.NumRecords()
+	}
+
+	// Baseline: the client must have picked up a real (non-negative) leader
+	// epoch. A -1 here means kfake / the client are not using leader epochs,
+	// which would invalidate the test premise.
+	if _, epoch, err := cl.PartitionLeader(testTopic, 0); err != nil || epoch < 0 {
+		t.Fatalf("baseline PartitionLeader epoch = %d, err = %v; want a real non-negative epoch", epoch, err)
+	}
+
+	// Arm the leaderless window and wait until it spans well past
+	// maxEpochRewinds (5) refreshes.
+	armed.Store(true)
+	deadline := time.Now().Add(15 * time.Second)
+	for fires.Load() < 8 {
+		if time.Now().After(deadline) {
+			t.Fatalf("metadata only refreshed %d times under the -1 window, want >= 8", fires.Load())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The fix: -1 is never accepted, so the client keeps its real epoch.
+	// Before the fix, the epoch is clobbered to -1 once the valve trips on
+	// the 6th leaderless refresh.
+	if _, epoch, err := cl.PartitionLeader(testTopic, 0); err != nil || epoch < 0 {
+		t.Fatalf("during the leaderless window PartitionLeader epoch = %d, err = %v; want the real epoch kept (>= 0), not the -1 no-leader sentinel", epoch, err)
+	}
+
+	// Disarm and verify the consumer still makes forward progress: newly
+	// produced records are consumed once a real leader epoch is reported again.
+	armed.Store(false)
+	prod, err := kgo.NewClient(
+		kgo.DefaultProduceTopic(testTopic),
+		kgo.SeedBrokers(c.ListenAddrs()...),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prod.Close()
+	for i := 0; i < nrecs; i++ {
+		if err := prod.ProduceSync(ctx, kgo.StringRecord("after-"+strconv.Itoa(i))).FirstErr(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for consumed := 0; consumed < nrecs; {
+		fs := cl.PollFetches(ctx)
+		if errs := fs.Errors(); errs != nil {
+			t.Fatalf("post-window consume error: %v", errs)
+		}
+		consumed += fs.NumRecords()
+	}
+}
+
 func TestRequestCachedMetadata(t *testing.T) {
 	t.Parallel()
 	c, err := NewCluster(

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -895,11 +895,47 @@ func (cl *Client) mergeTopicPartitions(
 		// fetched from an out of date broker. We just keep the old
 		// information.
 		if newTP.leaderEpoch < oldTP.leaderEpoch {
-			// If we repeatedly rewind, then perhaps the cluster
-			// entered some bad state and lost forward progress.
-			// We will log & allow the rewind to allow the client
-			// to continue; other requests may encounter fenced
-			// epoch errors (and respectively recover).
+			// A negative leader epoch is the "no leader" sentinel
+			// (Kafka uses -1): the partition is momentarily
+			// leaderless, e.g. mid-election after every replica
+			// restarted in a full cluster bounce. This is not a
+			// genuinely older epoch, so we must not treat it as a
+			// rewind. If we counted it toward maxEpochRewinds, then
+			// after enough leaderless refreshes we would fall through
+			// below and accept -1 as the partition's leader epoch --
+			// which is unsafe. A cursor at leader epoch -1 opts out of
+			// KIP-320 fencing: migrateCursorTo skips
+			// OffsetForLeaderEpoch validation for a negative new epoch,
+			// so a genuine log truncation during the leaderless window
+			// would go undetected (no ErrDataLoss), and the consumer
+			// would then fetch at a stale offset with currentLeaderEpoch
+			// -1 (which brokers never fence) and stall at the high
+			// watermark. Instead we keep our last known real leader and
+			// epoch and signal a retry; once a real epoch (>= old)
+			// reappears, normal validation runs and detects any
+			// truncation.
+			if newTP.leaderEpoch < 0 {
+				cl.cfg.logger.Log(LogLevelDebug, "metadata has a leader epoch of -1 (no leader); keeping our last known leader and epoch until a leader is elected",
+					"topic", topic,
+					"partition", part,
+					"old_leader_epoch", oldTP.leaderEpoch,
+				)
+				*newTP = *oldTP
+				retryWhy.add(topic, int32(part), errNoLeaderEpoch)
+				continue
+			}
+
+			// Otherwise newTP.leaderEpoch is a real (>= 0) epoch that
+			// is merely lower than ours. That can be the current
+			// reality: issue #119 saw an unclean leader election
+			// briefly surface a higher epoch from a broker that then
+			// died, leaving the surviving cluster on a real, lower
+			// epoch. Permanently refusing it stranded the client in an
+			// unrecoverable metadata loop, so if we repeatedly rewind we
+			// accept it to allow the client to continue. Unlike the -1
+			// sentinel handled above, a real lower epoch self-corrects
+			// downstream: consume sees FENCED_LEADER_EPOCH (and reports
+			// data loss) and produce sees NOT_LEADER_FOR_PARTITION.
 			//
 			// Five is a pretty low amount of retries, but since
 			// we iterate through known brokers, this basically
@@ -1048,6 +1084,7 @@ func (cl *Client) mergeTopicPartitions(
 var (
 	errEpochRewind    = errors.New("epoch rewind")
 	errMissingTopicID = errors.New("missing topic ID")
+	errNoLeaderEpoch  = errors.New("no leader epoch")
 )
 
 type multiUpdateWhy map[kerrOrString]map[string]map[int32]struct{}

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -657,9 +657,13 @@ func (old *topicPartition) migrateCursorTo( //nolint:revive // old/new naming ma
 	// leader epoch on the new broker to see if we experienced data loss
 	// before we can use this cursor.
 	//
-	// Metadata ensures that leaderEpoch is non-negative only if the broker
-	// supports KIP-320.
-	if new.leaderEpoch != -1 && old.cursor.lastConsumedEpoch >= 0 {
+	// We can only validate against a real (non-negative) leader epoch.
+	// Metadata reports a non-negative epoch only if the broker supports
+	// KIP-320, and the metadata merge keeps our last known real epoch
+	// rather than ever migrating us to the -1 "no leader" sentinel (see
+	// mergeTopicPartitions), so a negative epoch here means we genuinely
+	// have nothing to validate against and must skip validation.
+	if new.leaderEpoch >= 0 && old.cursor.lastConsumedEpoch >= 0 {
 		// Since the cursor consumed messages, it is definitely usable.
 		// We use it so that the epoch load can finish using it
 		// properly.


### PR DESCRIPTION
## Summary

When a partition briefly loses its leader (e.g. every replica restarts in a full cluster bounce), the broker advertises `leaderEpoch=-1`. `mergeTopicPartitions` treated `-1 < oldEpoch` as a leader-epoch rewind and counted it toward `maxEpochRewinds=5`; after five leaderless refreshes it **accepted `-1`** as the partition's epoch.

Accepting `-1` is unsafe:

- **Skips KIP-320 truncation detection.** `migrateCursorTo` only validates via `OffsetForLeaderEpoch` when the new epoch is non-negative, so a real log truncation during the leaderless window goes undetected (no `ErrDataLoss`).
- **Stalls the consumer.** A fetch with `currentLeaderEpoch=-1` opts out of fencing (brokers never return `FENCED_LEADER_EPOCH`), so the cursor sits at a stale offset / the high watermark and never recovers.

## Why `maxEpochRewinds` doesn't cover this

The valve was added in 12eaa1e4 for #119: an unclean leader election briefly surfaced a higher epoch from a broker that then died, leaving the surviving cluster on a **real, lower** epoch the client must eventually accept to escape an unrecoverable metadata loop. That is safe because a real epoch self-corrects downstream (`FENCED_LEADER_EPOCH` on consume, `NOT_LEADER_FOR_PARTITION` on produce). The `-1` sentinel has no such re-validation, so the reasoning never applied to it.

## Fix

- **`metadata.go`** — a negative (`< 0`) "no leader" epoch is kept as "no information": retain the last known real leader/epoch, signal a retry, and never count it toward `maxEpochRewinds` nor accept `-1`. The genuine real-but-lower rewind path (#119) is unchanged.
- **`topics_and_partitions.go`** — tightened `migrateCursorTo`'s validation guard from `!= -1` to `>= 0` to match its "non-negative" contract.

This matches the Kafka Java client, which maps a `-1` wire epoch to `Optional.empty()` and never compares it as an older epoch.

## Test

`TestIssue1331` (kfake) produces+consumes (establishing a real epoch 0), arms a Metadata control reporting `leaderEpoch=-1` across 8+ refreshes (past the 5-valve), and asserts the client keeps its real epoch instead of clobbering to `-1`, then confirms forward progress after recovery. Verified it **fails without the fix** (`PartitionLeader epoch = -1`) and **passes with it**, under `-race`.

Closes #1331.
