### PR TITLE
kgo: add nil check when loading topics in groupConsumer

### DIFF
--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -1927,7 +1927,9 @@ start:
 		}
 		reqTopic := kmsg.NewOffsetFetchRequestGroupTopic()
 		reqTopic.Topic = topic
-		reqTopic.TopicID = groupTopics.loadTopic(topic).id
+		if td := groupTopics.loadTopic(topic); td != nil {
+			reqTopic.TopicID = td.id
+		}
 		if reqTopic.TopicID == ([16]byte{}) {
 			pinV9 = true
 		}


### PR DESCRIPTION
This was removed here: https://github.com/twmb/franz-go/commit/62388b4b84b413e3650974e8cca4d3869167d222#diff-6431ddbe3825dc29fea7d488b4767c32c552edea39a929370d7c303a7b2705d2L1687

This is not easy to reproduce, but it can panic and it does for me:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x58 pc=0x102cbe34c]

goroutine 256 [running]:
github.com/twmb/franz-go/pkg/kgo.(*groupConsumer).fetchOffsets(0x22e96b718000, {0x1043f1430, 0x22e96b3bc3c0}, 0x22e96b57af60)
        go/pkg/mod/github.com/twmb/franz-go@v1.21.4/pkg/kgo/consumer_group.go:1930 +0x36c
github.com/twmb/franz-go/pkg/kgo.(*groupConsumer).setupAssignedAndHeartbeat.func3()
        go/pkg/mod/github.com/twmb/franz-go@v1.21.4/pkg/kgo/consumer_group.go:1082 +0x6c
created by github.com/twmb/franz-go/pkg/kgo.(*groupConsumer).setupAssignedAndHeartbeat in goroutine 40
        go/pkg/mod/github.com/twmb/franz-go@v1.21.4/pkg/kgo/consumer_group.go:1079 +0x3d4
```