### PR TITLE
kprom: enable native histograms for all histogram metrics

### DIFF
--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -3,6 +3,7 @@ package kprom
 import (
 	"maps"
 	"reflect"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -23,6 +24,11 @@ type cfg struct {
 	fetchProduceOpts fetchProduceOpts
 	brokerLabels     []string
 
+	disableClassicHistograms        bool
+	nativeHistogramBucketFactor     float64
+	nativeHistogramMaxBucketNumber  uint32
+	nativeHistogramMinResetDuration time.Duration
+
 	handlerOpts  promhttp.HandlerOpts
 	goCollectors bool
 }
@@ -40,6 +46,10 @@ func newCfg(namespace string, opts ...Opt) cfg {
 			labels:            []string{"node_id", "topic"},
 		},
 		brokerLabels: []string{"node_id"},
+
+		nativeHistogramBucketFactor:     DefNativeHistogramBucketFactor,
+		nativeHistogramMaxBucketNumber:  DefNativeHistogramMaxBucketNumber,
+		nativeHistogramMinResetDuration: DefNativeHistogramMinResetDuration,
 	}
 
 	for _, opt := range opts {
@@ -139,6 +149,50 @@ func Buckets(buckets []float64) Opt {
 // DefBuckets are the default Histogram buckets. The default buckets are
 // tailored to broadly measure the kafka timings (in seconds).
 var DefBuckets = []float64{0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.024, 2.048}
+
+// Default native histogram parameters, used by all kprom histograms unless
+// overridden with the NativeHistogram* options.
+const (
+	DefNativeHistogramBucketFactor     = 1.1
+	DefNativeHistogramMaxBucketNumber  = 100
+	DefNativeHistogramMinResetDuration = time.Hour
+)
+
+// NativeHistogramBucketFactor sets the bucket factor used by all kprom native
+// histograms, overriding the default of DefNativeHistogramBucketFactor. It
+// controls the resolution of native histogram buckets: the growth factor
+// between consecutive buckets is at most this value. It must be greater than 1
+// to enable native histograms; a value of 1 or less disables native histograms,
+// leaving only the classic histograms.
+func NativeHistogramBucketFactor(factor float64) Opt {
+	return opt{func(c *cfg) { c.nativeHistogramBucketFactor = factor }}
+}
+
+// NativeHistogramMaxBucketNumber sets the maximum number of buckets used by all
+// kprom native histograms, overriding the default of
+// DefNativeHistogramMaxBucketNumber. Once exceeded, buckets are widened to keep
+// cardinality bounded. A value of 0 means no limit.
+func NativeHistogramMaxBucketNumber(n uint32) Opt {
+	return opt{func(c *cfg) { c.nativeHistogramMaxBucketNumber = n }}
+}
+
+// NativeHistogramMinResetDuration sets the minimum duration that must pass
+// before kprom native histogram buckets may be reset to keep them within the
+// max bucket number, overriding the default of
+// DefNativeHistogramMinResetDuration.
+func NativeHistogramMinResetDuration(d time.Duration) Opt {
+	return opt{func(c *cfg) { c.nativeHistogramMinResetDuration = d }}
+}
+
+// DisableClassicHistograms stops kprom from emitting classic (fixed-bucket)
+// histograms, leaving only native histograms. Native histograms must be enabled
+// for this to work: if the native bucket factor is 1 or less (see
+// NativeHistogramBucketFactor), prometheus silently falls back to its own
+// default classic buckets (prometheus.DefBuckets), which are neither the kprom
+// defaults nor tailored to Kafka timings.
+func DisableClassicHistograms() Opt {
+	return opt{func(c *cfg) { c.disableClassicHistograms = true }}
+}
 
 // A Histogram is an identifier for a kprom histogram that can be enabled
 type Histogram uint8

--- a/plugin/kprom/config.go
+++ b/plugin/kprom/config.go
@@ -24,10 +24,10 @@ type cfg struct {
 	fetchProduceOpts fetchProduceOpts
 	brokerLabels     []string
 
-	disableClassicHistograms        bool
-	nativeHistogramBucketFactor     float64
-	nativeHistogramMaxBucketNumber  uint32
-	nativeHistogramMinResetDuration time.Duration
+	nativeBucketFactor   float64
+	nativeMaxBuckets     uint32
+	nativeBucketMinReset time.Duration
+	nativeBucketsOnly    bool
 
 	handlerOpts  promhttp.HandlerOpts
 	goCollectors bool
@@ -47,9 +47,9 @@ func newCfg(namespace string, opts ...Opt) cfg {
 		},
 		brokerLabels: []string{"node_id"},
 
-		nativeHistogramBucketFactor:     DefNativeHistogramBucketFactor,
-		nativeHistogramMaxBucketNumber:  DefNativeHistogramMaxBucketNumber,
-		nativeHistogramMinResetDuration: DefNativeHistogramMinResetDuration,
+		nativeBucketFactor:   DefNativeBucketFactor,
+		nativeMaxBuckets:     DefNativeMaxBuckets,
+		nativeBucketMinReset: DefNativeBucketMinReset,
 	}
 
 	for _, opt := range opts {
@@ -151,47 +151,45 @@ func Buckets(buckets []float64) Opt {
 var DefBuckets = []float64{0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.024, 2.048}
 
 // Default native histogram parameters, used by all kprom histograms unless
-// overridden with the NativeHistogram* options.
+// overridden with the Native* options.
 const (
-	DefNativeHistogramBucketFactor     = 1.1
-	DefNativeHistogramMaxBucketNumber  = 100
-	DefNativeHistogramMinResetDuration = time.Hour
+	DefNativeBucketFactor   = 1.1
+	DefNativeMaxBuckets     = 100
+	DefNativeBucketMinReset = time.Hour
 )
 
-// NativeHistogramBucketFactor sets the bucket factor used by all kprom native
-// histograms, overriding the default of DefNativeHistogramBucketFactor. It
-// controls the resolution of native histogram buckets: the growth factor
-// between consecutive buckets is at most this value. It must be greater than 1
-// to enable native histograms; a value of 1 or less disables native histograms,
-// leaving only the classic histograms.
-func NativeHistogramBucketFactor(factor float64) Opt {
-	return opt{func(c *cfg) { c.nativeHistogramBucketFactor = factor }}
+// NativeBucketFactor sets the bucket factor used by all kprom native
+// histograms, overriding the default of DefNativeBucketFactor. It controls the
+// resolution of native histogram buckets: the growth factor between consecutive
+// buckets is at most this value. It must be greater than 1 to enable native
+// histograms; a value of 1 or less disables native histograms, leaving only the
+// classic histograms.
+func NativeBucketFactor(factor float64) Opt {
+	return opt{func(c *cfg) { c.nativeBucketFactor = factor }}
 }
 
-// NativeHistogramMaxBucketNumber sets the maximum number of buckets used by all
-// kprom native histograms, overriding the default of
-// DefNativeHistogramMaxBucketNumber. Once exceeded, buckets are widened to keep
-// cardinality bounded. A value of 0 means no limit.
-func NativeHistogramMaxBucketNumber(n uint32) Opt {
-	return opt{func(c *cfg) { c.nativeHistogramMaxBucketNumber = n }}
+// NativeMaxBuckets sets the maximum number of buckets used by all kprom native
+// histograms, overriding the default of DefNativeMaxBuckets. Once exceeded,
+// buckets are widened to keep cardinality bounded. A value of 0 means no limit.
+func NativeMaxBuckets(n uint32) Opt {
+	return opt{func(c *cfg) { c.nativeMaxBuckets = n }}
 }
 
-// NativeHistogramMinResetDuration sets the minimum duration that must pass
-// before kprom native histogram buckets may be reset to keep them within the
-// max bucket number, overriding the default of
-// DefNativeHistogramMinResetDuration.
-func NativeHistogramMinResetDuration(d time.Duration) Opt {
-	return opt{func(c *cfg) { c.nativeHistogramMinResetDuration = d }}
+// NativeBucketMinReset sets the minimum duration that must pass before kprom
+// native histogram buckets may be reset to keep them within the max bucket
+// number, overriding the default of DefNativeBucketMinReset.
+func NativeBucketMinReset(d time.Duration) Opt {
+	return opt{func(c *cfg) { c.nativeBucketMinReset = d }}
 }
 
-// DisableClassicHistograms stops kprom from emitting classic (fixed-bucket)
-// histograms, leaving only native histograms. Native histograms must be enabled
-// for this to work: if the native bucket factor is 1 or less (see
-// NativeHistogramBucketFactor), prometheus silently falls back to its own
-// default classic buckets (prometheus.DefBuckets), which are neither the kprom
-// defaults nor tailored to Kafka timings.
-func DisableClassicHistograms() Opt {
-	return opt{func(c *cfg) { c.disableClassicHistograms = true }}
+// NativeBucketsOnly stops kprom from emitting classic (fixed-bucket) histograms,
+// leaving only native histograms. Native histograms must be enabled for this to
+// work: if the native bucket factor is 1 or less (see NativeBucketFactor),
+// prometheus silently falls back to its own default classic buckets
+// (prometheus.DefBuckets), which are neither the kprom defaults nor tailored to
+// Kafka timings.
+func NativeBucketsOnly() Opt {
+	return opt{func(c *cfg) { c.nativeBucketsOnly = true }}
 }
 
 // A Histogram is an identifier for a kprom histogram that can be enabled

--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -150,13 +150,16 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 
 	// newHistogramOpts builds HistogramOpts for histogram h: classic buckets
 	// (custom if configured, else default) plus the shared native-histogram
-	// parameters. Setting NativeHistogramBucketFactor while keeping Buckets makes
-	// each histogram emit both classic and native representations, preserving
-	// backward compatibility.
+	// parameters. By default both classic and native histograms are emitted;
+	// DisableClassicHistograms drops the classic buckets and a native bucket
+	// factor of 1 or less disables native histograms (see NativeHistogramBucketFactor).
 	newHistogramOpts := func(h Histogram, name, help string) prometheus.HistogramOpts {
-		buckets := m.cfg.defBuckets
-		if b, ok := m.cfg.histograms[h]; ok && len(b) != 0 {
-			buckets = b
+		var buckets []float64
+		if !m.cfg.disableClassicHistograms {
+			buckets = m.cfg.defBuckets
+			if b, ok := m.cfg.histograms[h]; ok && len(b) != 0 {
+				buckets = b
+			}
 		}
 		return prometheus.HistogramOpts{
 			Namespace:                       namespace,
@@ -165,9 +168,9 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 			Name:                            name,
 			Help:                            help,
 			Buckets:                         buckets,
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
+			NativeHistogramBucketFactor:     m.cfg.nativeHistogramBucketFactor,
+			NativeHistogramMaxBucketNumber:  m.cfg.nativeHistogramMaxBucketNumber,
+			NativeHistogramMinResetDuration: m.cfg.nativeHistogramMinResetDuration,
 		}
 	}
 

--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -151,11 +151,11 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 	// newHistogramOpts builds HistogramOpts for histogram h: classic buckets
 	// (custom if configured, else default) plus the shared native-histogram
 	// parameters. By default both classic and native histograms are emitted;
-	// DisableClassicHistograms drops the classic buckets and a native bucket
-	// factor of 1 or less disables native histograms (see NativeHistogramBucketFactor).
+	// NativeBucketsOnly drops the classic buckets and a native bucket factor of
+	// 1 or less disables native histograms (see NativeBucketFactor).
 	newHistogramOpts := func(h Histogram, name, help string) prometheus.HistogramOpts {
 		var buckets []float64
-		if !m.cfg.disableClassicHistograms {
+		if !m.cfg.nativeBucketsOnly {
 			buckets = m.cfg.defBuckets
 			if b, ok := m.cfg.histograms[h]; ok && len(b) != 0 {
 				buckets = b
@@ -168,9 +168,9 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 			Name:                            name,
 			Help:                            help,
 			Buckets:                         buckets,
-			NativeHistogramBucketFactor:     m.cfg.nativeHistogramBucketFactor,
-			NativeHistogramMaxBucketNumber:  m.cfg.nativeHistogramMaxBucketNumber,
-			NativeHistogramMinResetDuration: m.cfg.nativeHistogramMinResetDuration,
+			NativeHistogramBucketFactor:     m.cfg.nativeBucketFactor,
+			NativeHistogramMaxBucketNumber:  m.cfg.nativeMaxBuckets,
+			NativeHistogramMinResetDuration: m.cfg.nativeBucketMinReset,
 		}
 	}
 

--- a/plugin/kprom/kprom.go
+++ b/plugin/kprom/kprom.go
@@ -148,12 +148,27 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		constLabels["client_id"] = client.OptValue(kgo.ClientID).(string)
 	}
 
-	// returns Hist buckets if set, otherwise defBucket
-	getHistogramBuckets := func(h Histogram) []float64 {
-		if buckets, ok := m.cfg.histograms[h]; ok && len(buckets) != 0 {
-			return buckets
+	// newHistogramOpts builds HistogramOpts for histogram h: classic buckets
+	// (custom if configured, else default) plus the shared native-histogram
+	// parameters. Setting NativeHistogramBucketFactor while keeping Buckets makes
+	// each histogram emit both classic and native representations, preserving
+	// backward compatibility.
+	newHistogramOpts := func(h Histogram, name, help string) prometheus.HistogramOpts {
+		buckets := m.cfg.defBuckets
+		if b, ok := m.cfg.histograms[h]; ok && len(b) != 0 {
+			buckets = b
 		}
-		return m.cfg.defBuckets
+		return prometheus.HistogramOpts{
+			Namespace:                       namespace,
+			Subsystem:                       subsystem,
+			ConstLabels:                     constLabels,
+			Name:                            name,
+			Help:                            help,
+			Buckets:                         buckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}
 	}
 
 	// Connection
@@ -200,23 +215,13 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Help:        "Total number of write errors",
 	}, m.cfg.brokerLabels)
 
-	m.writeWaitSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		ConstLabels: constLabels,
-		Name:        "write_wait_seconds",
-		Help:        "Time spent waiting to write to Kafka",
-		Buckets:     getHistogramBuckets(WriteWait),
-	}, m.cfg.brokerLabels)
+	m.writeWaitSeconds = factory.NewHistogramVec(
+		newHistogramOpts(WriteWait, "write_wait_seconds", "Time spent waiting to write to Kafka"),
+		m.cfg.brokerLabels)
 
-	m.writeTimeSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		ConstLabels: constLabels,
-		Name:        "write_time_seconds",
-		Help:        "Time spent writing to Kafka",
-		Buckets:     getHistogramBuckets(WriteTime),
-	}, m.cfg.brokerLabels)
+	m.writeTimeSeconds = factory.NewHistogramVec(
+		newHistogramOpts(WriteTime, "write_time_seconds", "Time spent writing to Kafka"),
+		m.cfg.brokerLabels)
 
 	// Read
 
@@ -236,43 +241,23 @@ func (m *Metrics) OnNewClient(client *kgo.Client) {
 		Help:        "Total number of read errors",
 	}, m.cfg.brokerLabels)
 
-	m.readWaitSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		ConstLabels: constLabels,
-		Name:        "read_wait_seconds",
-		Help:        "Time spent waiting to read from Kafka",
-		Buckets:     getHistogramBuckets(ReadWait),
-	}, m.cfg.brokerLabels)
+	m.readWaitSeconds = factory.NewHistogramVec(
+		newHistogramOpts(ReadWait, "read_wait_seconds", "Time spent waiting to read from Kafka"),
+		m.cfg.brokerLabels)
 
-	m.readTimeSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		ConstLabels: constLabels,
-		Name:        "read_time_seconds",
-		Help:        "Time spent reading from Kafka",
-		Buckets:     getHistogramBuckets(ReadTime),
-	}, m.cfg.brokerLabels)
+	m.readTimeSeconds = factory.NewHistogramVec(
+		newHistogramOpts(ReadTime, "read_time_seconds", "Time spent reading from Kafka"),
+		m.cfg.brokerLabels)
 
 	// Request E2E duration & Throttle
 
-	m.requestDurationE2ESeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		ConstLabels: constLabels,
-		Name:        "request_duration_e2e_seconds",
-		Help:        "Time from the start of when a request is written to the end of when the response for that request was fully read",
-		Buckets:     getHistogramBuckets(RequestDurationE2E),
-	}, m.cfg.brokerLabels)
+	m.requestDurationE2ESeconds = factory.NewHistogramVec(
+		newHistogramOpts(RequestDurationE2E, "request_duration_e2e_seconds", "Time from the start of when a request is written to the end of when the response for that request was fully read"),
+		m.cfg.brokerLabels)
 
-	m.requestThrottledSeconds = factory.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:   namespace,
-		Subsystem:   subsystem,
-		ConstLabels: constLabels,
-		Name:        "request_throttled_seconds",
-		Help:        "Time the request was throttled",
-		Buckets:     getHistogramBuckets(RequestThrottled),
-	}, m.cfg.brokerLabels)
+	m.requestThrottledSeconds = factory.NewHistogramVec(
+		newHistogramOpts(RequestThrottled, "request_throttled_seconds", "Time the request was throttled"),
+		m.cfg.brokerLabels)
 
 	// Produce
 


### PR DESCRIPTION
Native (sparse) Prometheus histograms are more accurate than classic histograms: they capture a value's magnitude with high resolution across a wide dynamic range, instead of bucketing into a fixed, pre-chosen set of boundaries.

This matters in particular for kprom because the classic histograms are configured with `DefBuckets`, whose largest bucket is `2.048s`. Anything slower than ~2s all lands in the `+Inf` bucket, so quantile estimates above that range are effectively meaningless — and in practice Kafka timings (writes, reads, end-to-end request duration, throttling) can and do exceed 2s. Native histograms have no such ceiling: their buckets grow geometrically to cover whatever range the observed values fall into, so high latencies remain measurable without anyone having to tune bucket boundaries up front.

In this PR, I propose to change all histograms to emit both classic and native representations, so existing dashboards and recording rules keep working unchanged.