### PR TITLE
kgo: do not requeue offset loads after the session is canceled

### DIFF
--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -3308,3 +3308,67 @@ func TestIssue1328(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+func TestIssue1349(t *testing.T) {
+	t.Parallel()
+	const testTopic = "foo"
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// Every ListOffsets fails with a reloadable error, so the group member can
+	// never finish loading its start offset and keeps scheduling reloads.
+	c.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		req := kreq.(*kmsg.ListOffsetsRequest)
+		resp := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+		for _, reqTopic := range req.Topics {
+			rt := kmsg.NewListOffsetsResponseTopic()
+			rt.Topic = reqTopic.Topic
+			for _, reqPart := range reqTopic.Partitions {
+				rp := kmsg.NewListOffsetsResponseTopicPartition()
+				rp.Partition = reqPart.Partition
+				rp.ErrorCode = kerr.NotLeaderForPartition.Code
+				rt.Partitions = append(rt.Partitions, rp)
+			}
+			resp.Topics = append(resp.Topics, rt)
+		}
+		return resp, nil, true
+	})
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.ConsumerGroup("g"),
+		kgo.ConsumeTopics(testTopic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.MetadataMinAge(time.Minute),
+		kgo.MetadataMaxAge(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Join the group and start the failing offset load.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	cl.PollFetches(ctx)
+	cancel()
+
+	// Close leaves the group, cancelling the session while an offset load is
+	// outstanding. It must return rather than busy looping reloads.
+	done := make(chan struct{})
+	go func() {
+		cl.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Close hung leaving the group with an outstanding offset load")
+	}
+}

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1980,12 +1980,17 @@ func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool, 
 				// add things back to the session, we could abandon
 				// loading these offsets and have a stuck cursor.
 				defer s.decWorker()
-				defer reloads.loadWithSession(s, "reload offsets from load failure")
 				after := time.NewTimer(time.Second)
 				defer after.Stop()
 				select {
 				case <-after.C:
+					reloads.loadWithSession(s, "reload offsets from load failure")
 				case <-s.ctx.Done():
+					// Session is stopping; do not requeue. Requeuing here
+					// would skip the backoff above and immediately spawn a
+					// new listOrEpoch whose context is also already
+					// canceled, busy looping until the session is torn
+					// down. The session stop path manages waiting loads.
 					return
 				}
 			}()


### PR DESCRIPTION
Fixes #1349.

`(*consumerSession).listOrEpoch` requeued a failed offset load from an unconditional `defer`:

```go
defer s.decWorker()
defer reloads.loadWithSession(s, "reload offsets from load failure")
after := time.NewTimer(time.Second)
defer after.Stop()
select {
case <-after.C:
case <-s.ctx.Done():
    return
}
```

When the session context is canceled (group leave during `Close`), the select returns at once but the deferred `loadWithSession` still requeues the load. The requeued `listOrEpoch` runs with the same canceled context, fails, and requeues again with no backoff. The busy loop keeps a session worker alive, so `stopSession` never sees `workers == 0` and `Close` hangs.

This regressed in 6c7aab5, which removed the session-context early return from the drain loop. Before that, a canceled session returned before `reloads` was populated.

The fix only requeues when the backoff timer fires and returns without requeuing once the session context is done. Added `TestIssue1349` in kfake, which hangs without the fix.
