### PR TITLE
kgo: fix 848 stranding a regex topic assigned before metadata catches up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,36 @@
+v1.21.6
+===
+
+One bug fix:
+
+* Fixed a KIP-848 consumer stranding a regex-matched topic that was created
+  after the member joined. With server-side regex, the broker resolves the
+  pattern itself and can assign a newly-created topic via heartbeat before the
+  client's metadata loop has evaluated the regex and added the topic to its own
+  subscription. Two client paths then dropped the just-assigned topic -- the
+  end-of-session self-revoke and the `OffsetFetch` response validation. Because
+  the broker believed the client owned the topic, it never re-sent the
+  assignment, so the partition sat without a cursor and was never consumed. The
+  client now trusts the server's assignment for 848 in both paths. Classic and
+  share groups drive their own subscription, so the broker never assigns them a
+  live topic they have not subscribed to; they are unaffected.
+
+## Relevant commits
+
+- [`9b92299f`](https://github.com/twmb/franz-go/commit/9b92299f) **bugfix** kgo: fix 848 stranding a regex topic assigned before metadata catches up
+
 v1.21.5
 ===
 
 Three bug fixes:
 
 * Fixed a nil-pointer panic when building a group `OffsetFetch`: if the group
-  was assigned a topic the client was not itself tracking -- reachable when
-  regex consuming, or when the group hands the client a topic it did not ask
-  for (unlikely) -- `loadTopic` returned nil and dereferencing it for the topic
-  ID crashed the client. The topic ID is now only set when the topic is known.
-  Thanks [@iwittkau](https://github.com/iwittkau)!
+  was assigned a topic that was no longer in the client's tracked set --
+  reachable when a topic is purged from consuming while still assigned, for
+  example `PurgeTopicsFromConsuming` overlapping `AddConsumeTopics`, or the
+  automatic regex missing-topic purge -- `loadTopic` returned nil and
+  dereferencing it for the topic ID crashed the client. The topic ID is now
+  only set when the topic is known. Thanks [@iwittkau](https://github.com/iwittkau)!
 
 * Fixed a data race on a coordinator's cached node ID. When a broker
   disconnected while a `FindCoordinator` load for that broker was still in

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -775,8 +775,26 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 		// which causes a new metadata request -- in short, this could
 		// be concurrent with a metadata findNewAssignments, so we
 		// lock.
+		//
+		// For 848 the server owns assignment: nowAssigned only holds
+		// what the server currently wants us to own (handleResp already
+		// dropped anything the server revoked), while g.using is filled
+		// asynchronously by the metadata regex evaluation. When a new
+		// regex-matched topic is created, the server can assign it via
+		// heartbeat before our metadata loop has added it to g.using:
+		// the heartbeat exits this session with the topic in nowAssigned
+		// but the metadata goroutine has not yet run findNewAssignments.
+		// Self-revoking on (nowAssigned - g.using) here would then drop
+		// that just-assigned topic, and because the server still
+		// believes we own it (we echoed its topic id), it never re-sends
+		// -- stranding the topic permanently. Skip the self-revoke for
+		// 848 and let the server drive all revocation through heartbeats.
 		g.nowAssigned.write(func(nowAssigned map[string][]int32) {
 			g.mu.Lock()
+			defer g.mu.Unlock()
+			if g.is848 {
+				return
+			}
 			for topic, partitions := range nowAssigned {
 				if _, exists := g.using[topic]; !exists {
 					if lost == nil {
@@ -786,7 +804,6 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 					delete(nowAssigned, topic)
 				}
 			}
-			g.mu.Unlock()
 		})
 	}
 
@@ -2141,8 +2158,48 @@ start:
 	// groupTopics was already loaded above to populate reqTopic.TopicID;
 	// reuse that snapshot so we validate against the same view that
 	// built the request.
+	//
+	// wanted reports whether a topic in the response is one we actually
+	// want to assign. Normally this is our subscription snapshot
+	// (groupTopics). `added` (what we built the request from) can diverge
+	// from that snapshot, but the meaning of the divergence differs by
+	// protocol, so we only trust `added` for 848:
+	//
+	//   - Classic: the client drives its own subscription (g.using feeds
+	//     JoinGroup, and g.using never leads g.tps because g.tps is stored
+	//     before findNewAssignments runs), so an assigned topic stays in
+	//     g.tps -- unless it is purged after assignment. That purge is
+	//     either an explicit PurgeTopicsFromConsuming/PurgeTopicsFromClient
+	//     call (e.g. #1355, where it overlapped AddConsumeTopics) or the
+	//     automatic regex missing-topic purge. In every case the topic is
+	//     being removed, so dropping it is correct; the nil guard above
+	//     just stops #1355's crash, and the drop here is the right result.
+	//
+	//   - 848: the server resolves the regex itself and can assign a live,
+	//     newly-created topic via heartbeat before our metadata loop has
+	//     added it to g.tps. Dropping it leaves the partition without a
+	//     cursor while the server believes we own it (we echoed its id
+	//     back), so it never re-sends -- stranding the topic. It is in
+	//     `added` (we requested it), so we keep it.
+	//
+	// `added` is precisely "what we requested", so a topic a buggy broker
+	// invents (neither subscribed nor requested) is still dropped -- the
+	// #1271 protection.
+	g.mu.Lock()
+	is848 := g.is848
+	g.mu.Unlock()
+	wanted := func(topic string) bool {
+		if groupTopics.hasTopic(topic) {
+			return true
+		}
+		if is848 {
+			_, ok := added[topic]
+			return ok
+		}
+		return false
+	}
 	for fetchedTopic, topicOffsets := range offsets {
-		if !groupTopics.hasTopic(fetchedTopic) {
+		if !wanted(fetchedTopic) {
 			delete(offsets, fetchedTopic)
 			g.cfg.logger.Log(LogLevelWarn, "member was assigned topic that we did not ask for in ConsumeTopics! skipping assigning this topic!", "group", g.cfg.group, "topic", fetchedTopic)
 			continue
@@ -2181,7 +2238,7 @@ start:
 	// above.
 	var omitted mtmps
 	for topic, partitions := range added {
-		if !groupTopics.hasTopic(topic) {
+		if !wanted(topic) {
 			continue // already warned and skipped above
 		}
 		topicOffsets := offsets[topic]


### PR DESCRIPTION
## Problem

`Test848TopicCreatedAfterJoin` intermittently timed out in CI (`got 0/10`): a KIP-848 regex consumer never received records from a topic created after it joined. Not a flake -- a real race that permanently strands the topic.

With **server-side regex**, the broker resolves the pattern itself and can assign a newly-created matching topic via heartbeat **before** the client's metadata loop has evaluated the regex and added the topic to the client-side subscription (`g.using` / `g.tps`). Two client paths then dropped the just-assigned topic, and because the server believes the client owns it (its topic id is echoed back), it never re-sends -- the partition sits without a cursor and is never consumed.

A load harness reproduced it deterministically-enough to capture debug logs and pin both drop sites:

- **`revoke(revokeThisSession)`** self-revoked `nowAssigned` topics missing from `g.using`.
- **`fetchOffsets`** dropped `OffsetFetch` response topics missing from the `g.tps` subscription snapshot.

## Fix

Trust the server's assignment for 848 in both paths (gated on `is848`):

- Skip the session-end self-revoke; let the server drive revocation via heartbeats.
- Validate the `OffsetFetch` response against `added` (what the request was built from) instead of the possibly-lagging subscription snapshot. The per-topic/per-partition checks against `added` are unchanged, so the #1271 buggy-broker protection holds.

## Why classic and share groups are unaffected

- **Classic** drives its own subscription (`g.using` feeds JoinGroup and never leads `g.tps`), so `nowAssigned` only diverges from `g.tps` when a topic is *purged* after assignment -- there the topic is genuinely gone and dropping it is correct. The gate is deliberate, not just conservative: trusting `added` for classic would wrongly keep a purged topic.
- **Share groups** send resolved `SubscribedTopicNames`, never server-side regex, so the broker never assigns a topic the client hasn't already subscribed to by name.

## Verification

- Load harness: failed at iteration 302 unfixed; **7597 iterations clean** with the fix.
- `Test848*` pass under `-race`; full kfake package passes `-race`.

Also corrects the v1.21.5 CHANGELOG note for the #1355 `OffsetFetch` nil-panic: that was not from regex consuming but from a topic purged while still assigned (`PurgeTopicsFromConsuming` overlapping `AddConsumeTopics`).