### PR TITLE
kgo,kfake: route share group offset RPCs to the group coordinator

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -651,8 +651,10 @@ Redelivery       Only on consumer failure +   Automatic when the broker's
                  rebalance.                   acquisition lock expires.
 Order            In-partition order.          Best-effort; release re-queues.
 RPCs             Fetch / OffsetCommit.        ShareFetch / ShareAcknowledge,
-                                              both keyed off the share group
-                                              coordinator (`coordinatorTypeShare`).
+                                              sent to partition leaders like
+                                              Fetch (not to a coordinator); the
+                                              broker tracks per-record state
+                                              via the share-state coordinator.
 Group protocol   Classic or KIP-848.          ShareGroupHeartbeat (KIP-932),
                                               same shape as 848.
 ```

--- a/pkg/kfake/10_find_coordinator.go
+++ b/pkg/kfake/10_find_coordinator.go
@@ -1,6 +1,9 @@
 package kfake
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
@@ -83,10 +86,41 @@ func (c *Cluster) handleFindCoordinator(creq *clientReq) (kmsg.Response, error) 
 			continue
 		}
 
+		// Share keys must be groupId:topicId:partition; the real broker
+		// validates this and rejects e.g. a bare group id (#1330).
+		if req.CoordinatorType == 2 && !validShareCoordinatorKey(key) {
+			sc.ErrorCode = kerr.InvalidRequest.Code
+			continue
+		}
+
 		b := c.coordinator(key)
 		sc.NodeID = b.node
 		sc.Host, sc.Port = b.hostport()
 	}
 
 	return resp, nil
+}
+
+// validShareCoordinatorKey reports whether key is a groupId:topicId:partition
+// SharePartitionKey, mirroring SharePartitionKey.getInstance: split on ":", the
+// last token is an integer partition, the prior is the topic id, the rest a
+// non-empty group id. We do not decode the topic-id UUID.
+func validShareCoordinatorKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	tokens := strings.Split(key, ":")
+	if len(tokens) < 3 {
+		return false
+	}
+	if strings.TrimSpace(strings.Join(tokens[:len(tokens)-2], ":")) == "" {
+		return false
+	}
+	if tokens[len(tokens)-2] == "" {
+		return false
+	}
+	if _, err := strconv.Atoi(tokens[len(tokens)-1]); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/kfake/90_describe_share_group_offsets.go
+++ b/pkg/kfake/90_describe_share_group_offsets.go
@@ -37,8 +37,6 @@ func (c *Cluster) handleDescribeShareGroupOffsets(creq *clientReq) (kmsg.Respons
 		rsg := kmsg.NewDescribeShareGroupOffsetsResponseGroup()
 		rsg.GroupID = rg.GroupID
 
-		// Coordinator check: DescribeShareGroupOffsets is routed to
-		// the share coordinator.
 		if c.coordinator(rg.GroupID).node != creq.cc.b.node {
 			rsg.ErrorCode = kerr.NotCoordinator.Code
 			resp.Groups = append(resp.Groups, rsg)

--- a/pkg/kfake/91_alter_share_group_offsets.go
+++ b/pkg/kfake/91_alter_share_group_offsets.go
@@ -25,8 +25,6 @@ func (c *Cluster) handleAlterShareGroupOffsets(creq *clientReq) (kmsg.Response, 
 		return nil, err
 	}
 
-	// Coordinator check: AlterShareGroupOffsets is routed to the
-	// share coordinator.
 	if c.coordinator(req.GroupID).node != creq.cc.b.node {
 		resp.ErrorCode = kerr.NotCoordinator.Code
 		return resp, nil

--- a/pkg/kfake/92_delete_share_group_offsets.go
+++ b/pkg/kfake/92_delete_share_group_offsets.go
@@ -25,8 +25,6 @@ func (c *Cluster) handleDeleteShareGroupOffsets(creq *clientReq) (kmsg.Response,
 		return nil, err
 	}
 
-	// Coordinator check: DeleteShareGroupOffsets is routed to the
-	// share coordinator.
 	if c.coordinator(req.GroupID).node != creq.cc.b.node {
 		resp.ErrorCode = kerr.NotCoordinator.Code
 		return resp, nil

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2978,3 +2978,57 @@ func TestDescribeTopicPartitionsCursor(t *testing.T) {
 		t.Fatal("expected error for cursor topic not in request list, got nil")
 	}
 }
+
+// TestIssue1330 verifies the share-state coordinator (FindCoordinator type 2)
+// rejects keys that are not groupId:topicId:partition triplets with
+// INVALID_REQUEST, matching the real broker. kfake previously accepted any key,
+// so the #1330 mis-routing passed every kfake test yet failed a real broker.
+func TestIssue1330(t *testing.T) {
+	t.Parallel()
+	c := newCluster(t)
+	cl := newPlainClient(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const (
+		bareKey  = "hello-share"                          // a bare group id, as the #1330 bug sent
+		validKey = "hello-share:nT3i4OXyR0mr0my1RZx9pQ:0" // groupId:topicId:partition
+	)
+
+	req := kmsg.NewPtrFindCoordinatorRequest()
+	req.CoordinatorType = 2 // share
+	req.CoordinatorKeys = []string{bareKey, validKey}
+	resp, err := req.RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatalf("FindCoordinator: %v", err)
+	}
+	if len(resp.Coordinators) != 2 {
+		t.Fatalf("expected 2 coordinators, got %d", len(resp.Coordinators))
+	}
+
+	got := make(map[string]kmsg.FindCoordinatorResponseCoordinator, 2)
+	for _, co := range resp.Coordinators {
+		got[co.Key] = co
+	}
+
+	// The bare group id is not a valid SharePartitionKey -> INVALID_REQUEST.
+	if co, ok := got[bareKey]; !ok {
+		t.Errorf("missing coordinator entry for %q", bareKey)
+	} else if co.ErrorCode != kerr.InvalidRequest.Code {
+		t.Errorf("bare group id: got error code %d (%v), want INVALID_REQUEST",
+			co.ErrorCode, kerr.ErrorForCode(co.ErrorCode))
+	}
+
+	// A well-formed SharePartitionKey resolves to a real broker.
+	if co, ok := got[validKey]; !ok {
+		t.Errorf("missing coordinator entry for %q", validKey)
+	} else {
+		if err := kerr.ErrorForCode(co.ErrorCode); err != nil {
+			t.Errorf("valid SharePartitionKey: unexpected error %v", err)
+		}
+		if co.NodeID < 0 {
+			t.Errorf("valid SharePartitionKey: got NodeID %d, want a real broker node", co.NodeID)
+		}
+	}
+}

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -1897,6 +1897,11 @@ func (cl *Client) forgetControllerID(id int32) {
 	}
 }
 
+// Coordinator types match Kafka's FindCoordinator key-type enum.
+// coordinatorTypeShare (the share-state coordinator) is keyed by a
+// groupId:topicId:partition SharePartitionKey and serves only the
+// broker-internal persister RPCs (keys 83-87), which kgo never issues; share
+// groups go entirely through the GROUP coordinator (see #1330).
 const (
 	coordinatorTypeGroup int8 = 0
 	coordinatorTypeTxn   int8 = 1
@@ -2309,9 +2314,9 @@ func (cl *Client) handleCoordinatorReq(ctx context.Context, req kmsg.Request) Re
 		}
 		return shard(br, req, resp, err)
 	case *kmsg.AlterShareGroupOffsetsRequest:
-		return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeShare, t.GroupID, req)
+		return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeGroup, t.GroupID, req)
 	case *kmsg.DeleteShareGroupOffsetsRequest:
-		return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeShare, t.GroupID, req)
+		return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeGroup, t.GroupID, req)
 	}
 }
 
@@ -5450,7 +5455,7 @@ func (cl *describeShareGroupOffsetsSharder) shard(ctx context.Context, kreq kmsg
 	for _, g := range req.Groups {
 		groupIDs = append(groupIDs, g.GroupID)
 	}
-	coordinators := cl.loadCoordinators(ctx, coordinatorTypeShare, groupIDs...)
+	coordinators := cl.loadCoordinators(ctx, coordinatorTypeGroup, groupIDs...)
 	type unkerr struct {
 		err     error
 		groupID string
@@ -5510,7 +5515,7 @@ func (cl *describeShareGroupOffsetsSharder) onResp(_ kmsg.Request, kresp kmsg.Re
 	for i := range resp.Groups {
 		group := &resp.Groups[i]
 		err := kerr.ErrorForCode(group.ErrorCode)
-		cl.maybeDeleteStaleCoordinator(group.GroupID, coordinatorTypeShare, err)
+		cl.maybeDeleteStaleCoordinator(group.GroupID, coordinatorTypeGroup, err)
 		onRespShardErr(&retErr, err)
 	}
 	return retErr

--- a/pkg/kgo/consumer_share.go
+++ b/pkg/kgo/consumer_share.go
@@ -969,9 +969,12 @@ func (sc *shareConsumer) manage() {
 			consecutiveErrors = 0
 			continue
 
+		// Evict with coordinatorTypeGroup to match how the heartbeat loads it:
+		// the cache is keyed by {name, type}, so a share-typed evict never
+		// matches and we would retry the stale coordinator forever (#1330).
 		case isRetryableBrokerErr(err),
 			isAnyDialErr(err),
-			sc.cl.maybeDeleteStaleCoordinator(sc.cfg.shareGroup, coordinatorTypeShare, err):
+			sc.cl.maybeDeleteStaleCoordinator(sc.cfg.shareGroup, coordinatorTypeGroup, err):
 			// Retryable -- fall through to shared backoff below.
 
 		default:

--- a/pkg/kgo/share_test.go
+++ b/pkg/kgo/share_test.go
@@ -825,6 +825,156 @@ func TestShareGroupAckOnClose(t *testing.T) {
 	}
 }
 
+// TestShareGroupOffsetsAdmin is the real-broker regression test for #1330: it
+// exercises Alter/Describe/DeleteShareGroupOffsets, which kgo had routed via a
+// SHARE-typed FindCoordinator (rejected with INVALID_REQUEST, since SHARE keys
+// must be groupId:topicId:partition) instead of the group coordinator.
+//
+// No consumer runs, so the group stays empty (required to alter/delete offsets);
+// altering a fresh group creates the share state we then describe and delete.
+func TestShareGroupOffsetsAdmin(t *testing.T) {
+	t.Parallel()
+	adm() // ensure allowShare is initialized
+	if !allowShare {
+		t.Skip("broker does not support share groups (requires ShareFetch v2 and ShareAcknowledge v2, Kafka 4.2+)")
+	}
+
+	const (
+		nrecs   = 20
+		setSPSO = 8 // strictly within (0, nrecs) so the round-trip is unambiguous
+	)
+
+	topic, topicCleanup := tmpTopicPartitions(t, 1)
+	defer topicCleanup()
+	group, groupCleanup := tmpShareGroup(t)
+	defer groupCleanup()
+
+	cl, err := newTestClient(DefaultProduceTopic(topic), UnknownTopicRetries(-1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Produce nrecs records to the single partition so its HWM is nrecs and an
+	// SPSO of setSPSO is a real, in-range offset.
+	for i := range nrecs {
+		cl.Produce(ctx, StringRecord(strconv.Itoa(i)), func(_ *Record, err error) {
+			if err != nil {
+				t.Errorf("produce: %v", err)
+			}
+		})
+	}
+	if err := cl.Flush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// AlterShareGroupOffsets: create the (empty) group's share state and set
+	// its SPSO. Pre-#1330 this failed with INVALID_REQUEST at FindCoordinator.
+	{
+		req := kmsg.NewPtrAlterShareGroupOffsetsRequest()
+		req.GroupID = group
+		rt := kmsg.NewAlterShareGroupOffsetsRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewAlterShareGroupOffsetsRequestTopicPartition()
+		rp.Partition = 0
+		rp.StartOffset = setSPSO
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+
+		resp, err := req.RequestWith(ctx, cl)
+		if err != nil {
+			t.Fatalf("AlterShareGroupOffsets: %v", err)
+		}
+		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+			t.Fatalf("AlterShareGroupOffsets group error: %v", err)
+		}
+		if len(resp.Topics) != 1 || len(resp.Topics[0].Partitions) != 1 {
+			t.Fatalf("AlterShareGroupOffsets: unexpected response shape %+v", resp.Topics)
+		}
+		if err := kerr.ErrorForCode(resp.Topics[0].Partitions[0].ErrorCode); err != nil {
+			t.Fatalf("AlterShareGroupOffsets partition error: %v", err)
+		}
+	}
+
+	// describeStartOffset returns the SPSO for topic/partition 0. allTopics=true
+	// sends nil Topics (the "all partitions" path kadm uses); both paths must
+	// route to the group coordinator and report the altered offset.
+	describeStartOffset := func(allTopics bool) int64 {
+		t.Helper()
+		req := kmsg.NewPtrDescribeShareGroupOffsetsRequest()
+		rg := kmsg.NewDescribeShareGroupOffsetsRequestGroup()
+		rg.GroupID = group
+		if !allTopics {
+			rt := kmsg.NewDescribeShareGroupOffsetsRequestGroupTopic()
+			rt.Topic = topic
+			rt.Partitions = []int32{0}
+			rg.Topics = append(rg.Topics, rt)
+		}
+		req.Groups = append(req.Groups, rg)
+
+		resp, err := req.RequestWith(ctx, cl)
+		if err != nil {
+			t.Fatalf("DescribeShareGroupOffsets(all=%v): %v", allTopics, err)
+		}
+		if len(resp.Groups) != 1 {
+			t.Fatalf("DescribeShareGroupOffsets(all=%v): expected 1 group, got %d", allTopics, len(resp.Groups))
+		}
+		g := resp.Groups[0]
+		if err := kerr.ErrorForCode(g.ErrorCode); err != nil {
+			t.Fatalf("DescribeShareGroupOffsets(all=%v) group error: %v", allTopics, err)
+		}
+		for _, rt := range g.Topics {
+			if rt.Topic != topic {
+				continue
+			}
+			for _, rp := range rt.Partitions {
+				if rp.Partition != 0 {
+					continue
+				}
+				if err := kerr.ErrorForCode(rp.ErrorCode); err != nil {
+					t.Fatalf("DescribeShareGroupOffsets(all=%v) partition error: %v", allTopics, err)
+				}
+				return rp.StartOffset
+			}
+		}
+		t.Fatalf("DescribeShareGroupOffsets(all=%v): topic %s partition 0 not in response", allTopics, topic)
+		return 0
+	}
+
+	if got := describeStartOffset(false); got != setSPSO {
+		t.Errorf("describe (explicit topic): StartOffset = %d, want %d", got, setSPSO)
+	}
+	if got := describeStartOffset(true); got != setSPSO {
+		t.Errorf("describe (all topics): StartOffset = %d, want %d", got, setSPSO)
+	}
+
+	// DeleteShareGroupOffsets: remove the topic's share state. Same routing
+	// path as the above, so pre-#1330 it also failed with INVALID_REQUEST.
+	{
+		req := kmsg.NewPtrDeleteShareGroupOffsetsRequest()
+		req.GroupID = group
+		rt := kmsg.NewDeleteShareGroupOffsetsRequestTopic()
+		rt.Topic = topic
+		req.Topics = append(req.Topics, rt)
+
+		resp, err := req.RequestWith(ctx, cl)
+		if err != nil {
+			t.Fatalf("DeleteShareGroupOffsets: %v", err)
+		}
+		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+			t.Fatalf("DeleteShareGroupOffsets group error: %v", err)
+		}
+		for _, rt := range resp.Topics {
+			if err := kerr.ErrorForCode(rt.ErrorCode); err != nil {
+				t.Errorf("DeleteShareGroupOffsets topic %s error: %v", rt.Topic, err)
+			}
+		}
+	}
+}
+
 // setShareGroupConfigs applies one or more share-group configs in a
 // single IncrementalAlterConfigs call on the GROUP resource, then
 // polls DescribeConfigs until the broker's DynamicConfigPublisher has


### PR DESCRIPTION
`DescribeShareGroupOffsets`, `AlterShareGroupOffsets`, and `DeleteShareGroupOffsets` (KIP-932) returned `INVALID_REQUEST` against Kafka 4.2 because kgo routed them through a `FindCoordinator` of type `SHARE`. The broker only accepts SHARE-typed coordinator keys that are `groupId:topicId:partition` `SharePartitionKey` triplets (and requires `CLUSTER_ACTION`) -- that coordinator exists only for the broker-internal persister RPCs (`{Initialize,Read,Write,Delete}ShareGroupState`, `ReadShareGroupStateSummary`; keys 83-87). A bare group id was rejected during `FindCoordinator`, before the request reached any coordinator.

These RPCs are served by the **group** coordinator: the broker hands them to `groupCoordinator.{describe,alter,delete}ShareGroupOffsets`, and the Java AdminClient looks them up with `CoordinatorType.GROUP`. kgo already routed `ShareGroupHeartbeat`/`ShareGroupDescribe` to the group coordinator; the offset RPCs now match.

## Also in here
- Fix the share-group heartbeat's stale-coordinator eviction: it passed `coordinatorTypeShare` while the heartbeat loads the coordinator as `coordinatorTypeGroup`. The coordinator cache is keyed by `{name, type}`, so the eviction never matched and a moved coordinator would be retried forever.
- kfake's `FindCoordinator` accepted any SHARE key, which is why this mis-routing passed every kfake test yet failed a real broker. It now validates SHARE keys like the broker's `SharePartitionKey`.
- DESIGN.md: correct the note claiming `ShareFetch`/`ShareAcknowledge` are keyed off a coordinator -- they go to partition leaders.

## Tests
- kfake `TestIssue1330`: a SHARE `FindCoordinator` rejects a bare group id with `INVALID_REQUEST` and accepts a valid triplet.
- kgo `TestShareGroupOffsetsAdmin`: real-broker round-trip of all three RPCs (alter the SPSO on a fresh group, describe via the explicit-topic and all-topics paths, delete).

Closes #1330
