### PR TITLE
feat(kotel): support record offset in consume/produce spans

### DIFF
--- a/plugin/kotel/tracer.go
+++ b/plugin/kotel/tracer.go
@@ -136,7 +136,7 @@ func (t *Tracer) WithProcessSpan(r *kgo.Record) (context.Context, trace.Span) {
 		semconv.MessagingSourceName(r.Topic),
 		semconv.MessagingOperationProcess,
 		semconv.MessagingKafkaSourcePartition(int(r.Partition)),
-		semconv.MessagingKafkaMessageOffset(int(r.Offset)),
+		semconv.MessagingKafkaMessageOffsetKey.Int64(r.Offset),
 	}
 	attrs = t.maybeKeyAttr(attrs, r)
 	if t.clientID != "" {
@@ -213,6 +213,7 @@ func (t *Tracer) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 	defer span.End()
 	span.SetAttributes(
 		semconv.MessagingKafkaDestinationPartition(int(r.Partition)),
+		semconv.MessagingKafkaMessageOffsetKey.Int64(r.Offset),
 	)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -235,6 +236,7 @@ func (t *Tracer) OnFetchRecordBuffered(r *kgo.Record) {
 		semconv.MessagingSourceName(r.Topic),
 		semconv.MessagingOperationReceive,
 		semconv.MessagingKafkaSourcePartition(int(r.Partition)),
+		semconv.MessagingKafkaMessageOffsetKey.Int64(r.Offset),
 	}
 	attrs = t.maybeKeyAttr(attrs, r)
 	if t.clientID != "" {

--- a/plugin/kotel/tracer_test.go
+++ b/plugin/kotel/tracer_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
Add record offset to Kafka consumer and producer spans. Useful information for debugging and investigation.

While working on this, I explored migrating kotel from semantic conventions v1.18.0 to v1.41.0. However, this migration introduces several naming and convention questions that require team alignment:

In v1.41.0 there is [no longer a publish operation](https://github.com/open-telemetry/opentelemetry-go/blob/main/semconv/v1.41.0/attribute_group.go#L11881) type (unlike in [v1.18.0](https://github.com/open-telemetry/opentelemetry-go/blob/main/semconv/v1.18.0/trace.go#L2779)).
This affects how we should name spans and attributes going forward. Example of the possible new naming style: [fork](https://github.com/vdorokhin/franz-go/pull/1/changes)

I’d like feedback on whether we should proceed with the semconv upgrade as part of (or right after) this change. Happy to include it in this MR or handle it separately

