### PR TITLE
kgo: re-resolve topic ID when a known topic's ID changes (recover from UNKNOWN_TOPIC_ID loop)

### DIFF
--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -431,12 +431,27 @@ func (cl *Client) updateMetadata() (retryWhy multiUpdateWhy, err error) {
 			}
 			if _, exists := knownNames[mt.topic]; exists {
 				// This name already has an ID in the map.
-				// Only update if it's the same ID (normal
-				// case), skip if it's a different ID
-				// (recreated topic).
 				if _, sameID := merged[mt.id]; sameID {
+					// Same ID (normal case): refresh mapping.
 					merged[mt.id] = mt.topic
+					continue
 				}
+				// A different ID for a name we already know means the
+				// topic's ID changed: the topic was deleted+recreated,
+				// or (super-seed DR) the client failed over to another
+				// cluster where the same topic name has a different ID.
+				// Previously we pinned the stale ID until the user called
+				// PurgeTopicsFromClient, which makes consumers loop
+				// forever on UNKNOWN_TOPIC_ID. Instead, re-resolve to the
+				// new ID from this fresh metadata, dropping the stale
+				// ID->name entries so we keep exactly one ID per name.
+				for id, name := range merged {
+					if name == mt.topic {
+						delete(merged, id)
+					}
+				}
+				merged[mt.id] = mt.topic
+				knownNames[mt.topic] = struct{}{}
 				continue
 			}
 			merged[mt.id] = mt.topic


### PR DESCRIPTION
## Problem

When fresh metadata reports a **different topic ID for a name the client already knows**, the current id2t merge keeps the **stale** ID and ignores the new one until the user calls `PurgeTopicsFromClient`:

```go
// Only update if it's the same ID (normal case), skip if it's a
// different ID (recreated topic).
if _, sameID := merged[mt.id]; sameID {
    merged[mt.id] = mt.topic
}
continue
```

A topic's ID changes in two real scenarios:
1. the topic is **deleted and recreated**, and
2. a client configured with **multiple seed brokers fails over to a different cluster** where the same topic name has a different topic ID (e.g. Redpanda **ShadowLink** cross-region DR / a "super-seed" multi-bootstrap pattern).

In both cases a long-lived **consumer loops indefinitely on `UNKNOWN_TOPIC_ID`** because it keeps fetching with the old ID, and never recovers without an explicit `PurgeTopicsFromClient`.

## Change

On a metadata merge, when a known topic **name** reports a **new ID**, adopt the new ID (dropping the stale `ID -> name` entries so exactly one ID is kept per name) instead of pinning the old one. This lets a long-lived consumer **re-resolve and recover automatically** across a recreation / cross-cluster failover.

## How it was found / tested

Hit while testing Redpanda cross-region DR failover ("super-seed": clients list both clusters' seeds, fail over on outage). The **producer** path fails over fine (franz-go re-queries seeds), but a **long-lived consumer** riding through the promote got stuck looping `UNKNOWN_TOPIC_ID: This server does not host this topic ID` (the promoted topic on the secondary cluster has a different topic ID). A *fresh* consumer worked; the long-lived one did not. With this change the long-lived consumer re-resolves the ID and resumes from the secondary.

End-to-end validated against a custom Redpanda Connect image built with this franz-go (2 EKS clusters, us-west-2 → us-east-1, ShadowLink).

## Notes

- Draft — opening for discussion. This intentionally changes the documented "keep stale ID until purge" behavior; happy to gate it behind an option if preferred.
- `go build ./pkg/kgo/` passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
