### PR TITLE
srfake: add GET /schemas, all-versions compatibility, full mode, and deleted/subject query params

### DIFF
--- a/pkg/sr/srfake/errors.go
+++ b/pkg/sr/srfake/errors.go
@@ -69,6 +69,10 @@ func errInvalidCompatLevel(msg string) *registryError {
 	return newErr(http.StatusBadRequest, sr.ErrInvalidCompatibilityLevel.Code, "%s", msg)
 }
 
+func errInvalidMode(msg string) *registryError {
+	return newErr(http.StatusUnprocessableEntity, sr.ErrInvalidMode.Code, "%s", msg)
+}
+
 func errCircularDependency(subject string) *registryError {
 	return newErr(http.StatusUnprocessableEntity, sr.ErrInvalidSchema.Code, "circular dependency detected: subject %s is referenced in a cycle", subject)
 }

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -664,10 +664,84 @@ func (r *Registry) handleDeleteSubjectConfig(w http.ResponseWriter, req *http.Re
    Handler – Mode
    ------------------------------------------------------------------------- */
 
-// handleGetMode emulates GET /mode and returns the mock's current operational
-// mode.
-func (*Registry) handleGetMode(w http.ResponseWriter, _ *http.Request) {
-	respondJSON(w, http.StatusOK, map[string]string{"mode": "READWRITE"})
+// handleGetMode emulates GET /mode and returns the global mode.
+func (r *Registry) handleGetMode(w http.ResponseWriter, _ *http.Request) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": r.globalMode})
+}
+
+// handlePutMode emulates PUT /mode and sets the global mode.
+func (r *Registry) handlePutMode(w http.ResponseWriter, req *http.Request) {
+	req.Body = http.MaxBytesReader(w, req.Body, 1<<10)
+	var body struct {
+		Mode sr.Mode `json:"mode"`
+	}
+	if err := decodeJSONRequest(req.Body, &body); err != nil {
+		r.handleAPIError(w, errInvalidMode(err.Error()))
+		return
+	}
+	r.mu.Lock()
+	r.globalMode = body.Mode
+	r.mu.Unlock()
+	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": body.Mode})
+}
+
+// handleGetSubjectMode emulates GET /mode/{subject}. If the subject has no mode
+// override it falls back to the global mode unless defaultToGlobal=false.
+func (r *Registry) handleGetSubjectMode(w http.ResponseWriter, req *http.Request) {
+	subject := req.PathValue("subject")
+	useDefault := req.URL.Query().Get("defaultToGlobal") != "false"
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	subj, ok := r.subjects[subject]
+	switch {
+	case ok && subj.mode != nil:
+		respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": *subj.mode})
+	case useDefault:
+		respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": r.globalMode})
+	default:
+		r.handleAPIError(w, errSubjectNotFound(subject))
+	}
+}
+
+// handlePutSubjectMode emulates PUT /mode/{subject} and sets a per-subject mode.
+func (r *Registry) handlePutSubjectMode(w http.ResponseWriter, req *http.Request) {
+	req.Body = http.MaxBytesReader(w, req.Body, 1<<10)
+	subject := req.PathValue("subject")
+
+	var body struct {
+		Mode sr.Mode `json:"mode"`
+	}
+	if err := decodeJSONRequest(req.Body, &body); err != nil {
+		r.handleAPIError(w, errInvalidMode(err.Error()))
+		return
+	}
+	if err := r.SetMode(subject, body.Mode); err != nil {
+		r.handleAPIError(w, errInvalidMode(err.Error()))
+		return
+	}
+	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": body.Mode})
+}
+
+// handleDeleteSubjectMode emulates DELETE /mode/{subject}, removing a
+// per-subject mode override and returning the mode that was removed.
+func (r *Registry) handleDeleteSubjectMode(w http.ResponseWriter, req *http.Request) {
+	subject := req.PathValue("subject")
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	subj, ok := r.subjects[subject]
+	if !ok || subj.mode == nil {
+		r.handleAPIError(w, errSubjectNotFound(subject))
+		return
+	}
+	deleted := *subj.mode
+	subj.mode = nil
+	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": deleted})
 }
 
 /* -------------------------------------------------------------------------

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -260,6 +260,57 @@ func (r *Registry) handleGetSubjectsByID(w http.ResponseWriter, req *http.Reques
 
 // handleGetSubjects emulates GET /subjects to return a list of all registered
 // subjects.
+// handleGetSchemas implements GET /schemas, returning every schema across all
+// subjects and versions. It supports the subjectPrefix, deleted, and latestOnly
+// query parameters.
+func (r *Registry) handleGetSchemas(w http.ResponseWriter, req *http.Request) {
+	includeDeleted := req.URL.Query().Get("deleted") == "true"
+	subjPrefix := req.URL.Query().Get("subjectPrefix")
+	latestOnly := req.URL.Query().Get("latestOnly") == "true"
+	ctx := requestContext(req)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	subjects := make([]string, 0, len(r.subjects))
+	for s := range r.subjects {
+		subjects = append(subjects, s)
+	}
+	sort.Strings(subjects)
+
+	out := make([]sr.SubjectSchema, 0)
+	for _, s := range subjects {
+		subj := r.subjects[s]
+		if !includeDeleted && subj.isDeleted {
+			continue
+		}
+		if ctx != "" && subjectContext(s) != ctx {
+			continue
+		}
+		if subjPrefix != "" && !strings.HasPrefix(s, subjPrefix) {
+			continue
+		}
+
+		versions := make([]int, 0, len(subj.versions))
+		for v := range subj.versions {
+			versions = append(versions, v)
+		}
+		sort.Ints(versions)
+		for _, v := range versions {
+			vd := subj.versions[v]
+			if !includeDeleted && vd.isDeleted {
+				continue
+			}
+			if latestOnly && v != subj.latestVersion {
+				continue
+			}
+			out = append(out, vd.schema)
+		}
+	}
+
+	respondJSON(w, http.StatusOK, out)
+}
+
 func (r *Registry) handleGetSubjects(w http.ResponseWriter, req *http.Request) {
 	includeDeleted := req.URL.Query().Get("deleted") == "true"
 	subjPrefix := req.URL.Query().Get("subjectPrefix")

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -127,6 +127,10 @@ func (r *Registry) handleGetSchemaByID(w http.ResponseWriter, req *http.Request)
 			return
 		}
 	}
+	if subject := req.URL.Query().Get("subject"); subject != "" && !r.schemaIDInSubjectLocked(id, subject) {
+		r.handleAPIError(w, errSchemaNotFound())
+		return
+	}
 	respondJSON(w, http.StatusOK, sch)
 }
 
@@ -152,6 +156,10 @@ func (r *Registry) handleGetRawSchemaByID(w http.ResponseWriter, req *http.Reque
 			return
 		}
 	}
+	if subject := req.URL.Query().Get("subject"); subject != "" && !r.schemaIDInSubjectLocked(id, subject) {
+		r.handleAPIError(w, errSchemaNotFound())
+		return
+	}
 	respondJSON(w, http.StatusOK, sch.Schema)
 }
 
@@ -165,6 +173,8 @@ func (r *Registry) handleGetSchemaVersionsByID(w http.ResponseWriter, req *http.
 	}
 
 	ctx := requestContext(req)
+	del := parseDeleted(req)
+	subjectParam := req.URL.Query().Get("subject")
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -178,18 +188,17 @@ func (r *Registry) handleGetSchemaVersionsByID(w http.ResponseWriter, req *http.
 	// Find all subject-version pairs that use this schema ID
 	var usages []map[string]any
 	for subject, subj := range r.subjects {
-		if subj.isDeleted {
+		if !del.keep(subj.isDeleted) {
 			continue
 		}
 		if ctx != "" && subjectContext(subject) != ctx {
 			continue
 		}
+		if subjectParam != "" && subject != subjectParam {
+			continue
+		}
 		for version, versionData := range subj.versions {
-			if versionData.schema.ID == id {
-				// Skip soft-deleted versions
-				if versionData.isDeleted {
-					continue
-				}
+			if versionData.schema.ID == id && del.keep(versionData.isDeleted) {
 				usages = append(usages, map[string]any{
 					"subject": subject,
 					"version": version,
@@ -215,6 +224,8 @@ func (r *Registry) handleGetSubjectsByID(w http.ResponseWriter, req *http.Reques
 	}
 
 	ctx := requestContext(req)
+	del := parseDeleted(req)
+	subjectParam := req.URL.Query().Get("subject")
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -226,14 +237,17 @@ func (r *Registry) handleGetSubjectsByID(w http.ResponseWriter, req *http.Reques
 
 	subjectSet := make(map[string]bool)
 	for subject, subj := range r.subjects {
-		if subj.isDeleted {
+		if !del.keep(subj.isDeleted) {
 			continue
 		}
 		if ctx != "" && subjectContext(subject) != ctx {
 			continue
 		}
+		if subjectParam != "" && subject != subjectParam {
+			continue
+		}
 		for _, vd := range subj.versions {
-			if !vd.isDeleted && vd.schema.ID == id {
+			if del.keep(vd.isDeleted) && vd.schema.ID == id {
 				subjectSet[subject] = true
 				break
 			}
@@ -260,9 +274,40 @@ func (r *Registry) handleGetSubjectsByID(w http.ResponseWriter, req *http.Reques
 
 // handleGetSubjects emulates GET /subjects to return a list of all registered
 // subjects.
+// deletedFilter captures the ?deleted and ?deletedOnly query parameters.
+// deletedOnly returns only soft-deleted items, deleted returns active and
+// soft-deleted, and neither returns only active items.
+type deletedFilter struct {
+	includeDeleted bool
+	onlyDeleted    bool
+}
+
+func parseDeleted(req *http.Request) deletedFilter {
+	q := req.URL.Query()
+	return deletedFilter{
+		includeDeleted: q.Get("deleted") == "true",
+		onlyDeleted:    q.Get("deletedOnly") == "true",
+	}
+}
+
+// keep reports whether an item with the given soft-delete state is included.
+func (f deletedFilter) keep(isDeleted bool) bool {
+	if f.onlyDeleted {
+		return isDeleted
+	}
+	if f.includeDeleted {
+		return true
+	}
+	return !isDeleted
+}
+
+// any reports whether soft-deleted items are requested at all, used by
+// single-item lookups to decide whether a soft-deleted item may be returned.
+func (f deletedFilter) any() bool { return f.includeDeleted || f.onlyDeleted }
+
 // handleGetSchemas implements GET /schemas, returning every schema across all
-// subjects and versions. It supports the subjectPrefix, deleted, and latestOnly
-// query parameters.
+// subjects and versions. It supports the subjectPrefix, deleted, deletedOnly,
+// and latestOnly query parameters.
 func (r *Registry) handleGetSchemas(w http.ResponseWriter, req *http.Request) {
 	includeDeleted := req.URL.Query().Get("deleted") == "true"
 	subjPrefix := req.URL.Query().Get("subjectPrefix")
@@ -312,14 +357,14 @@ func (r *Registry) handleGetSchemas(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *Registry) handleGetSubjects(w http.ResponseWriter, req *http.Request) {
-	includeDeleted := req.URL.Query().Get("deleted") == "true"
+	del := parseDeleted(req)
 	subjPrefix := req.URL.Query().Get("subjectPrefix")
 	ctx := requestContext(req)
 
 	r.mu.RLock()
 	subjects := make([]string, 0, len(r.subjects))
 	for s, subj := range r.subjects {
-		if !includeDeleted && subj.isDeleted {
+		if !del.keep(subj.isDeleted) {
 			continue
 		}
 		if ctx != "" && subjectContext(s) != ctx {
@@ -343,20 +388,20 @@ func (r *Registry) handleGetSubjects(w http.ResponseWriter, req *http.Request) {
 // a list of all versions for a given subject.
 func (r *Registry) handleGetSubjectVersions(w http.ResponseWriter, req *http.Request) {
 	subject := req.PathValue("subject")
-	includeDeleted := req.URL.Query().Get("deleted") == "true"
+	del := parseDeleted(req)
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	subj, ok := r.subjects[subject]
-	if !ok || (subj.isDeleted && !includeDeleted) {
+	if !ok || (subj.isDeleted && !del.any()) {
 		r.handleAPIError(w, errSubjectNotFound(subject))
 		return
 	}
 
 	var versions []int
 	for v, versionData := range subj.versions {
-		if !includeDeleted && versionData.isDeleted {
+		if !del.keep(versionData.isDeleted) {
 			continue
 		}
 		versions = append(versions, v)
@@ -390,14 +435,15 @@ func (r *Registry) handlePostSubjectVersion(w http.ResponseWriter, req *http.Req
 func (r *Registry) handleGetSubjectSchemaByVersion(w http.ResponseWriter, req *http.Request) {
 	subject := req.PathValue("subject")
 	versionStr := req.PathValue("version")
+	del := parseDeleted(req)
 
-	version, err := r.resolveVersion(subject, versionStr)
+	version, err := r.resolveVersion(subject, versionStr, del.any())
 	if err != nil {
 		r.handleAPIError(w, err)
 		return
 	}
 
-	sch, ok := r.getSchemaBySubjectVersion(subject, version)
+	sch, ok := r.getSchemaBySubjectVersion(subject, version, del.any())
 	if !ok {
 		r.handleAPIError(w, errVersionNotFound(subject, version))
 		return
@@ -410,14 +456,15 @@ func (r *Registry) handleGetSubjectSchemaByVersion(w http.ResponseWriter, req *h
 func (r *Registry) handleGetSubjectRawSchemaByVersion(w http.ResponseWriter, req *http.Request) {
 	subject := req.PathValue("subject")
 	versionStr := req.PathValue("version")
+	del := parseDeleted(req)
 
-	version, err := r.resolveVersion(subject, versionStr)
+	version, err := r.resolveVersion(subject, versionStr, del.any())
 	if err != nil {
 		r.handleAPIError(w, err)
 		return
 	}
 
-	sch, ok := r.getSchemaBySubjectVersion(subject, version)
+	sch, ok := r.getSchemaBySubjectVersion(subject, version, del.any())
 	if !ok {
 		r.handleAPIError(w, errVersionNotFound(subject, version))
 		return
@@ -430,8 +477,9 @@ func (r *Registry) handleGetSubjectRawSchemaByVersion(w http.ResponseWriter, req
 func (r *Registry) handleGetReferencedBy(w http.ResponseWriter, req *http.Request) {
 	subject := req.PathValue("subject")
 	versionStr := req.PathValue("version")
+	del := parseDeleted(req)
 
-	version, err := r.resolveVersion(subject, versionStr)
+	version, err := r.resolveVersion(subject, versionStr, del.any())
 	if err != nil {
 		r.handleAPIError(w, err)
 		return
@@ -441,7 +489,7 @@ func (r *Registry) handleGetReferencedBy(w http.ResponseWriter, req *http.Reques
 	defer r.mu.RUnlock()
 
 	// Check if the target schema exists
-	_, exists := r.getSchemaBySubjectVersionLocked(subject, version)
+	_, exists := r.getSchemaBySubjectVersionLocked(subject, version, del.any())
 	if !exists {
 		r.handleAPIError(w, errVersionNotFound(subject, version))
 		return
@@ -450,14 +498,12 @@ func (r *Registry) handleGetReferencedBy(w http.ResponseWriter, req *http.Reques
 	// Find all schemas that reference this target schema
 	referencingIDs := make([]int, 0) // Initialize as empty slice, not nil
 	for _, subj := range r.subjects {
-		// Skip soft-deleted subjects
-		if subj.isDeleted {
+		if !del.keep(subj.isDeleted) {
 			continue
 		}
 
 		for _, versionData := range subj.versions {
-			// Skip soft-deleted versions
-			if versionData.isDeleted {
+			if !del.keep(versionData.isDeleted) {
 				continue
 			}
 
@@ -534,18 +580,20 @@ func (r *Registry) handleCheckSchema(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	del := parseDeleted(req)
+
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	// Check if subject exists and is not soft-deleted
 	subj, ok := r.subjects[subject]
-	if !ok || subj.isDeleted {
+	if !ok || (subj.isDeleted && !del.any()) {
 		r.handleAPIError(w, errSubjectNotFound(subject))
 		return
 	}
 
 	for v, versionData := range subj.versions {
-		if versionData.isDeleted || !r.schemasEqual(versionData.schema.Schema, body) {
+		if !del.keep(versionData.isDeleted) || !r.schemasEqual(versionData.schema.Schema, body) {
 			continue
 		}
 		resp := map[string]any{
@@ -671,7 +719,9 @@ func (r *Registry) handleGetMode(w http.ResponseWriter, _ *http.Request) {
 	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": r.globalMode})
 }
 
-// handlePutMode emulates PUT /mode and sets the global mode.
+// handlePutMode emulates PUT /mode and sets the global mode. The ?force query
+// parameter is accepted but not enforced: the mock does not restrict setting
+// IMPORT mode on a non-empty registry.
 func (r *Registry) handlePutMode(w http.ResponseWriter, req *http.Request) {
 	req.Body = http.MaxBytesReader(w, req.Body, 1<<10)
 	var body struct {
@@ -708,6 +758,7 @@ func (r *Registry) handleGetSubjectMode(w http.ResponseWriter, req *http.Request
 }
 
 // handlePutSubjectMode emulates PUT /mode/{subject} and sets a per-subject mode.
+// As with the global setter, ?force is accepted but not enforced.
 func (r *Registry) handlePutSubjectMode(w http.ResponseWriter, req *http.Request) {
 	req.Body = http.MaxBytesReader(w, req.Body, 1<<10)
 	subject := req.PathValue("subject")

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -380,7 +380,7 @@ func (r *Registry) SetMode(subject string, m sr.Mode) error {
 
 // GetSchema retrieves a schema by subject and version.
 func (r *Registry) GetSchema(subject string, version int) (sr.SubjectSchema, bool) {
-	return r.getSchemaBySubjectVersion(subject, version)
+	return r.getSchemaBySubjectVersion(subject, version, false)
 }
 
 // SubjectExists returns true if subject exists and has not been hard-deleted.
@@ -403,19 +403,36 @@ func (r *Registry) Reset() {
 	r.globalCompat = sr.CompatBackward
 }
 
-// getSchemaBySubjectVersionLocked is like getSchemaBySubjectVersion but assumes caller holds lock
-func (r *Registry) getSchemaBySubjectVersionLocked(subject string, version int) (sr.SubjectSchema, bool) {
+// getSchemaBySubjectVersionLocked is like getSchemaBySubjectVersion but assumes
+// caller holds lock. If includeDeleted is true, soft-deleted subjects/versions
+// are returned (matching the ?deleted=true query parameter).
+func (r *Registry) getSchemaBySubjectVersionLocked(subject string, version int, includeDeleted bool) (sr.SubjectSchema, bool) {
 	subj, ok := r.subjects[subject]
-	if !ok || subj.isDeleted {
+	if !ok || (subj.isDeleted && !includeDeleted) {
 		return sr.SubjectSchema{}, false
 	}
 
 	versionData, ok := subj.versions[version]
-	if !ok || versionData.isDeleted {
+	if !ok || (versionData.isDeleted && !includeDeleted) {
 		return sr.SubjectSchema{}, false
 	}
 
 	return versionData.schema, true
+}
+
+// schemaIDInSubjectLocked reports whether schema id is registered under subject.
+// Caller must hold the lock.
+func (r *Registry) schemaIDInSubjectLocked(id int, subject string) bool {
+	subj, ok := r.subjects[subject]
+	if !ok {
+		return false
+	}
+	for _, vd := range subj.versions {
+		if vd.schema.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // isSchemaReferenced checks if the given schema version is referenced by any other schemas.
@@ -521,7 +538,7 @@ func (r *Registry) deleteVersion(subject string, version int, permanent bool) er
 	return nil
 }
 
-func (r *Registry) resolveVersion(subject, versionStr string) (int, error) {
+func (r *Registry) resolveVersion(subject, versionStr string, includeDeleted bool) (int, error) {
 	if versionStr == "latest" {
 		r.mu.RLock()
 		defer r.mu.RUnlock()
@@ -532,8 +549,12 @@ func (r *Registry) resolveVersion(subject, versionStr string) (int, error) {
 			return 0, errSubjectNotFound(subject)
 		}
 		if subj.latestVersion == 0 {
-			// Subject exists but has no active versions - for "latest" requests,
-			// this should be treated as "subject not found" per Confluent API behavior
+			// No active versions. With ?deleted=true, fall back to the highest
+			// ever-assigned version (which is soft-deleted); otherwise treat as
+			// not found, per Confluent API behavior.
+			if includeDeleted && subj.highestVersion > 0 {
+				return subj.highestVersion, nil
+			}
 			return 0, errSubjectNotFound(subject)
 		}
 		return subj.latestVersion, nil
@@ -545,11 +566,11 @@ func (r *Registry) resolveVersion(subject, versionStr string) (int, error) {
 	return v, nil
 }
 
-func (r *Registry) getSchemaBySubjectVersion(subject string, version int) (sr.SubjectSchema, bool) {
+func (r *Registry) getSchemaBySubjectVersion(subject string, version int, includeDeleted bool) (sr.SubjectSchema, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return r.getSchemaBySubjectVersionLocked(subject, version)
+	return r.getSchemaBySubjectVersionLocked(subject, version, includeDeleted)
 }
 
 func (*Registry) schemasEqual(a, b sr.Schema) bool {

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -36,6 +36,7 @@ type subjectData struct {
 	highestVersion int                    // The highest version number ever assigned (persists through deletes to prevent reuse)
 	isDeleted      bool                   // Whether the subject is soft-deleted
 	compatLevel    *sr.CompatibilityLevel // Pointer to distinguish "not set" from a zero-value
+	mode           *sr.Mode               // Pointer to distinguish "not set" from a zero-value
 }
 
 // recalculateLatestVersion updates the latestVersion field to the highest
@@ -78,6 +79,7 @@ type Registry struct {
 
 	// Global/unrelated state
 	globalCompat sr.CompatibilityLevel
+	globalMode   sr.Mode
 
 	// middleware
 	expectedAuth string
@@ -112,6 +114,7 @@ func NewRegistry(opts ...Option) *Registry {
 		schemasByID:  make(map[int]sr.Schema),
 		nextID:       1,
 		globalCompat: sr.CompatBackward,
+		globalMode:   sr.ModeReadWrite,
 	}
 
 	for _, opt := range opts {
@@ -153,8 +156,12 @@ func NewRegistry(opts ...Option) *Registry {
 	mux.HandleFunc("GET /contexts", r.handleGetContexts)
 	mux.HandleFunc("DELETE /contexts/{context}", r.handleDeleteContext)
 
-	// mode route
+	// mode routes (global and per-subject)
 	mux.HandleFunc("GET /mode", r.handleGetMode)
+	mux.HandleFunc("PUT /mode", r.handlePutMode)
+	mux.HandleFunc("GET /mode/{subject}", r.handleGetSubjectMode)
+	mux.HandleFunc("PUT /mode/{subject}", r.handlePutSubjectMode)
+	mux.HandleFunc("DELETE /mode/{subject}", r.handleDeleteSubjectMode)
 
 	var h http.Handler = mux
 	h = r.contextMiddleware(h)
@@ -355,6 +362,19 @@ func (r *Registry) SetCompat(subject string, c sr.CompatibilityLevel) error {
 	subj := r.getOrCreateSubject(subject)
 
 	subj.compatLevel = &c
+	return nil
+}
+
+// SetMode sets the per-subject mode override, creating the subject if needed.
+func (r *Registry) SetMode(subject string, m sr.Mode) error {
+	if m.String() == "" {
+		return fmt.Errorf("invalid mode")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	subj := r.getOrCreateSubject(subject)
+	subj.mode = &m
 	return nil
 }
 

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -121,6 +121,7 @@ func NewRegistry(opts ...Option) *Registry {
 	mux := http.NewServeMux()
 
 	// schema routes
+	mux.HandleFunc("GET /schemas", r.handleGetSchemas)
 	mux.HandleFunc("GET /schemas/ids/{id}", r.handleGetSchemaByID)
 	mux.HandleFunc("GET /schemas/ids/{id}/schema", r.handleGetRawSchemaByID)
 	mux.HandleFunc("GET /schemas/ids/{id}/versions", r.handleGetSchemaVersionsByID)
@@ -144,8 +145,9 @@ func NewRegistry(opts ...Option) *Registry {
 	mux.HandleFunc("PUT /config/{subject}", r.handlePutSubjectConfig)
 	mux.HandleFunc("DELETE /config/{subject}", r.handleDeleteSubjectConfig)
 
-	// compatibility route
+	// compatibility routes (against one version, or against all versions)
 	mux.HandleFunc("POST /compatibility/subjects/{subject}/versions/{version}", r.handleCheckCompatibility)
+	mux.HandleFunc("POST /compatibility/subjects/{subject}/versions", r.handleCheckCompatibility)
 
 	// context routes (standalone endpoints, not subject to prefix stripping)
 	mux.HandleFunc("GET /contexts", r.handleGetContexts)

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -403,6 +403,66 @@ func TestCheckCompatibilityAllVersions(t *testing.T) {
 	}
 }
 
+func TestModeGlobal(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// Default global mode is READWRITE.
+	got := cl.Mode(ctx)
+	if len(got) != 1 || got[0].Err != nil || got[0].Mode != sr.ModeReadWrite {
+		t.Fatalf("default global mode: %+v", got)
+	}
+
+	// Set then read it back.
+	set := cl.SetMode(ctx, sr.ModeReadOnly)
+	if len(set) != 1 || set[0].Err != nil || set[0].Mode != sr.ModeReadOnly {
+		t.Fatalf("set global mode: %+v", set)
+	}
+	if got = cl.Mode(ctx); got[0].Mode != sr.ModeReadOnly {
+		t.Fatalf("global mode after set = %v, want READONLY", got[0].Mode)
+	}
+}
+
+func TestModeSubject(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	reg.SeedSchema("user-value", 1, 1, userSchema)
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// With no subject override, it falls back to the global mode.
+	got := cl.Mode(ctx, "user-value")
+	if got[0].Err != nil || got[0].Mode != sr.ModeReadWrite {
+		t.Fatalf("subject mode fallback: %+v", got)
+	}
+
+	// Set a per-subject override.
+	set := cl.SetMode(ctx, sr.ModeReadOnly, "user-value")
+	if set[0].Err != nil || set[0].Mode != sr.ModeReadOnly {
+		t.Fatalf("set subject mode: %+v", set)
+	}
+	if got = cl.Mode(ctx, "user-value"); got[0].Mode != sr.ModeReadOnly {
+		t.Fatalf("subject mode after set = %v, want READONLY", got[0].Mode)
+	}
+
+	// Reset reverts to the global default.
+	rst := cl.ResetMode(ctx, "user-value")
+	if len(rst) != 1 || rst[0].Err != nil {
+		t.Fatalf("reset subject mode: %+v", rst)
+	}
+	if got = cl.Mode(ctx, "user-value"); got[0].Mode != sr.ModeReadWrite {
+		t.Fatalf("subject mode after reset = %v, want READWRITE (global)", got[0].Mode)
+	}
+}
+
 func TestSchemaHandlers(t *testing.T) {
 	reg := srfake.New()
 	t.Cleanup(reg.Close)

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -350,6 +350,59 @@ func TestSubjectHandlers(t *testing.T) {
 	}
 }
 
+func TestGetAllSchemas(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	reg.SeedSchema("user-value", 1, 1, userSchema)
+	reg.SeedSchema("user-value", 2, 2, userSchemaV2)
+	reg.SeedSchema("product-value", 1, 3, productSchema)
+
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	all, err := cl.AllSchemas(ctx)
+	if err != nil {
+		t.Fatalf("AllSchemas: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("AllSchemas: got %d schemas, want 3", len(all))
+	}
+	// Sorted by subject then version.
+	if all[0].Subject != "product-value" || all[1].Subject != "user-value" || all[1].Version != 1 || all[2].Version != 2 {
+		t.Errorf("AllSchemas unexpected ordering: %+v", all)
+	}
+
+	latest, err := cl.AllSchemas(sr.WithParams(ctx, sr.LatestOnly))
+	if err != nil {
+		t.Fatalf("AllSchemas(latestOnly): %v", err)
+	}
+	if len(latest) != 2 {
+		t.Fatalf("AllSchemas(latestOnly): got %d, want 2 (one per subject)", len(latest))
+	}
+}
+
+func TestCheckCompatibilityAllVersions(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	reg.SeedSchema("user-value", 1, 1, userSchema)
+
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Version -2 posts to /compatibility/subjects/{subject}/versions (all versions).
+	res, err := cl.CheckCompatibility(context.Background(), "user-value", -2, userSchemaV2)
+	if err != nil {
+		t.Fatalf("CheckCompatibility(all versions): %v", err)
+	}
+	if !res.Is {
+		t.Fatal("want is_compatible true")
+	}
+}
+
 func TestSchemaHandlers(t *testing.T) {
 	reg := srfake.New()
 	t.Cleanup(reg.Close)

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -463,6 +463,83 @@ func TestModeSubject(t *testing.T) {
 	}
 }
 
+func TestDeletedQueryParams(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	if _, err := cl.CreateSchema(ctx, "user-value", userSchema); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cl.CreateSchema(ctx, "user-value", userSchemaV2); err != nil {
+		t.Fatal(err)
+	}
+	// Soft-delete version 1.
+	if err := cl.DeleteSchema(ctx, "user-value", 1, sr.SoftDelete); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+
+	eq := func(name string, got []int, want ...int) {
+		t.Helper()
+		if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+			t.Errorf("%s = %v, want %v", name, got, want)
+		}
+	}
+
+	// Default: only active versions.
+	v, err := cl.SubjectVersions(ctx, "user-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq("default versions", v, 2)
+
+	// deleted=true: active + soft-deleted.
+	v, err = cl.SubjectVersions(sr.WithParams(ctx, sr.ShowDeleted), "user-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq("deleted versions", v, 1, 2)
+
+	// deletedOnly=true: only soft-deleted.
+	v, err = cl.SubjectVersions(sr.WithParams(ctx, sr.DeletedOnly), "user-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	eq("deletedOnly versions", v, 1)
+
+	// A soft-deleted version is hidden by default, visible with deleted=true.
+	if _, err := cl.SchemaByVersion(ctx, "user-value", 1); err == nil {
+		t.Error("expected soft-deleted version 1 to be hidden by default")
+	}
+	if _, err := cl.SchemaByVersion(sr.WithParams(ctx, sr.ShowDeleted), "user-value", 1); err != nil {
+		t.Errorf("expected soft-deleted version 1 visible with deleted=true: %v", err)
+	}
+}
+
+func TestSubjectQueryParamOnSchemaByID(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	reg.SeedSchema("user-value", 1, 1, userSchema)
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// Scoped to the owning subject: found.
+	if _, err := cl.SchemaByID(sr.WithParams(ctx, sr.Subject("user-value")), 1); err != nil {
+		t.Errorf("SchemaByID scoped to owning subject: %v", err)
+	}
+	// Scoped to a different subject: not found.
+	if _, err := cl.SchemaByID(sr.WithParams(ctx, sr.Subject("other-value")), 1); err == nil {
+		t.Error("expected SchemaByID scoped to a non-owning subject to fail")
+	}
+}
+
 func TestSchemaHandlers(t *testing.T) {
 	reg := srfake.New()
 	t.Cleanup(reg.Close)


### PR DESCRIPTION
Expands `srfake`'s coverage of the Confluent Schema Registry REST API to
everything `sr.Client` exercises that the mock was missing. Shapes and
parameters were checked against the Confluent API reference / source.

### `GET /schemas`
Returns every schema across all subjects and versions (what
`sr.Client.AllSchemas` calls). Honors `subjectPrefix`, `deleted`, `deletedOnly`,
and `latestOnly`; sorted by subject then version. Elements are `SubjectSchema`
(`subject`/`version`/`id`/`schemaType`/`schema`/`references`).

### All-versions compatibility
Adds `POST /compatibility/subjects/{subject}/versions` (no version in path),
which `sr.Client.CheckCompatibility` issues for version `-2`. Reuses the
existing (permissive) compatibility handler.

### Full mode API
Mode is now stateful (default global `READWRITE`, per-subject overrides stored
like compatibility levels):

- `PUT /mode` — set the global mode.
- `GET /mode/{subject}` — subject override, falling back to global unless
  `defaultToGlobal=false`.
- `PUT /mode/{subject}` — set a per-subject mode (also via a new exported
  `SetMode` helper, mirroring `SetCompat`).
- `DELETE /mode/{subject}` — clear an override, returning the removed mode.

### Query parameters: `deleted`, `deletedOnly`, `subject`
Endpoints that previously accepted-and-ignored these now honor them:

- `deleted` / `deletedOnly` on `GET /subjects`, `GET /subjects/{subject}/versions`,
  `GET /schemas/ids/{id}/subjects`, `GET /schemas/ids/{id}/versions`,
  `POST /subjects/{subject}` (lookup), and the per-version GETs
  (`/versions/{version}`, `…/schema`, `…/referencedby`) — so soft-deleted
  entities can be listed and fetched. A shared `deletedFilter` centralizes the
  semantics (`deletedOnly` ⇒ only deleted; `deleted` ⇒ active + deleted; neither
  ⇒ active only).
- `subject` on `GET /schemas/ids/{id}` and `/schema` (scope the id lookup to a
  subject) and the two `GET /schemas/ids/{id}/{subjects,versions}` listings.

All wire shapes follow the Confluent API (`{"mode":"..."}`, the `Schema` entity
field names, `{"is_compatible":...}`). Tests added for `AllSchemas` (incl.
`latestOnly`), all-versions compatibility, mode (global + per-subject
get/set/reset), `deleted`/`deletedOnly` filtering, and subject-scoped id lookup;
the full `srfake` suite passes.

### Deliberate non-goals
- Compatibility checking remains a permissive stub (always `is_compatible:
  true`) — this only adds the missing route with the correct shape, matching the
  existing single-version handler. Tests needing an incompatible verdict can use
  the existing `Intercept` hook.
- `force` on the mode setters is accepted but not enforced (the mock does not
  restrict `IMPORT` on a non-empty registry).
- `format`, `fetchMaxId`, `normalize`, and `verbose` remain no-ops — honoring
  them would require real-server transforms or only add empty fields.
