### PR TITLE
kgo: add RebootstrapTrigger for timeout-based rebootstrap (KIP-1102)

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -319,6 +319,8 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.missingTopicDelete}
 	case namefn(OnRebootstrapRequired):
 		return []any{cfg.onRebootstrapRequired}
+	case namefn(RebootstrapTrigger):
+		return []any{cfg.rebootstrapTrigger}
 	case namefn(WithContext):
 		return []any{cfg.ctx}
 	case namefn(DisableClientMetrics):

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -93,6 +93,7 @@ type cfg struct {
 	minVersions *kversion.Versions
 
 	onRebootstrapRequired func() ([]string, error)
+	rebootstrapTrigger    time.Duration
 
 	retryBackoff func(int) time.Duration
 	retries      int64
@@ -1008,6 +1009,29 @@ func ConsiderMissingTopicDeletedAfter(t time.Duration) Opt {
 // You can read KIP-1102 for more info about this option.
 func OnRebootstrapRequired(fn func() ([]string, error)) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.onRebootstrapRequired = fn }}
+}
+
+// RebootstrapTrigger sets a duration after which, if the client has been unable
+// to obtain a successful metadata response for that long, the client
+// rebootstraps using its seed brokers (re-resolving them) and reconnects. A
+// value of 0 (the default) disables timeout based rebootstrapping.
+//
+// This is the timeout based rebootstrap trigger described in KIP-1102, the
+// counterpart to the error code trigger handled by [OnRebootstrapRequired].
+// Whereas the error code trigger relies on the broker returning
+// REBOOTSTRAP_REQUIRED, this trigger lets the client rebootstrap on its own
+// when its currently known brokers all become unreachable, mirroring the Java
+// client's metadata.recovery.rebootstrap.trigger.ms.
+//
+// Note that franz-go already periodically queries a seed broker to recover from
+// the scenario where all previously discovered brokers are unavailable, so this
+// option is primarily useful when you want a bounded, configurable window after
+// which a full rebootstrap (including re-resolving seed broker addresses, e.g.
+// for DNS based failover) is forced. If [OnRebootstrapRequired] is set, it is
+// consulted for the seeds to use; otherwise the originally configured
+// [SeedBrokers] are re-resolved.
+func RebootstrapTrigger(d time.Duration) Opt {
+	return clientOpt{func(cfg *cfg) { cfg.rebootstrapTrigger = d }}
 }
 
 // DisableClientMetrics opts out of collecting and sending client metrics to

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -187,6 +187,7 @@ func (cl *Client) updateMetadataLoop() {
 	defer close(cl.metadone)
 	var consecutiveErrors int
 	var lastAt time.Time
+	lastSuccess := time.Now()
 
 	ticker := time.NewTicker(cl.cfg.metadataMaxAge)
 	defer ticker.Stop()
@@ -289,10 +290,25 @@ loop:
 			cl.metawait.signal()
 			cl.consumer.doOnMetadataUpdate()
 			consecutiveErrors = 0
+			lastSuccess = time.Now()
 			continue
 		}
 
 		consecutiveErrors++
+		// KIP-1102 timeout based rebootstrap: if we have been unable to obtain
+		// a successful metadata response for longer than the configured
+		// trigger, rebootstrap from our seed brokers (re-resolving their
+		// addresses) and reconnect.
+		if cl.cfg.rebootstrapTrigger > 0 && time.Since(lastSuccess) >= cl.cfg.rebootstrapTrigger {
+			if rerr := cl.rebootstrap(); rerr != nil {
+				cl.cfg.logger.Log(LogLevelWarn, "rebootstrap trigger fired but rebootstrapping failed", "err", rerr)
+			} else {
+				cl.cfg.logger.Log(LogLevelInfo, "rebootstrapped from seed brokers after metadata was unavailable for longer than the rebootstrap trigger", "trigger", cl.cfg.rebootstrapTrigger)
+			}
+			// Reset regardless of outcome so we wait another full trigger
+			// interval before attempting to rebootstrap again.
+			lastSuccess = time.Now()
+		}
 		// We sleep a bit in case the max metadata age is very small;
 		// typically this sleep is inconsequential.
 		after := time.NewTimer(cl.cfg.retryBackoff(consecutiveErrors))
@@ -307,6 +323,30 @@ loop:
 			goto backoff
 		}
 	}
+}
+
+// rebootstrap re-bootstraps the client from its seed brokers, re-resolving
+// their addresses and dropping current seed connections. If OnRebootstrapRequired
+// is configured it is consulted for the seeds to use, otherwise the originally
+// configured seed brokers are reused. This backs the RebootstrapTrigger timeout
+// trigger from KIP-1102 (the error code trigger is handled inline in
+// fetchMetadata).
+func (cl *Client) rebootstrap() error {
+	seeds := cl.cfg.seedBrokers
+	if cl.cfg.onRebootstrapRequired != nil {
+		s, err := cl.cfg.onRebootstrapRequired()
+		if err != nil {
+			return err
+		}
+		if len(s) > 0 {
+			seeds = s
+		}
+	}
+	if err := cl.UpdateSeedBrokers(seeds...); err != nil {
+		return err
+	}
+	cl.updateBrokers(nil)
+	return nil
 }
 
 var errMissingTopic = errors.New("topic_missing")

--- a/pkg/kgo/rebootstrap_test.go
+++ b/pkg/kgo/rebootstrap_test.go
@@ -1,0 +1,93 @@
+package kgo
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRebootstrapTriggerOption verifies the RebootstrapTrigger option is wired
+// into the client config.
+func TestRebootstrapTriggerOption(t *testing.T) {
+	t.Parallel()
+
+	cl, err := NewClient(
+		SeedBrokers("127.0.0.1:9092"),
+		RebootstrapTrigger(42*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("unable to create client: %v", err)
+	}
+	defer cl.Close()
+
+	if got := cl.cfg.rebootstrapTrigger; got != 42*time.Second {
+		t.Errorf("rebootstrapTrigger = %v, want %v", got, 42*time.Second)
+	}
+}
+
+// TestRebootstrapUsesOnRebootstrapRequiredSeeds verifies that, when a callback
+// is configured, rebootstrap re-seeds the client with the addresses it returns.
+func TestRebootstrapUsesOnRebootstrapRequiredSeeds(t *testing.T) {
+	t.Parallel()
+
+	cl, err := NewClient(
+		SeedBrokers("127.0.0.1:9092"),
+		OnRebootstrapRequired(func() ([]string, error) {
+			return []string{"127.0.0.10:9092", "127.0.0.11:9092"}, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unable to create client: %v", err)
+	}
+	defer cl.Close()
+
+	if err := cl.rebootstrap(); err != nil {
+		t.Fatalf("rebootstrap: %v", err)
+	}
+
+	got := seedHosts(cl)
+	want := []string{"127.0.0.10", "127.0.0.11"}
+	if len(got) != len(want) {
+		t.Fatalf("after rebootstrap got %d seeds (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("seed %d host = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestRebootstrapReusesConfiguredSeeds verifies that, with no callback,
+// rebootstrap re-resolves the originally configured seed brokers.
+func TestRebootstrapReusesConfiguredSeeds(t *testing.T) {
+	t.Parallel()
+
+	cl, err := NewClient(SeedBrokers("127.0.0.1:9092", "127.0.0.2:9092"))
+	if err != nil {
+		t.Fatalf("unable to create client: %v", err)
+	}
+	defer cl.Close()
+
+	if err := cl.rebootstrap(); err != nil {
+		t.Fatalf("rebootstrap: %v", err)
+	}
+
+	got := seedHosts(cl)
+	want := []string{"127.0.0.1", "127.0.0.2"}
+	if len(got) != len(want) {
+		t.Fatalf("after rebootstrap got %d seeds (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("seed %d host = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func seedHosts(cl *Client) []string {
+	seeds := cl.loadSeeds()
+	hosts := make([]string, len(seeds))
+	for i, s := range seeds {
+		hosts[i] = s.meta.Host
+	}
+	return hosts
+}


### PR DESCRIPTION
## Summary

Adds `RebootstrapTrigger(d time.Duration)`, the **timeout-based** rebootstrap trigger described in [KIP-1102](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1102%3A+Enable+clients+to+rebootstrap+based+on+timeout+or+error+code).

franz-go already implements the KIP-1102 **error-code** trigger via `OnRebootstrapRequired` (acting on `REBOOTSTRAP_REQUIRED`). KIP-1102 defines a second trigger — a timeout — which is the Java client's `metadata.recovery.rebootstrap.trigger.ms`. This PR adds that counterpart.

## Behavior

`RebootstrapTrigger(d)` sets a duration after which, if the client has been unable to obtain a **successful metadata response** for that long, it rebootstraps from its seed brokers (re-resolving their addresses) and reconnects.

- `0` (default) disables the behavior — existing clients are unaffected.
- If `OnRebootstrapRequired` is set, it is consulted for the seeds to use; otherwise the originally configured `SeedBrokers` are re-resolved (useful for DNS-based failover, where the seed addresses repoint to a different cluster).

I kept the option opt-in (default off) rather than mirroring the Java default of 5m, since franz-go already periodically queries a seed broker to recover from the "all known brokers down" case — so this is additive and non-behavior-changing unless explicitly enabled. Happy to change the default if you'd prefer KIP parity.

## Implementation

- `config.go`: new `rebootstrapTrigger` cfg field + `RebootstrapTrigger` option.
- `client.go`: `OptValues` case for the new option.
- `metadata.go`: `updateMetadataLoop` tracks the time of the last successful update; on continued failure past the trigger it calls a new `rebootstrap()` helper, then resets the window. The helper selects seeds (callback vs. configured), calls `UpdateSeedBrokers`, and drops current connections via `updateBrokers(nil)` — the same primitives the error-code path already uses.

## Tests

`rebootstrap_test.go` (no cluster required):
- option wiring (`RebootstrapTrigger` → cfg)
- `rebootstrap()` re-seeds from `OnRebootstrapRequired` when set
- `rebootstrap()` re-resolves the configured `SeedBrokers` when no callback is set

`go build ./...`, `go vet ./pkg/kgo/`, and `go test -run TestRebootstrap ./pkg/kgo/` all pass.

## Notes / open questions

- I left `CHANGELOG.md` untouched — happy to add an entry under your preferred section.
- The timeout trigger reuses `OnRebootstrapRequired` for seed selection when present, which means that callback can now also fire on the timeout path (not just `REBOOTSTRAP_REQUIRED`). I think that's the desirable single-source behavior, but I can split them if you'd rather keep the callback strictly tied to the error code.
- Motivation: enabling seamless failover between Redpanda shadow/primary clusters in Redpanda Connect, where the broker may not always emit `REBOOTSTRAP_REQUIRED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
