### PR TITLE
kgo: do not exit manageFetchConcurrency while sources are pending in wantFetch

### DIFF
--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1679,7 +1679,14 @@ func (fm *fetchManager) manageFetchConcurrency() {
 			continue
 		}
 
-		if wantQuit && activeFetches == 0 {
+		// We cannot return while sources are still registered in
+		// wantFetch: each of them is (or is about to be) blocked
+		// sending on cancelFetchCh, which only we drain. Returning
+		// early orphans those sends once the channel's small buffer
+		// fills; the sources then hold session workers forever and
+		// stopSession never finishes (consumer deadlock). Keep
+		// looping until every registered source has canceled.
+		if wantQuit && activeFetches == 0 && len(wantFetch) == 0 {
 			return
 		}
 	}

--- a/pkg/kgo/fetch_manager_quit_test.go
+++ b/pkg/kgo/fetch_manager_quit_test.go
@@ -1,0 +1,94 @@
+package kgo
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestFetchManagerQuitDrainsPendingFetches models the exact dance every
+// source.loopFetch goroutine performs against the fetchManager, and asserts
+// that all sources can exit once the session context is canceled.
+//
+// Since v1.21.0, manageFetchConcurrency gates fetch grants on pollActive
+// (with the default MaxConcurrentFetches == 0). When no poll is in progress,
+// registered sources accumulate in wantFetch ungranted. If the session is
+// then stopped (metadata update -> migrateCursorTo -> stopSession cancels the
+// session ctx), manageFetchConcurrency observes wantQuit && activeFetches ==
+// 0 and returns immediately -- while wantFetch is still non-empty and the
+// registered sources are about to send on cancelFetchCh. cancelFetchCh is
+// buffered (4): the first four cancels are absorbed, every additional source
+// blocks forever on the bare `session.cancelFetchCh <- canFetch` send
+// (source.go, ctx.Done branch of the fetch handoff). Each such source holds a
+// session worker (incWorker/decWorker), so consumer.stopSession waits on
+// workersCond forever and PollRecords never returns: the client is a zombie.
+//
+// This is the runtime counterpart of the shutdown-path hang: it needs no
+// Close() call, only a session stop while >4 sources are registered and no
+// poll is active.
+func TestFetchManagerQuitDrainsPendingFetches(t *testing.T) {
+	t.Parallel()
+
+	const sources = 8 // > cancelFetchCh buffer of 4
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var pollActive atomic.Bool // false: no poll in progress
+	pollWake := make(chan struct{}, 1)
+
+	fm := newFetchManager(ctx, cancel, &pollActive, pollWake, 0) // 0 == default MaxConcurrentFetches
+
+	var registered sync.WaitGroup
+	var finished sync.WaitGroup
+	registered.Add(sources)
+	finished.Add(sources)
+
+	for i := 0; i < sources; i++ {
+		go func() {
+			defer finished.Done()
+
+			// Mirrors source.loopFetch: register the desire to
+			// fetch, then either receive the grant or cancel.
+			canFetch := make(chan chan bool, 1)
+			select {
+			case <-ctx.Done():
+				registered.Done()
+				return
+			case fm.desireFetch() <- canFetch:
+				registered.Done()
+			}
+
+			select {
+			case <-ctx.Done():
+				fm.cancelFetchCh <- canFetch // bare send, as in source.go
+			case doneFetch := <-canFetch:
+				select {
+				case <-ctx.Done():
+				default:
+				}
+				doneFetch <- true
+			}
+		}()
+	}
+
+	registered.Wait() // all sources are in wantFetch (unbuffered desireFetchCh)
+	cancel()          // session stop: stopSession cancels the session ctx
+
+	allDone := make(chan struct{})
+	go func() {
+		finished.Wait()
+		close(allDone)
+	}()
+
+	select {
+	case <-allDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetch sources still blocked 5s after session cancel: " +
+			"manageFetchConcurrency exited with pending wantFetch, " +
+			"orphaning cancelFetchCh; sources hold session workers forever " +
+			"and stopSession can never finish")
+	}
+}

--- a/pkg/kgo/fetch_manager_quit_test.go
+++ b/pkg/kgo/fetch_manager_quit_test.go
@@ -13,7 +13,11 @@ import (
 // that all sources can exit once the session context is canceled.
 //
 // Since v1.21.0, manageFetchConcurrency gates fetch grants on pollActive
-// (with the default MaxConcurrentFetches == 0). When no poll is in progress,
+// when MaxConcurrentFetches == 0. Zero is not the default (that is -1,
+// unbounded; before v1.21.0, zero WAS both the default and unbounded): it is
+// poll-gated mode, entered by explicitly opting in with
+// MaxConcurrentFetches(0), or forced for share groups by
+// ShareMaxRecordsStrict. When no poll is in progress,
 // registered sources accumulate in wantFetch ungranted. If the session is
 // then stopped (metadata update -> migrateCursorTo -> stopSession cancels the
 // session ctx), manageFetchConcurrency observes wantQuit && activeFetches ==
@@ -39,7 +43,9 @@ func TestFetchManagerQuitDrainsPendingFetches(t *testing.T) {
 	var pollActive atomic.Bool // false: no poll in progress
 	pollWake := make(chan struct{}, 1)
 
-	fm := newFetchManager(ctx, cancel, &pollActive, pollWake, 0) // 0 == default MaxConcurrentFetches
+	// 0 == poll-gated mode: explicit MaxConcurrentFetches(0), or forced by
+	// ShareMaxRecordsStrict; not the default, which is -1 (unbounded).
+	fm := newFetchManager(ctx, cancel, &pollActive, pollWake, 0)
 
 	var registered sync.WaitGroup
 	var finished sync.WaitGroup
@@ -55,6 +61,13 @@ func TestFetchManagerQuitDrainsPendingFetches(t *testing.T) {
 			canFetch := make(chan chan bool, 1)
 			select {
 			case <-ctx.Done():
+				// Unreachable: cancel() fires only after
+				// registered.Wait() returns. If this ever
+				// fires, the premise below that every source
+				// is sitting in wantFetch is silently broken
+				// (we would count this source as registered
+				// without it registering), so flag it.
+				t.Error("ctx canceled before all sources registered; the all-sources-in-wantFetch premise is broken")
 				registered.Done()
 				return
 			case fm.desireFetch() <- canFetch:
@@ -65,9 +78,15 @@ func TestFetchManagerQuitDrainsPendingFetches(t *testing.T) {
 			case <-ctx.Done():
 				fm.cancelFetchCh <- canFetch // bare send, as in source.go
 			case doneFetch := <-canFetch:
-				select {
-				case <-ctx.Done():
-				default:
+				// Unreachable in this test (no poll is ever
+				// active and allowed fetches is 0, so the
+				// manager never grants); kept to document the
+				// full loopFetch shape, mirroring source.go
+				// exactly: a grant that lost the race with
+				// cancelation returns the token with false.
+				if ctx.Err() != nil {
+					doneFetch <- false
+					return
 				}
 				doneFetch <- true
 			}


### PR DESCRIPTION
Fixes #1338 — permanent consumer deadlock since v1.21.0 (PollRecords never returns after a session stop while no poll is active).

## What

`manageFetchConcurrency`'s quit condition predates the v1.21.0 poll-gating rework and can return while sources are still registered in `wantFetch`:

- with the default `MaxConcurrentFetches(0)`, registrations are only granted while a poll is in progress (`pollAllowed && activeFetches == 0`), so `wantFetch` lingers non-empty whenever the application is between polls;
- on session stop (`stopSession` via any metadata-driven cursor migration), the manager saw `wantQuit && activeFetches == 0` and returned with those sources still registered;
- nothing drains `cancelFetchCh` after that. The registered sources take the cancel path in `loopFetch` — a bare `session.cancelFetchCh <- canFetch` send. The buffer of 4 absorbs four; every additional source blocks forever, never reaching its deferred `decWorker`;
- `stopSession` waits on `workersCond` for eternity → metadata loop dead → `PollRecords` never returns. The client looks healthy but consumes nothing.

Before v1.21.0 this was unreachable: `allowedFetches == 0` meant *unbounded*, registrations were granted immediately, and `wantFetch` was always empty by quit time.

The fix keeps the manager looping until `wantFetch` is empty. Safe on the quit path: after ctx-done each registered source sends exactly one cancel which the still-running manager drains, and no new registrations can arrive (the register select also has a `ctx.Done` case).

## Testing

- New `TestFetchManagerQuitDrainsPendingFetches` models the exact `loopFetch` handshake (8 sources > cancel buffer of 4, no active poll, then session cancel). It deadlocks (5s timeout) on current master and v1.21.0–v1.21.2, and passes with `-race` on the fix.
- `go test ./pkg/kgo` against a live single-node broker (`KGO_TEST_RF=1`): identical results with and without the patch (no regressions).

Real-world stacks, affected-version analysis and production context are in #1338 (observed on v1.21.1 and v1.21.2 across two different workloads; instances stuck up to 7.3 days).