### PR TITLE
kgo: rejoin on fatal commit errors; fall back to all partitions when none writable

### DIFF
--- a/pkg/kfake/behavior_test.go
+++ b/pkg/kfake/behavior_test.go
@@ -6064,3 +6064,95 @@ func TestShareGroupRecyclePoolAliasing(t *testing.T) {
 		}
 	}
 }
+
+// injectOffsetCommitError returns a one-shot ControlKey callback that
+// fails every partition of the next OffsetCommit with the given error
+// code. Returning true pops the control after first use.
+func injectOffsetCommitError(code int16) func(kmsg.Request) (kmsg.Response, error, bool) {
+	return func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		req := kreq.(*kmsg.OffsetCommitRequest)
+		resp := req.ResponseKind().(*kmsg.OffsetCommitResponse)
+		for _, t := range req.Topics {
+			rt := kmsg.NewOffsetCommitResponseTopic()
+			rt.Topic = t.Topic
+			rt.TopicID = t.TopicID
+			for _, p := range t.Partitions {
+				rp := kmsg.NewOffsetCommitResponseTopicPartition()
+				rp.Partition = p.Partition
+				rp.ErrorCode = code
+				rt.Partitions = append(rt.Partitions, rp)
+			}
+			resp.Topics = append(resp.Topics, rt)
+		}
+		return resp, nil, true
+	}
+}
+
+// TestCommitFatalMemberErrorTriggersRejoin verifies that a classic
+// (non-848) group member rejoins immediately when an OffsetCommit
+// returns an error meaning the broker no longer recognizes the member.
+// Without the fix, the consumer would zombie along (consuming but
+// unable to commit) until the heartbeat loop noticed the dead session
+// up to a heartbeat interval later.
+func TestCommitFatalMemberErrorTriggersRejoin(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		code int16
+	}{
+		{"UnknownMemberID", kerr.UnknownMemberID.Code},
+		{"IllegalGeneration", kerr.IllegalGeneration.Code},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			topic := "t-commit-fatal-" + test.name
+			group := "g-commit-fatal-" + test.name
+			const nRecords = 10
+
+			c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic))
+			produceNStrings(t, newPlainClient(t, c), topic, nRecords)
+
+			cl := newPlainClient(t, c,
+				kgo.ConsumeTopics(topic),
+				kgo.ConsumerGroup(group),
+				kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+				kgo.FetchMaxWait(250*time.Millisecond),
+				kgo.DisableAutoCommit(),
+			)
+			consumeN(t, cl, nRecords, 10*time.Second)
+
+			// Count JoinGroups to observe the rejoin; the group is
+			// stable now, so any join from here on is the rejoin.
+			var joins atomic.Int64
+			c.ControlKey(int16(kmsg.JoinGroup), func(kmsg.Request) (kmsg.Response, error, bool) {
+				c.KeepControl()
+				joins.Add(1)
+				return nil, nil, false
+			})
+
+			c.ControlKey(int16(kmsg.OffsetCommit), injectOffsetCommitError(test.code))
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cl.CommitUncommittedOffsets(ctx) // fails with the injected error; the fix reacts to it
+
+			deadline := time.Now().Add(10 * time.Second)
+			for joins.Load() == 0 && time.Now().Before(deadline) {
+				time.Sleep(50 * time.Millisecond)
+			}
+			if joins.Load() == 0 {
+				t.Fatal("timed out waiting for a rejoin after a fatal commit error")
+			}
+
+			// The member must fully recover: new records are consumable
+			// and committable after the rejoin.
+			produceNStrings(t, newPlainClient(t, c), topic, nRecords)
+			if got := consumeN(t, cl, nRecords, 15*time.Second); len(got) != nRecords {
+				t.Fatalf("expected %d records after recovery, got %d", nRecords, len(got))
+			}
+			if err := cl.CommitUncommittedOffsets(context.Background()); err != nil {
+				t.Fatalf("commit after recovery: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -811,7 +811,25 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 	}
 
 	if stage != revokeThisSession { // cooperative consumers rejoin after revoking what they lost
-		defer g.rejoin("after revoking what we lost from a rebalance")
+		// The rejoin triggers the second join of the classic
+		// cooperative two-phase rebalance: after giving up lost
+		// partitions, the member rejoins so the group can reassign
+		// them. 848 has no second join, the server reconciles
+		// through heartbeats. There, this signal would only tear
+		// down and rebuild the heartbeat session: the session that
+		// called us already handled both our lost and added
+		// partitions, so the rebuilt session re-enters with an empty
+		// diff, and because rebuilding re-arms the heartbeat timer
+		// at a full interval, the bounce also DELAYS the heartbeat
+		// that acks our revocation to the server. For 848, prerevoke
+		// instead forces an immediate heartbeat to ack the
+		// revocation.
+		g.mu.Lock()
+		is848 := g.is848
+		g.mu.Unlock()
+		if !is848 {
+			defer g.rejoin("after revoking what we lost from a rebalance")
+		}
 	}
 
 	// The block below deletes everything lost from our uncommitted map.
@@ -863,6 +881,7 @@ func (s *assignRevokeSession) prerevoke(g *groupConsumer, lost map[string][]int3
 	// very first concurrent heartbeat sends keepalive.
 	g.mu.Lock()
 	g848 := g.g848
+	is848 := g.is848 // g848 stays non-nil after a fallback to classic; is848 is what tracks the protocol
 	g.mu.Unlock()
 	if g848 != nil {
 		g848.prerevoking.Store(true)
@@ -876,6 +895,33 @@ func (s *assignRevokeSession) prerevoke(g *groupConsumer, lost map[string][]int3
 		// subsequent heartbeats resume sending full requests.
 		if g848 != nil {
 			g848.prerevoking.Store(false)
+		}
+		// If we revoked, ack the revocation to the server right away
+		// rather than waiting out the heartbeat timer: the server
+		// cannot give the revoked partitions to other members until
+		// it sees a heartbeat without them, so an immediate full
+		// heartbeat (prerevoking was cleared above, so it will not
+		// be a keepalive) directly speeds group-wide reconciliation.
+		// The Java client acks the same way the moment revocation
+		// callbacks complete.
+		//
+		// The send must be best effort, NOT blocking. If the
+		// heartbeat loop exits on a fatal error before consuming our
+		// send (its first heartbeat can fail while we are still
+		// revoking), nothing reads heartbeatForceCh again until the
+		// next session begins, but the next session cannot begin
+		// until we return: setupAssignedAndHeartbeat waits on
+		// assignDone, which waits on prerevokeDone, which closes
+		// only when this goroutine exits. A blocking send would
+		// deadlock the manage loop. If the send is missed (loop
+		// mid-heartbeat or already gone), the regular heartbeat
+		// timer acks within one interval, which is no worse than
+		// what the session bounce this replaced provided.
+		if is848 && len(lost) > 0 {
+			select {
+			case g.heartbeatForceCh <- func(error) {}:
+			default:
+			}
 		}
 	}()
 	return s.prerevokeDone

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -2158,7 +2158,23 @@ func (g *groupConsumer) findNewAssignments() {
 	}
 
 	if numNewTopics > 0 {
-		g.rejoin("rejoining because there are more topics to consume, our interests have changed")
+		// 848 needs no rejoin here: mkreq rebuilds the subscription
+		// from live state on every heartbeat and the keepalive check
+		// sends a full request when it changes, so the next heartbeat
+		// already carries our new interests. Bouncing the session
+		// would only delay that, since rebuilding re-arms the
+		// heartbeat timer at a full interval. Instead, force an
+		// immediate heartbeat (best effort, must not block; see the
+		// walkthrough in prerevoke); if the force is missed, the
+		// timer sends within one interval.
+		if g.is848 {
+			select {
+			case g.heartbeatForceCh <- func(error) {}:
+			default:
+			}
+		} else {
+			g.rejoin("rejoining because there are more topics to consume, our interests have changed")
+		}
 	} else if g.leader.Load() {
 		if len(toChange) > 0 {
 			g.rejoin("rejoining because we are the leader and noticed some topics have new partitions")

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -3159,6 +3159,7 @@ func (g *groupConsumer) commit(
 	req.Generation = generation
 	req.MemberID = memberID
 	req.InstanceID = g.cfg.instanceID
+	is848 := g.is848 // g.mu is held, per the function comment above
 
 	if ctx.Done() != nil {
 		go func() {
@@ -3401,9 +3402,65 @@ func (g *groupConsumer) commit(
 		// original request, not the wire-filtered one.
 		req.Topics = origReqTopics
 
+		// If the broker no longer recognizes our member (the session
+		// expired during a network blip, or the group rebalanced
+		// without us), every commit from here on fails identically
+		// while we keep consuming as a zombie, until the heartbeat
+		// loop sees the same error up to a full heartbeat interval
+		// later. Rejoin immediately instead; the join itself repairs
+		// the session (joinAndSync clears the member id and retries
+		// if the broker rejects the join with UnknownMemberID).
+		//
+		// Classic protocol only: in 848 mode, a forced "rejoin" does
+		// not actually rejoin. The heartbeat loop treats the signal
+		// as RebalanceInProgress and the manage loop restarts the
+		// session with the same member id and epoch; only a
+		// heartbeat error resets the member to epoch 0. Worse, with
+		// autocommit the restart livelocks: ending a session runs
+		// the default revoke, which sync-commits uncommitted
+		// offsets; that commit fails with the same fatal error and
+		// re-queues the rejoin signal; the restarted session then
+		// consumes the queued signal before its first heartbeat
+		// timer can fire, and the cycle repeats forever without a
+		// single heartbeat reaching the broker. Classic does not
+		// loop because joinAndSync drains rejoinCh before joining
+		// and the join re-registers us. For 848 we leave fatal
+		// member errors to the heartbeat loop, matching the Java
+		// clients: the classic Java consumer rejoins from the commit
+		// path, while the next-gen one leaves fencing detection to
+		// the heartbeat.
+		if !is848 {
+			if fatalErr := commitHasFatalMemberError(resp); fatalErr != nil {
+				g.cfg.logger.Log(LogLevelInfo, "offset commit returned a fatal group member error, triggering rejoin",
+					"group", g.cfg.group,
+					"err", fatalErr,
+				)
+				g.rejoin(fmt.Sprintf("offset commit error: %s", fatalErr))
+			}
+		}
+
 		g.updateCommitted(req, resp)
 		onDone(g.cl, req, resp, nil)
 	}()
+}
+
+// commitHasFatalMemberError returns the first per-partition error that
+// means the broker no longer recognizes this member's session. The
+// broker validates membership before any per-partition handling, so
+// these errors arrive on every partition or none. FencedInstanceID is
+// deliberately not included: it means another instance with our
+// instance id has taken over, and rejoining would fight that instance
+// for the group slot rather than repair anything.
+func commitHasFatalMemberError(resp *kmsg.OffsetCommitResponse) error {
+	for i := range resp.Topics {
+		for _, p := range resp.Topics[i].Partitions {
+			switch p.ErrorCode {
+			case kerr.UnknownMemberID.Code, kerr.IllegalGeneration.Code:
+				return kerr.ErrorForCode(p.ErrorCode)
+			}
+		}
+	}
+	return nil
 }
 
 type reNews struct {

--- a/pkg/kgo/consumer_group_848.go
+++ b/pkg/kgo/consumer_group_848.go
@@ -425,6 +425,18 @@ func (g *g848) initialJoin() (time.Duration, error) {
 	g.lastSubscribedTopics = nil
 	g.lastTopics = nil
 	g.prerevoking.Store(false)
+	// Drain any stale rejoin signal, mirroring joinAndSync. Nothing
+	// else on the 848 path consumes the channel across a member reset:
+	// if a signal was queued (e.g. metadata found new matching topics)
+	// and the heartbeat loop then exited on a fatal error without
+	// reading it, the signal would survive into the session we are
+	// about to build and immediately bounce it. The join below already
+	// carries our current subscription (mkreq reads live state), which
+	// is everything a queued signal could ask for.
+	select {
+	case <-g.g.rejoinCh:
+	default:
+	}
 	req := g.mkreq()
 	resp, err := req.RequestWith(g.g.ctx, g.g.cl)
 	if err == nil {

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -767,6 +767,18 @@ func (cl *Client) doPartition(parts *topicPartitions, partsData *topicPartitions
 	mapping := partsData.writablePartitions
 	if parts.partitioner.RequiresConsistency(pr.Record) {
 		mapping = partsData.partitions
+	} else if len(mapping) == 0 && len(partsData.partitions) > 0 {
+		// Every partition has a retriable load error, e.g. a rolling
+		// restart of an RF=1 broker briefly left all partitions
+		// leaderless. Rather than failing the record up front with
+		// the synthetic error below, fall back to the full set: the
+		// record buffers and rides the normal metadata-refresh retry
+		// path, the same as records on consistency-requiring
+		// partitioners via the branch above. If the outage outlasts
+		// the delivery timeout or retry limits, the record fails
+		// with the partition's actual load error. The Java client
+		// falls back identically when no partition is available.
+		mapping = partsData.partitions
 	}
 	if len(mapping) == 0 {
 		cl.producer.promiseRecord(pr, errors.New("unable to partition record due to no usable partitions"))


### PR DESCRIPTION
Two small client fixes superseding #1326 and #1327 (scoped down to the load-bearing parts), plus three 848 reconciliation cleanups that fell out of the livelock analysis.

## Rejoin a classic group when a commit returns a fatal member error (from #1326)

If the broker stops recognizing a member (session expired during a network blip, or the group rebalanced without us), OffsetCommit fails with UNKNOWN_MEMBER_ID / ILLEGAL_GENERATION. Previously the client only logged the error and kept consuming as a zombie - commits failing the whole time - until the heartbeat loop noticed the dead session, up to a full heartbeat interval later. We now trigger the rejoin directly from the commit path, matching the classic Java consumer.

Changes from #1326:
- **Classic protocol only.** In 848 mode a forced rejoin does not actually rejoin: the heartbeat session restarts with the same member id and epoch (only a heartbeat error resets the member to epoch 0). Worse, with autocommit enabled it livelocks: the session-ending revoke sync-commits, that commit fails with the same fatal error and re-queues the rejoin signal, and the restarted session consumes the queued signal before its first heartbeat timer can fire - repeating forever without a single heartbeat reaching the broker. (Classic cannot loop: joinAndSync drains rejoinCh before joining, and the join itself re-registers the member.) The next-gen Java consumer likewise leaves fencing detection to the heartbeat, so 848 keeps that behavior.
- FENCED_MEMBER_EPOCH dropped from the fatal set: brokers never return it for OffsetCommit (the 848 coordinator returns UNKNOWN_MEMBER_ID / STALE_MEMBER_EPOCH / ILLEGAL_GENERATION there; classic returns UNKNOWN_MEMBER_ID / ILLEGAL_GENERATION / FENCED_INSTANCE_ID / REBALANCE_IN_PROGRESS). FENCED_INSTANCE_ID stays excluded on purpose: rejoining a fenced static member would fight the newer instance rather than repair anything.
- The two kfake tests are folded into one table-driven test; the 848 test is dropped along with the 848 behavior.

## Fall back to all partitions when no partition is writable (from #1327)

When every partition of a topic briefly has a retriable load error (e.g. a rolling restart of an RF=1 broker leaves all partitions leaderless), produce failed records up front with the synthetic "unable to partition record due to no usable partitions" error instead of buffering them through the blip. We now fall back to the full partition list when the partitioner does not require consistency, exactly how consistency-requiring partitioners already behave and how the Java client partitions. Records buffer and ride the normal metadata-refresh retry path; if the outage outlasts delivery timeouts or retry limits, they fail with the partition's actual load error.

Kept as the one-line fix; the original PR's test file is dropped.

## 848 reconciliation cleanups

Pre-existing behaviors around the classic-protocol rejoin signal leaking into 848 mode, surfaced by the livelock analysis above:

- **Prerevoke no longer bounces the session.** The "rejoin after revoking what we lost" signal exists to trigger the second join of the classic cooperative two-phase rebalance; 848 has no second join. There the signal only tore down and rebuilt the heartbeat session with an empty diff - and since rebuilding re-arms the heartbeat timer at a full interval, it also *delayed* the heartbeat that acks the revocation. The signal is now classic-only, and 848 instead force-sends an immediate ack heartbeat once revocation callbacks complete, matching the Java client. The forced send is deliberately best-effort (non-blocking): a blocking send could deadlock the manage loop if the heartbeat loop exited on a fatal error first; a missed send falls back to the regular heartbeat timer, which is never worse than the bounce this replaces.
- **Subscription changes force a heartbeat instead of bouncing.** Same pattern: when metadata finds new matching topics, the rejoin signal bounced the 848 session even though every heartbeat already rebuilds the subscription from live state (the keepalive check sends a full request whenever it changes), and the new topics are not assigned yet, so the rebuilt session re-enters with an empty diff. 848 now forces an immediate heartbeat; AddConsumeTopics and regex discovery converge typically immediately instead of after a bounce plus a full interval. ForceRebalance and PurgeFetchTopics still bounce: the former is documented to do exactly that, and the latter relies on the session-end revoke to revoke purged topics locally.
- **initialJoin drains stale rejoin signals**, mirroring classic joinAndSync. Nothing else on the 848 path consumes the channel across a member reset, so a signal queued before a fatal heartbeat error survived into the freshly built session and bounced it once for no reason.

After these, no internal code path queues the rejoin signal in 848 mode; only ForceRebalance and PurgeFetchTopics do, both user-invoked.

## Tests

- gofmt clean; go build ./... and go vet pass on kgo and kfake
- New: TestCommitFatalMemberErrorTriggersRejoin (UnknownMemberID + IllegalGeneration subtests) verifies the rejoin fires and the member fully recovers (consumes and commits after rejoining)
- Full kfake suite with -race run after each change set (latest: ok in 14.6s)

Thanks @v14dis14v and @ericsg666 for the originals; both are credited with Co-authored-by trailers.

Closes #1326
Closes #1327