### PR TITLE
kgo: fix data race on coordinatorLoad.node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+v1.22.0
+===
+
+* Fixed a data race on a coordinator's cached node ID. When a broker
+  disconnected while a `FindCoordinator` load for that broker was still in
+  flight, `deleteStaleCoordinatorsByNode` could read the in-flight load's
+  `node` field before the loading goroutine published it (via closing the
+  load's wait channel), which `go test -race` flagged. The node read now
+  happens only after the load has been observed as complete.
+
 v1.21.4
 ===
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -2225,13 +2225,35 @@ func (cl *Client) deleteStaleCoordinatorsByNode(node int32) {
 	cl.coordinatorsMu.Lock()
 	defer cl.coordinatorsMu.Unlock()
 	for k, v := range cl.coordinators {
-		if v == nil || v.node != node {
+		if v == nil {
 			continue
 		}
+		// v.node is written by doLoadCoordinators outside of
+		// coordinatorsMu; that write is published only by the
+		// close(loadWait) ending the load. We must observe the close
+		// before reading v.node, so the v.node check lives inside the
+		// loadWait arm -- not in the range filter above.
+		//
+		// Race walkthrough if we checked v.node before the select:
+		//   1) doLoadCoordinators inserts v with an open loadWait, then
+		//      releases coordinatorsMu and issues FindCoordinator.
+		//   2) The response arrives and the loader writes v.node =
+		//      rc.NodeID, lock-free (doLoadCoordinators, above).
+		//   3) Concurrently a broker disconnect calls us here. We hold
+		//      coordinatorsMu, but the writer in step 2 never takes it,
+		//      so the mutex does not order us against that write --
+		//      reading v.node now is a data race (go test -race flags
+		//      it). close(loadWait) in step 2 has not happened yet, so
+		//      the default arm is what we would take anyway.
+		// Reading inside the loadWait arm makes the read happen-after
+		// the publishing close, so v.node is safe to observe.
 		select {
 		case <-v.loadWait:
-			delete(cl.coordinators, k)
+			if v.node == node {
+				delete(cl.coordinators, k)
+			}
 		default:
+			// Still loading: v.node is not yet published; skip.
 		}
 	}
 }

--- a/pkg/kgo/coordinator_race_test.go
+++ b/pkg/kgo/coordinator_race_test.go
@@ -1,0 +1,57 @@
+package kgo
+
+import (
+	"sync"
+	"testing"
+)
+
+// Regression test for issue #1353: a data race on coordinatorLoad.node
+// between doLoadCoordinators (the loader) and deleteStaleCoordinatorsByNode.
+//
+// doLoadCoordinators inserts a coordinatorLoad into cl.coordinators with an
+// open loadWait, releases coordinatorsMu, then -- lock-free -- writes c.node
+// from the FindCoordinator response and publishes that write by closing
+// loadWait. deleteStaleCoordinatorsByNode runs under coordinatorsMu, but the
+// mutex does not order it against the lock-free node write: before the fix it
+// read v.node in the range filter, before observing close(loadWait), which is
+// a genuine data race.
+//
+// This test recreates exactly that interleaving: a loader goroutine writes
+// c.node then closes loadWait, racing a deleteStaleCoordinatorsByNode call.
+// Under `go test -race` the pre-fix code reports a race; the fixed code, which
+// only reads v.node inside the `case <-v.loadWait` arm, does not.
+func TestDeleteStaleCoordinatorsByNodeNoRace(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 300
+	for i := 0; i < iterations; i++ {
+		cl := &Client{coordinators: make(map[coordinatorKey]*coordinatorLoad)}
+
+		loadWait := make(chan struct{})
+		c := &coordinatorLoad{loadWait: loadWait}
+		cl.coordinators[coordinatorKey{"group", coordinatorTypeGroup}] = c
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Loader: write node lock-free, then publish via close(loadWait),
+		// exactly as doLoadCoordinators does.
+		go func() {
+			defer wg.Done()
+			<-start
+			c.node = 1
+			close(loadWait)
+		}()
+
+		// Concurrent stale-deletion as a broker disconnect would trigger.
+		go func() {
+			defer wg.Done()
+			<-start
+			cl.deleteStaleCoordinatorsByNode(1)
+		}()
+
+		close(start) // release both goroutines together to maximize overlap
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a data race on `coordinatorLoad.node` between `doLoadCoordinators` and `deleteStaleCoordinatorsByNode` (issue #1353).

`doLoadCoordinators` writes a `coordinatorLoad`'s `node` field outside of `coordinatorsMu` and publishes that write by closing the load's `loadWait` channel. `deleteStaleCoordinatorsByNode` holds `coordinatorsMu`, but it read `v.node` in its range filter **before** observing `close(loadWait)`. When a broker disconnect triggers `deleteStaleCoordinatorsByNode` while a `FindCoordinator` load for that broker is still in flight, the filter read races the lock-free `node` write of the in-flight load. `go test -race` flags it.

## Fix

Move the `v.node == node` check **inside** the `case <-v.loadWait:` arm so the read happens-after the publishing `close`. This matches the existing singular `deleteStaleCoordinator`, which already only reads after the `loadWait` check. Behavior is unchanged: completed entries for the node are deleted, in-flight loads are skipped.

A WHY-comment with the event-sequence walkthrough is included per the `pkg/kgo/CLAUDE.md` house rule for subtle-race fixes.

## Test

`pkg/kgo/coordinator_race_test.go` seeds `cl.coordinators` with an open-`loadWait` entry and races a `c.node` write + `close(loadWait)` against `deleteStaleCoordinatorsByNode`. It reports `WARNING: DATA RACE` on the pre-fix code and passes under `go test -race` with the fix.

## Verification

- `go build`, `go vet`, `gofmt -l` — clean
- New regression test fails (DATA RACE) on pre-fix code, passes with the fix under `-race`

Closes #1353

@twmb