### PR TITLE
Fable audit rounds 1-5: kgo, kadm, and protocol-definition fixes

### DIFF
--- a/.github/workflows/validate-definitions.yml
+++ b/.github/workflows/validate-definitions.yml
@@ -9,6 +9,12 @@ on:
     branches: ["*"]
     paths:
       - 'generate/**'
+  # A new Kafka release moves the latest-tag checkout, so run on a schedule
+  # too: without this, a release that adds request versions produces no
+  # signal until someone happens to touch generate/ (Kafka 4.3 went
+  # unnoticed exactly this way).
+  schedule:
+    - cron: '0 8 * * 1'
 
 concurrency:
   group: validate-definitions-${{ github.ref }}

--- a/pkg/kadm/acls.go
+++ b/pkg/kadm/acls.go
@@ -699,11 +699,15 @@ func (cl *Client) CreateACLs(ctx context.Context, b *ACLBuilder) (CreateACLsResu
 	if pattern == ACLPatternUnknown {
 		pattern = ACLPatternLiteral
 	}
-	if len(b.allow) != 0 && len(b.allowHosts) == 0 {
-		b.allowHosts = []string{"*"}
+	// Default unset hosts to the wildcard in LOCALS: writing the default
+	// back into the builder is an observable side effect on reuse (a later
+	// AllowHosts-less filter call would inherit the create's wildcard).
+	allowHosts, denyHosts := b.allowHosts, b.denyHosts
+	if len(b.allow) != 0 && len(allowHosts) == 0 {
+		allowHosts = []string{"*"}
 	}
-	if len(b.deny) != 0 && len(b.denyHosts) == 0 {
-		b.denyHosts = []string{"*"}
+	if len(b.deny) != 0 && len(denyHosts) == 0 {
+		denyHosts = []string{"*"}
 	}
 
 	var clusters []string
@@ -729,8 +733,8 @@ func (cl *Client) CreateACLs(ctx context.Context, b *ACLBuilder) (CreateACLsResu
 					hosts      []string
 					permType   kmsg.ACLPermissionType
 				}{
-					{b.allow, b.allowHosts, kmsg.ACLPermissionTypeAllow},
-					{b.deny, b.denyHosts, kmsg.ACLPermissionTypeDeny},
+					{b.allow, allowHosts, kmsg.ACLPermissionTypeAllow},
+					{b.deny, denyHosts, kmsg.ACLPermissionTypeDeny},
 				} {
 					for _, principal := range perm.principals {
 						for _, host := range perm.hosts {

--- a/pkg/kadm/acls.go
+++ b/pkg/kadm/acls.go
@@ -113,9 +113,7 @@ func NewACLs() *ACLBuilder {
 // This function does nothing for creating.
 func (b *ACLBuilder) AnyResource(name ...string) *ACLBuilder {
 	b.any = name
-	if len(name) == 0 {
-		b.anyResource = true
-	}
+	b.anyResource = len(name) == 0 // set OR clear: the last call wins
 	return b
 }
 
@@ -129,15 +127,13 @@ func (b *ACLBuilder) AnyResource(name ...string) *ACLBuilder {
 // function does nothing.
 func (b *ACLBuilder) Topics(t ...string) *ACLBuilder {
 	b.topics = t
-	if len(t) == 0 {
-		b.anyTopic = true
-	}
+	b.anyTopic = len(t) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeTopics is the same as Topics, but does not match all topics if none are
 // provided.
-func (b *ACLBuilder) MaybeTopics(t ...string) *ACLBuilder { b.topics = t; return b }
+func (b *ACLBuilder) MaybeTopics(t ...string) *ACLBuilder { b.topics = t; b.anyTopic = false; return b }
 
 // Groups lists/deletes/creates ACLs of resource type "group" for the given
 // groups.
@@ -149,15 +145,13 @@ func (b *ACLBuilder) MaybeTopics(t ...string) *ACLBuilder { b.topics = t; return
 // function does nothing.
 func (b *ACLBuilder) Groups(g ...string) *ACLBuilder {
 	b.groups = g
-	if len(g) == 0 {
-		b.anyGroup = true
-	}
+	b.anyGroup = len(g) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeGroups is the same as Groups, but does not match all groups if none are
 // provided.
-func (b *ACLBuilder) MaybeGroups(g ...string) *ACLBuilder { b.groups = g; return b }
+func (b *ACLBuilder) MaybeGroups(g ...string) *ACLBuilder { b.groups = g; b.anyGroup = false; return b }
 
 // Clusters lists/deletes/creates ACLs of resource type "cluster".
 //
@@ -185,15 +179,17 @@ func (b *ACLBuilder) MaybeClusters(c bool) *ACLBuilder { b.anyCluster = c; retur
 // function does nothing.
 func (b *ACLBuilder) TransactionalIDs(x ...string) *ACLBuilder {
 	b.txnIDs = x
-	if len(x) == 0 {
-		b.anyTxn = true
-	}
+	b.anyTxn = len(x) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeTransactionalIDs is the same as TransactionalIDs, but does not match
 // all transactional ID's if none are provided.
-func (b *ACLBuilder) MaybeTransactionalIDs(x ...string) *ACLBuilder { b.txnIDs = x; return b }
+func (b *ACLBuilder) MaybeTransactionalIDs(x ...string) *ACLBuilder {
+	b.txnIDs = x
+	b.anyTxn = false
+	return b
+}
 
 // DelegationTokens lists/deletes/creates ACLs of resource type
 // "delegation_token" for the given delegation tokens.
@@ -205,15 +201,17 @@ func (b *ACLBuilder) MaybeTransactionalIDs(x ...string) *ACLBuilder { b.txnIDs =
 // tokens are provided, this function does nothing.
 func (b *ACLBuilder) DelegationTokens(t ...string) *ACLBuilder {
 	b.tokens = t
-	if len(t) == 0 {
-		b.anyToken = true
-	}
+	b.anyToken = len(t) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeDelegationTokens is the same as DelegationTokens, but does not match
 // all tokens if none are provided.
-func (b *ACLBuilder) MaybeDelegationTokens(t ...string) *ACLBuilder { b.tokens = t; return b }
+func (b *ACLBuilder) MaybeDelegationTokens(t ...string) *ACLBuilder {
+	b.tokens = t
+	b.anyToken = false
+	return b
+}
 
 // Allow sets the principals to add allow permissions for. For listing and
 // deleting, you must also use AllowHosts.
@@ -226,15 +224,17 @@ func (b *ACLBuilder) MaybeDelegationTokens(t ...string) *ACLBuilder { b.tokens =
 // For listing & deleting, if the principals are empty, this matches any user.
 func (b *ACLBuilder) Allow(principals ...string) *ACLBuilder {
 	b.allow = principals
-	if len(principals) == 0 {
-		b.anyAllow = true
-	}
+	b.anyAllow = len(principals) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeAllow is the same as Allow, but does not match all allowed principals
 // if none are provided.
-func (b *ACLBuilder) MaybeAllow(principals ...string) *ACLBuilder { b.allow = principals; return b }
+func (b *ACLBuilder) MaybeAllow(principals ...string) *ACLBuilder {
+	b.allow = principals
+	b.anyAllow = false
+	return b
+}
 
 // AllowHosts sets the hosts to add allow permissions for. If using this, you
 // must also use Allow.
@@ -247,15 +247,17 @@ func (b *ACLBuilder) MaybeAllow(principals ...string) *ACLBuilder { b.allow = pr
 // For listing & deleting, if the hosts are empty, this matches any host.
 func (b *ACLBuilder) AllowHosts(hosts ...string) *ACLBuilder {
 	b.allowHosts = hosts
-	if len(hosts) == 0 {
-		b.anyAllowHosts = true
-	}
+	b.anyAllowHosts = len(hosts) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeAllowHosts is the same as AllowHosts, but does not match all allowed
 // hosts if none are provided.
-func (b *ACLBuilder) MaybeAllowHosts(hosts ...string) *ACLBuilder { b.allowHosts = hosts; return b }
+func (b *ACLBuilder) MaybeAllowHosts(hosts ...string) *ACLBuilder {
+	b.allowHosts = hosts
+	b.anyAllowHosts = false
+	return b
+}
 
 // Deny sets the principals to add deny permissions for. For listing and
 // deleting, you must also use DenyHosts.
@@ -268,15 +270,17 @@ func (b *ACLBuilder) MaybeAllowHosts(hosts ...string) *ACLBuilder { b.allowHosts
 // For listing & deleting, if the principals are empty, this matches any user.
 func (b *ACLBuilder) Deny(principals ...string) *ACLBuilder {
 	b.deny = principals
-	if len(principals) == 0 {
-		b.anyDeny = true
-	}
+	b.anyDeny = len(principals) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeDeny is the same as Deny, but does not match all denied principals if
 // none are provided.
-func (b *ACLBuilder) MaybeDeny(principals ...string) *ACLBuilder { b.deny = principals; return b }
+func (b *ACLBuilder) MaybeDeny(principals ...string) *ACLBuilder {
+	b.deny = principals
+	b.anyDeny = false
+	return b
+}
 
 // DenyHosts sets the hosts to add deny permissions for. If using this, you
 // must also use Deny.
@@ -289,15 +293,17 @@ func (b *ACLBuilder) MaybeDeny(principals ...string) *ACLBuilder { b.deny = prin
 // For listing & deleting, if the hosts are empty, this matches any host.
 func (b *ACLBuilder) DenyHosts(hosts ...string) *ACLBuilder {
 	b.denyHosts = hosts
-	if len(hosts) == 0 {
-		b.anyDenyHosts = true
-	}
+	b.anyDenyHosts = len(hosts) == 0 // set OR clear: the last call wins
 	return b
 }
 
 // MaybeDenyHosts is the same as DenyHosts, but does not match all denied
 // hosts if none are provided.
-func (b *ACLBuilder) MaybeDenyHosts(hosts ...string) *ACLBuilder { b.denyHosts = hosts; return b }
+func (b *ACLBuilder) MaybeDenyHosts(hosts ...string) *ACLBuilder {
+	b.denyHosts = hosts
+	b.anyDenyHosts = false
+	return b
+}
 
 // ACLOperation is a type alias for kmsg.ACLOperation, which is an enum
 // containing all Kafka ACL operations and has helper functions.
@@ -546,8 +552,13 @@ func (b *ACLBuilder) ValidateCreate() error {
 
 	switch b.pattern {
 	case ACLPatternLiteral, ACLPatternPrefixed:
+	case ACLPatternUnknown: // unset; defaulted to literal at build time, per the ACLPattern docs
 	default:
 		return fmt.Errorf("invalid acl resource pattern %s for creating ACLs", b.pattern)
+	}
+
+	if len(b.ops) == 0 {
+		return fmt.Errorf("invalid empty operations for creating ACLs: Operations must be called")
 	}
 
 	if len(b.allowHosts) != 0 && len(b.allow) == 0 {
@@ -681,6 +692,13 @@ func (cl *Client) CreateACLs(ctx context.Context, b *ACLBuilder) (CreateACLsResu
 	if err := b.ValidateCreate(); err != nil {
 		return nil, err
 	}
+	// Per the ACLPattern docs, literal is the default pattern. An unset
+	// pattern previously failed ValidateCreate outright, forcing every
+	// caller to spell out the documented default.
+	pattern := b.pattern
+	if pattern == ACLPatternUnknown {
+		pattern = ACLPatternLiteral
+	}
 	if len(b.allow) != 0 && len(b.allowHosts) == 0 {
 		b.allowHosts = []string{"*"}
 	}
@@ -719,7 +737,7 @@ func (cl *Client) CreateACLs(ctx context.Context, b *ACLBuilder) (CreateACLsResu
 							c := kmsg.NewCreateACLsRequestCreation()
 							c.ResourceType = typeNames.t
 							c.ResourceName = name
-							c.ResourcePatternType = b.pattern
+							c.ResourcePatternType = pattern
 							c.Operation = op
 							c.Principal = principal
 							c.Host = host
@@ -995,6 +1013,23 @@ func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.De
 		return nil, nil, err
 	}
 
+	// The builder's unset-means-any philosophy applies to the pattern and
+	// the operations as well. An unset pattern was previously sent as
+	// UNKNOWN (the zero value), which conformant brokers reject when
+	// parsing the request -- every describe or delete from a builder that
+	// never called ResourcePatternType failed against a real broker
+	// (kfake historically did not validate the pattern, hiding this).
+	// Unset operations previously generated ZERO filters, silently doing
+	// nothing and returning no error.
+	pattern := b.pattern
+	if pattern == ACLPatternUnknown {
+		pattern = ACLPatternAny
+	}
+	ops := b.ops
+	if len(ops) == 0 {
+		ops = []ACLOperation{OpAny}
+	}
+
 	// As a special shortcut, if we have any allow and deny principals and
 	// hosts, we collapse these into one "any" group. The anyAny and
 	// anyAnyHosts vars are used in our looping below, and if we do this,
@@ -1038,7 +1073,7 @@ func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.De
 			typeNames.names = sliceAny
 		}
 		for _, name := range typeNames.names {
-			for _, op := range b.ops {
+			for _, op := range ops {
 				for _, perm := range []struct {
 					principals   []string
 					anyPrincipal bool
@@ -1087,8 +1122,8 @@ func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.De
 								describe.ResourceName = kmsg.StringPtr(name)
 							}
 
-							deletion.ResourcePatternType = b.pattern
-							describe.ResourcePatternType = b.pattern
+							deletion.ResourcePatternType = pattern
+							describe.ResourcePatternType = pattern
 
 							deletion.Operation = op
 							describe.Operation = op

--- a/pkg/kadm/audit_test.go
+++ b/pkg/kadm/audit_test.go
@@ -1,0 +1,136 @@
+package kadm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// An ACL filter builder that never sets the pattern or operations must
+// default both to "any" (the builder's unset-means-any philosophy); it
+// previously sent pattern UNKNOWN(0) -- rejected by real brokers at request
+// parse -- and generated ZERO filters for unset operations, silently doing
+// nothing.
+func TestACLBuilderFilterDefaults(t *testing.T) {
+	b := NewACLs().Topics("a").Allow().AllowHosts().Deny().DenyHosts()
+	dels, descs, err := createDelDescACL(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dels) != 1 || len(descs) != 1 {
+		t.Fatalf("got %d deletions, %d describes, want 1 and 1", len(dels), len(descs))
+	}
+	if got := dels[0].ResourcePatternType; got != kmsg.ACLResourcePatternTypeAny {
+		t.Errorf("deletion pattern %v, want ANY", got)
+	}
+	if got := descs[0].ResourcePatternType; got != kmsg.ACLResourcePatternTypeAny {
+		t.Errorf("describe pattern %v, want ANY", got)
+	}
+	if got := dels[0].Operation; got != kmsg.ACLOperationAny {
+		t.Errorf("deletion operation %v, want ANY", got)
+	}
+	if dels[0].ResourceName == nil || *dels[0].ResourceName != "a" {
+		t.Errorf("deletion resource name %v, want a", dels[0].ResourceName)
+	}
+}
+
+// Builder list setters must be last-call-wins: an empty call previously set
+// a sticky any-flag that a later call with names did not clear, silently
+// broadening delete filters to ALL names of that resource type.
+func TestACLBuilderLastCallWins(t *testing.T) {
+	b := NewACLs().Topics().Topics("a").Allow().Allow("User:x").AllowHosts().Deny().DenyHosts()
+	dels, _, err := createDelDescACL(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range dels {
+		if d.ResourceName == nil || *d.ResourceName != "a" {
+			t.Errorf("deletion resource name %v, want a (any-topic flag was sticky)", d.ResourceName)
+		}
+	}
+	var explicitPrincipal bool
+	for _, d := range dels {
+		if d.Principal != nil && *d.Principal == "User:x" {
+			explicitPrincipal = true
+		}
+		if d.PermissionType == kmsg.ACLPermissionTypeAllow && d.Principal == nil {
+			t.Error("allow filter has any principal; the any-allow flag was sticky")
+		}
+	}
+	if !explicitPrincipal {
+		t.Error("no filter carries the explicitly allowed principal")
+	}
+}
+
+func TestValidateCreateDefaults(t *testing.T) {
+	b := NewACLs().Topics("a").Allow("User:x")
+	if err := b.ValidateCreate(); err == nil {
+		t.Error("expected an error for creating with no operations")
+	}
+	b.Operations(OpRead)
+	if err := b.ValidateCreate(); err != nil {
+		t.Errorf("unset pattern should validate (defaults to literal): %v", err)
+	}
+}
+
+// shardErrEachBroker must record response-level errors from the callback:
+// kgo deliberately strips retry-exhausted response errors from shard.Err so
+// callers can parse the ErrorCode, and dropping what the callback found made
+// broadcast list APIs return silently short results with a nil error.
+func TestShardErrEachBrokerRecordsResponseErrors(t *testing.T) {
+	req := kmsg.NewPtrListGroupsRequest()
+	shards := []kgo.ResponseShard{{
+		Meta: kgo.BrokerMetadata{NodeID: 1},
+		Req:  req,
+		Resp: kmsg.NewPtrListGroupsResponse(),
+	}}
+
+	err := shardErrEachBroker(req, shards, func(BrokerDetail, kmsg.Response) error {
+		return kerr.CoordinatorLoadInProgress
+	})
+	var se *ShardErrors
+	if !errors.As(err, &se) {
+		t.Fatalf("got %v, want ShardErrors", err)
+	}
+	if len(se.Errs) != 1 || !errors.Is(se.Errs[0].Err, kerr.CoordinatorLoadInProgress) {
+		t.Fatalf("got %v, want one CoordinatorLoadInProgress shard error", se.Errs)
+	}
+	if !se.AllFailed {
+		t.Error("AllFailed false with every shard errored")
+	}
+
+	// Auth errors still return immediately as *AuthError.
+	autherr := &AuthError{Err: kerr.GroupAuthorizationFailed}
+	err = shardErrEachBroker(req, shards, func(BrokerDetail, kmsg.Response) error {
+		return autherr
+	})
+	var ae *AuthError
+	if !errors.As(err, &ae) {
+		t.Fatalf("got %v, want AuthError", err)
+	}
+}
+
+// mergeShardErrs must not lose a non-ShardErrors error: a first-round
+// AuthError followed by an error-free rerequest round previously merged to
+// nil, reporting partial results as clean.
+func TestMergeShardErrs(t *testing.T) {
+	ae := &AuthError{Err: kerr.GroupAuthorizationFailed}
+	if got := mergeShardErrs(ae, nil); got != error(ae) {
+		t.Errorf("merge(auth, nil) = %v, want the auth error", got)
+	}
+	se := &ShardErrors{Errs: []ShardError{{}}}
+	if got := mergeShardErrs(nil, se); got != error(se) {
+		t.Errorf("merge(nil, se) = %v, want the shard errors", got)
+	}
+	merged := mergeShardErrs(
+		&ShardErrors{Errs: []ShardError{{}}},
+		&ShardErrors{Errs: []ShardError{{}}},
+	)
+	var mse *ShardErrors
+	if !errors.As(merged, &mse) || len(mse.Errs) != 2 {
+		t.Errorf("merge(se, se) = %v, want two merged shard errors", merged)
+	}
+}

--- a/pkg/kadm/audit_test.go
+++ b/pkg/kadm/audit_test.go
@@ -1,6 +1,7 @@
 package kadm
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -132,5 +133,34 @@ func TestMergeShardErrs(t *testing.T) {
 	var mse *ShardErrors
 	if !errors.As(merged, &mse) || len(mse.Errs) != 2 {
 		t.Errorf("merge(se, se) = %v, want two merged shard errors", merged)
+	}
+}
+
+// Duplicate requested types must not duplicate results (the inner loop
+// previously continued instead of breaking).
+func TestFilterTypesNoDuplicates(t *testing.T) {
+	l := ListedConfigResources{Resources: []ConfigResource{{Type: kmsg.ConfigResourceTypeTopic, Name: "a"}}}
+	got := l.FilterTypes(kmsg.ConfigResourceTypeTopic, kmsg.ConfigResourceTypeTopic)
+	if len(got) != 1 {
+		t.Errorf("got %d results, want 1", len(got))
+	}
+}
+
+// FetchOffsetsForTopics previously filtered the caller's variadic slice in
+// place, rewriting its backing array.
+func TestFetchOffsetsForTopicsDoesNotMutateInput(t *testing.T) {
+	cl, err := kgo.NewClient(kgo.SeedBrokers("localhost:1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	adm := NewClient(cl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	topics := []string{FetchAllGroupTopics, "a", "b"}
+	adm.FetchOffsetsForTopics(ctx, "g", topics...) //nolint:errcheck // the canceled ctx fails the call; we assert only non-mutation
+	if topics[0] != FetchAllGroupTopics || topics[1] != "a" || topics[2] != "b" {
+		t.Errorf("caller slice was mutated: %v", topics)
 	}
 }

--- a/pkg/kadm/configs.go
+++ b/pkg/kadm/configs.go
@@ -462,7 +462,7 @@ func (l ListedConfigResources) FilterTypes(resourceType ...ConfigResourceType) [
 		for _, typ := range resourceType {
 			if r.Type == typ {
 				filtered = append(filtered, r)
-				continue
+				break // duplicate requested types must not duplicate results
 			}
 		}
 	}

--- a/pkg/kadm/dtoken.go
+++ b/pkg/kadm/dtoken.go
@@ -84,13 +84,21 @@ type CreateDelegationToken struct {
 // This can return *AuthError.
 func (cl *Client) CreateDelegationToken(ctx context.Context, d CreateDelegationToken) (DelegationToken, error) {
 	req := kmsg.NewPtrCreateDelegationTokenRequest()
+	// The Principal docs promise an empty Type defaults to "User".
+	principalType := func(t string) string {
+		if t == "" {
+			return "User"
+		}
+		return t
+	}
 	if d.Owner != nil {
-		req.OwnerPrincipalType = &d.Owner.Type
+		ownerType := principalType(d.Owner.Type)
+		req.OwnerPrincipalType = &ownerType
 		req.OwnerPrincipalName = &d.Owner.Name
 	}
 	for _, renewer := range d.Renewers {
 		rr := kmsg.NewCreateDelegationTokenRequestRenewer()
-		rr.PrincipalType = renewer.Type
+		rr.PrincipalType = principalType(renewer.Type)
 		rr.PrincipalName = renewer.Name
 		req.Renewers = append(req.Renewers, rr)
 	}

--- a/pkg/kadm/errors.go
+++ b/pkg/kadm/errors.go
@@ -84,8 +84,27 @@ func shardErrEachBroker(req kmsg.Request, shards []kgo.ResponseShard, fn func(Br
 			})
 			continue
 		}
-		if err := fn(shard.Meta, shard.Resp); errors.As(err, &ae) {
-			return ae
+		if err := fn(shard.Meta, shard.Resp); err != nil {
+			if errors.As(err, &ae) {
+				return ae
+			}
+			// A response-level error is a failed shard too. kgo
+			// deliberately strips retry-exhausted response errors
+			// from shard.Err so callers can parse the ErrorCode
+			// themselves; the fn callbacks do exactly that and
+			// return what they find. Dropping the error here made
+			// broadcast list APIs (ListGroups, ListTransactions,
+			// DescribeAllLogDirs) return silently SHORT results
+			// with a nil error whenever one broker answered with,
+			// e.g., COORDINATOR_LOAD_IN_PROGRESS past kgo's retry
+			// budget -- and everything built on those lists
+			// (no-arg Describes, Lag) under-reported with no
+			// signal.
+			se.Errs = append(se.Errs, ShardError{
+				Req:    shard.Req,
+				Err:    err,
+				Broker: shard.Meta,
+			})
 		}
 	}
 	se.AllFailed = len(shards) == len(se.Errs)
@@ -101,12 +120,22 @@ func (se *ShardErrors) into() error {
 
 // Merges two shard errors; the input errors should come from the same request.
 func mergeShardErrs(e1, e2 error) error {
-	var se1, se2 *ShardErrors
-	if !errors.As(e1, &se1) {
+	if e1 == nil {
 		return e2
 	}
-	if !errors.As(e2, &se2) {
+	if e2 == nil {
 		return e1
+	}
+	var se1, se2 *ShardErrors
+	// A non-ShardErrors error (e.g. *AuthError from a first round) must
+	// win, not vanish: returning e2 here previously dropped a round-one
+	// auth error whenever a rerequest round followed with no error of
+	// its own, reporting partial results as clean.
+	if !errors.As(e1, &se1) {
+		return e1
+	}
+	if !errors.As(e2, &se2) {
+		return e2
 	}
 	se1.Errs = append(se1.Errs, se2.Errs...)
 	se1.AllFailed = se1.AllFailed && se2.AllFailed

--- a/pkg/kadm/groups.go
+++ b/pkg/kadm/groups.go
@@ -1060,7 +1060,9 @@ func (cl *Client) FetchOffsetsForTopics(ctx context.Context, group string, topic
 	os := make(Offsets)
 
 	var all bool
-	keept := topics[:0]
+	// Filter into a fresh slice: topics is the caller's variadic slice and
+	// filtering into topics[:0] would rewrite the caller's backing array.
+	keept := make([]string, 0, len(topics))
 	for _, topic := range topics {
 		if topic == FetchAllGroupTopics {
 			all = true
@@ -2619,8 +2621,16 @@ func (cl *Client) CommitOffsetsByID(ctx context.Context, group string, os Offset
 		if topic == "" {
 			topic = id2name[id]
 		}
-		rt := make(map[int32]OffsetResponse)
-		rs[id] = rt
+		// Merge rather than overwrite: if the broker returns a topic we
+		// cannot resolve to an ID (absent from our request mapping), id
+		// stays the zero value; two such topics previously collided on
+		// the zero key and only the last survived. Per-partition Offset
+		// values still carry their topic names.
+		rt := rs[id]
+		if rt == nil {
+			rt = make(map[int32]OffsetResponse)
+			rs[id] = rt
+		}
 		for _, p := range t.Partitions {
 			o, ok := Offset{}, false
 			if ops := os[id]; ops != nil {
@@ -2736,28 +2746,14 @@ func (cl *Client) FetchOffsetsByID(ctx context.Context, group string) (OffsetRes
 		return rs, nil
 	}
 
-	// v0-v7 fallback: resp.Topics only. Convert to group format
-	// for the shared buildPartitions helper.
-	rs := make(OffsetResponsesByID)
-	for _, t := range resp.Topics {
-		gp := make([]kmsg.OffsetFetchResponseGroupTopicPartition, len(t.Partitions))
-		for i, p := range t.Partitions {
-			gp[i] = kmsg.OffsetFetchResponseGroupTopicPartition{
-				Partition:   p.Partition,
-				Offset:      p.Offset,
-				LeaderEpoch: p.LeaderEpoch,
-				Metadata:    p.Metadata,
-				ErrorCode:   p.ErrorCode,
-			}
-		}
-		// v0-v7 has no TopicID; use zero value.
-		rt, err := buildPartitions(t.Topic, TopicID{}, gp)
-		if err != nil {
-			return nil, err
-		}
-		rs[TopicID{}] = rt
-	}
-	return rs, nil
+	// Unreachable defensively: kgo's OffsetFetch sharder synthesizes
+	// resp.Groups from the top-level Topics for v0-v7 responses, so the
+	// group loop above always runs. If we ever do land here, the response
+	// carries topic NAMES only -- there is no ID to key the by-ID result
+	// type with, and the prior code funneled every topic onto the zero
+	// TopicID key, keeping only the last. Fail loudly instead of
+	// returning silently collapsed data.
+	return nil, errors.New("offset fetch response contained no groups and cannot be keyed by topic ID; use FetchOffsets against brokers this old")
 }
 
 ///////////////////

--- a/pkg/kadm/kadm.go
+++ b/pkg/kadm/kadm.go
@@ -153,6 +153,10 @@ func (cl *Client) Close() {
 //	UpdateFeatures
 //
 // Not all requests above are supported in the admin API.
+//
+// This is not safe to call concurrently with in-flight admin requests: the
+// value is read without synchronization while building requests. Set it once
+// after NewClient, before concurrent use.
 func (cl *Client) SetTimeoutMillis(millis int32) {
 	cl.timeoutMillis = millis
 }

--- a/pkg/kadm/metadata.go
+++ b/pkg/kadm/metadata.go
@@ -538,7 +538,15 @@ func (cl *Client) listOffsets(ctx context.Context, isolation int8, timestamp int
 					LeaderEpoch: p.LeaderEpoch,
 					Err:         kerr.ErrorForCode(p.ErrorCode),
 				}
-				if timestamp != -1 && p.Offset == -1 && p.ErrorCode == 0 {
+				// Rerequest only for real by-time listings (their -1 means
+				// "no offset at or after this timestamp"; we return end
+				// offsets, the documented ListOffsetsAfterMilli fallback).
+				// The special negative listings must NOT rerequest: -1 is
+				// their honest answer (an empty partition has no max
+				// timestamp offset; an untiered partition has no remote
+				// offset), and rewriting it with the end offset invents an
+				// answer the broker never gave.
+				if timestamp >= 0 && p.Offset == -1 && p.ErrorCode == 0 {
 					rerequest[t.Topic] = append(rerequest[t.Topic], p.Partition)
 				}
 			}

--- a/pkg/kadm/metadata.go
+++ b/pkg/kadm/metadata.go
@@ -305,8 +305,17 @@ func (cl *Client) metadata(ctx context.Context, noTopics bool, topics []string) 
 	}
 	sort.Slice(m.Brokers, func(i, j int) bool { return m.Brokers[i].NodeID < m.Brokers[j].NodeID })
 
-	if len(topics) > 0 && len(m.Topics) != len(topics) {
-		return Metadata{}, fmt.Errorf("metadata returned only %d topics of %d requested", len(m.Topics), len(topics))
+	// Compare against the UNIQUE requested names: m.Topics is a map, so
+	// duplicate requested topics previously tripped this as a spurious
+	// "returned only N of M" error.
+	if len(topics) > 0 {
+		uniq := make(map[string]struct{}, len(topics))
+		for _, t := range topics {
+			uniq[t] = struct{}{}
+		}
+		if len(m.Topics) != len(uniq) {
+			return Metadata{}, fmt.Errorf("metadata returned only %d topics of %d requested", len(m.Topics), len(uniq))
+		}
 	}
 
 	return m, nil

--- a/pkg/kadm/misc.go
+++ b/pkg/kadm/misc.go
@@ -104,7 +104,8 @@ func (rs FindCoordinatorResponses) Ok() bool {
 
 // FindGroupCoordinators returns the coordinator for all requested group names.
 //
-// This may return *ShardErrors or *AuthError.
+// Failures are reported per key via each response's Err field, which can
+// unwrap to *AuthError.
 func (cl *Client) FindGroupCoordinators(ctx context.Context, groups ...string) FindCoordinatorResponses {
 	return cl.findCoordinators(ctx, 0, groups...)
 }
@@ -112,7 +113,8 @@ func (cl *Client) FindGroupCoordinators(ctx context.Context, groups ...string) F
 // FindTxnCoordinators returns the coordinator for all requested transactional
 // IDs.
 //
-// This may return *ShardErrors or *AuthError.
+// Failures are reported per key via each response's Err field, which can
+// unwrap to *AuthError.
 func (cl *Client) FindTxnCoordinators(ctx context.Context, txnIDs ...string) FindCoordinatorResponses {
 	return cl.findCoordinators(ctx, 1, txnIDs...)
 }
@@ -127,7 +129,8 @@ func (cl *Client) FindTxnCoordinators(ctx context.Context, txnIDs ...string) Fin
 //
 // This requires Kafka 4.2+ (KIP-932).
 //
-// This may return *ShardErrors or *AuthError.
+// Failures are reported per key via each response's Err field, which can
+// unwrap to *AuthError.
 func (cl *Client) FindShareCoordinators(ctx context.Context, shareGroups ...string) FindCoordinatorResponses {
 	return cl.findCoordinators(ctx, 2, shareGroups...)
 }
@@ -732,6 +735,16 @@ func (cl *Client) AlterUserSCRAMs(ctx context.Context, del []DeleteSCRAM, upsert
 		if u.Password != "" {
 			if len(u.Salt) > 0 || len(u.SaltedPassword) > 0 {
 				return nil, fmt.Errorf("user %s: cannot specify both a password and a salt / salted password", u.User)
+			}
+			// Enforce the documented (and broker-enforced) iteration
+			// bounds up front: a zero or tiny count previously produced
+			// a weak pbkdf2 result client-side that only the broker's
+			// own validation caught. Zero defaults to the minimum.
+			if u.Iterations == 0 {
+				u.Iterations = 4096
+			}
+			if u.Iterations < 4096 || u.Iterations > 16384 {
+				return nil, fmt.Errorf("user %s: iterations %d is outside the allowed 4096 to 16384 range", u.User, u.Iterations)
 			}
 			u.Salt = make([]byte, 24)
 			if _, err := rand.Read(u.Salt); err != nil {

--- a/pkg/kadm/misc.go
+++ b/pkg/kadm/misc.go
@@ -731,7 +731,19 @@ func (as AlteredUserSCRAMs) Ok() bool {
 // and deletes. This modifies elements of the upsert slice that need to have a
 // salted password generated.
 func (cl *Client) AlterUserSCRAMs(ctx context.Context, del []DeleteSCRAM, upsert []UpsertSCRAM) (AlteredUserSCRAMs, error) {
+	// Validate mechanisms up front for every input: the zero value would
+	// go on the wire as UNKNOWN, which the broker rejects per-user with
+	// UNSUPPORTED_SASL_MECHANISM. The password-generating path below has
+	// always validated; deletions and salt-based upsertions did not.
+	for _, d := range del {
+		if d.Mechanism != ScramSha256 && d.Mechanism != ScramSha512 {
+			return nil, fmt.Errorf("user %s: unknown deletion mechanism", d.User)
+		}
+	}
 	for i, u := range upsert {
+		if u.Mechanism != ScramSha256 && u.Mechanism != ScramSha512 {
+			return nil, fmt.Errorf("user %s: unknown mechanism", u.User)
+		}
 		if u.Password != "" {
 			if len(u.Salt) > 0 || len(u.SaltedPassword) > 0 {
 				return nil, fmt.Errorf("user %s: cannot specify both a password and a salt / salted password", u.User)

--- a/pkg/kadm/topics.go
+++ b/pkg/kadm/topics.go
@@ -3,6 +3,7 @@ package kadm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -620,6 +621,7 @@ func (cl *Client) createPartitions(ctx context.Context, dry bool, add, set int, 
 		}
 	}
 
+	rs := make(CreatePartitionsResponses)
 	req := kmsg.NewCreatePartitionsRequest()
 	req.TimeoutMillis = cl.timeoutMillis
 	req.ValidateOnly = dry
@@ -629,17 +631,31 @@ func (cl *Client) createPartitions(ctx context.Context, dry bool, add, set int, 
 		if add == -1 {
 			rt.Count = int32(set)
 		} else {
-			rt.Count = int32(len(td[t].Partitions) + add)
+			// Surface metadata failures rather than masking them: a
+			// topic that errored (or was missing) in the listing
+			// previously computed Count = 0 + add, sending a shrink
+			// request whose broker error hid the real cause.
+			d, exists := td[t]
+			switch {
+			case !exists:
+				rs[t] = CreatePartitionsResponse{Topic: t, Err: fmt.Errorf("unable to determine the current partition count: %w", kerr.UnknownTopicOrPartition)}
+				continue
+			case d.Err != nil:
+				rs[t] = CreatePartitionsResponse{Topic: t, Err: fmt.Errorf("unable to determine the current partition count: %w", d.Err)}
+				continue
+			}
+			rt.Count = int32(len(d.Partitions) + add)
 		}
 		req.Topics = append(req.Topics, rt)
+	}
+	if len(req.Topics) == 0 {
+		return rs, nil
 	}
 
 	resp, err := req.RequestWith(ctx, cl.cl)
 	if err != nil {
 		return nil, err
 	}
-
-	rs := make(CreatePartitionsResponses)
 	for _, t := range resp.Topics {
 		rs[t.Topic] = CreatePartitionsResponse{
 			Topic:      t.Topic,

--- a/pkg/kadm/txn.go
+++ b/pkg/kadm/txn.go
@@ -490,6 +490,9 @@ func (ls ListedTransactions) TransactionalIDs() []string {
 // producer.
 //
 // This may return *ShardErrors or *AuthError.
+// Note that filterStates requires brokers to support ListTransactions v1+
+// (Kafka 3.0+): against older brokers the field is not on the wire and the
+// listing is silently UNFILTERED, over-returning transactions.
 func (cl *Client) ListTransactions(ctx context.Context, producerIDs []int64, filterStates []string) (ListedTransactions, error) {
 	return cl.ListTransactionsByTxPattern(ctx, producerIDs, filterStates, "")
 }
@@ -502,6 +505,10 @@ func (cl *Client) ListTransactions(ctx context.Context, producerIDs []int64, fil
 // by transactional ID. This requires Kafka 4.1+.
 //
 // This may return *ShardErrors or *AuthError.
+// The pattern requires ListTransactions v2+ (Kafka 4.1+, KIP-1152) and
+// filterStates requires v1+: against older brokers the fields are not on the
+// wire and the listing is silently UNFILTERED for that dimension,
+// over-returning transactions.
 func (cl *Client) ListTransactionsByTxPattern(ctx context.Context, producerIDs []int64, filterStates []string, txIDPattern string) (ListedTransactions, error) {
 	req := kmsg.NewPtrListTransactionsRequest()
 	req.ProducerIDFilters = producerIDs

--- a/pkg/kfake/18_api_versions.go
+++ b/pkg/kfake/18_api_versions.go
@@ -32,6 +32,17 @@ func (c *Cluster) handleApiVersions(kreq kmsg.Request) (kmsg.Response, error) {
 		resp.ErrorCode = kerr.UnsupportedVersion.Code
 	}
 
+	// v3+ carries the client software name and version; a real broker
+	// validates both against [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])?
+	// and answers INVALID_REQUEST on a mismatch. kgo validates at
+	// NewClient, but raw kmsg users may not; without this, kfake accepted
+	// values every real broker rejects.
+	if resp.ErrorCode == 0 && req.Version >= 3 &&
+		(!validSoftwareNameVersion(req.ClientSoftwareName) || !validSoftwareNameVersion(req.ClientSoftwareVersion)) {
+		resp.ErrorCode = kerr.InvalidRequest.Code
+		return resp, nil
+	}
+
 	// We do not checkReqVersion for ApiVersions; if the client uses a
 	// version larger than we support, we auto-downgrade.
 
@@ -163,4 +174,22 @@ func regKey(key, min, max int16) {
 		MinVersion: min,
 		MaxVersion: max,
 	}
+}
+
+// validSoftwareNameVersion mirrors the broker's ApiVersions validation
+// pattern: non-empty alphanumeric ends with dashes and dots allowed
+// internally.
+func validSoftwareNameVersion(s string) bool {
+	alnum := func(c byte) bool {
+		return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+	}
+	if len(s) == 0 || !alnum(s[0]) || !alnum(s[len(s)-1]) {
+		return false
+	}
+	for i := 1; i < len(s)-1; i++ {
+		if c := s[i]; !alnum(c) && c != '-' && c != '.' {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/kfake/29_describe_acls.go
+++ b/pkg/kfake/29_describe_acls.go
@@ -40,6 +40,12 @@ func (c *Cluster) handleDescribeACLs(creq *clientReq) (kmsg.Response, error) {
 		host:         req.Host,
 	}
 
+	if !filter.validate() {
+		resp.ErrorCode = kerr.InvalidRequest.Code
+		resp.ErrorMessage = kmsg.StringPtr("DescribeAclsRequest contains UNKNOWN elements")
+		return resp, nil
+	}
+
 	matching := c.acls.describe(filter)
 
 	// Group by resource type + name + pattern

--- a/pkg/kfake/31_delete_acls.go
+++ b/pkg/kfake/31_delete_acls.go
@@ -47,6 +47,13 @@ func (c *Cluster) handleDeleteACLs(creq *clientReq) (kmsg.Response, error) {
 			host:         rf.Host,
 		}
 
+		if !filter.validate() {
+			result.ErrorCode = kerr.InvalidRequest.Code
+			result.ErrorMessage = kmsg.StringPtr("DeleteAclsRequest contains UNKNOWN elements")
+			resp.Results = append(resp.Results, result)
+			continue
+		}
+
 		for _, a := range c.acls.delete(filter) {
 			result.MatchingACLs = append(result.MatchingACLs, kmsg.DeleteACLsResponseResultMatchingACL{
 				ResourceType:        a.resourceType,

--- a/pkg/kfake/acl.go
+++ b/pkg/kfake/acl.go
@@ -143,6 +143,17 @@ func (a *clusterACLs) describe(filter aclFilter) []acl {
 	return result
 }
 
+// A real broker rejects describe/delete filters containing UNKNOWN
+// elements when parsing the request (normalizeAndValidate); model that so
+// clients sending zero-value filter fields fail here like they would in
+// production rather than silently matching.
+func (f aclFilter) validate() bool {
+	return f.pattern != kmsg.ACLResourcePatternTypeUnknown &&
+		f.resourceType != kmsg.ACLResourceTypeUnknown &&
+		f.operation != kmsg.ACLOperationUnknown &&
+		f.permission != kmsg.ACLPermissionTypeUnknown
+}
+
 type aclFilter struct {
 	resourceType kmsg.ACLResourceType
 	resourceName *string

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
 )
 
 func TestIssue885(t *testing.T) {
@@ -4013,5 +4014,246 @@ func TestShareGroupIDNotFoundRejoin(t *testing.T) {
 		if ctx.Err() != nil {
 			t.Fatal("share consumer did not resume consuming after rejoining")
 		}
+	}
+}
+
+// reentrantFetchHook re-enters the client from OnFetchRecordUnbuffered.
+// Pre-fix, the hook fired while the poll path held c.mu (and the discard
+// path held c.mu+sessionChangeMu), so a hook calling anything that needs
+// c.mu deadlocked the poll permanently and wedged rebalances and Close
+// behind it. Post-fix, polled-record hooks fire after the locks release.
+type reentrantFetchHook struct {
+	cl    atomic.Pointer[kgo.Client]
+	fired atomic.Int32
+}
+
+func (h *reentrantFetchHook) OnFetchRecordUnbuffered(r *kgo.Record, polled bool) {
+	if !polled {
+		return
+	}
+	if cl := h.cl.Load(); cl != nil {
+		cl.AddConsumeTopics("fetch-hook-reentry-extra") // needs c.mu
+		h.fired.Add(1)
+	}
+}
+
+func TestFetchUnbufferedHookReentrancy(t *testing.T) {
+	t.Parallel()
+	const testTopic = "fetch-hook-reentry"
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	producer, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+	if err := producer.ProduceSync(ctx, kgo.StringRecord("v")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+
+	hook := new(reentrantFetchHook)
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.ConsumeTopics(testTopic),
+		kgo.FetchMaxWait(250*time.Millisecond),
+		kgo.WithHooks(hook),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	hook.cl.Store(cl)
+
+	polled := make(chan struct{})
+	go func() {
+		defer close(polled)
+		for {
+			fs := cl.PollFetches(ctx)
+			if fs.NumRecords() > 0 {
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-polled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("poll deadlocked: OnFetchRecordUnbuffered re-entering the client blocked on c.mu")
+	}
+	if hook.fired.Load() == 0 {
+		t.Fatal("hook never fired; test proved nothing")
+	}
+}
+
+// TestOnDataLossCallbackReentrancy: ProducerOnDataLossDetected used to fire
+// while the partition's recBuf.mu was held; producing to the reported
+// partition from the callback -- the natural reaction -- deadlocked that
+// partition and the sink's response processing forever. Post-fix the
+// callback dispatches on its own goroutine.
+func TestOnDataLossCallbackReentrancy(t *testing.T) {
+	t.Parallel()
+	const testTopic = "on-data-loss-reentry"
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// One-shot: the first produce gets OUT_OF_ORDER_SEQUENCE_NUMBER,
+	// which for a non-transactional producer (stopOnDataLoss unset)
+	// fires the data-loss callback and reloads the producer id.
+	c.ControlKey(0, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		req := kreq.(*kmsg.ProduceRequest)
+		resp := req.ResponseKind().(*kmsg.ProduceResponse)
+		for _, rt := range req.Topics {
+			respt := kmsg.NewProduceResponseTopic()
+			respt.Topic = rt.Topic
+			respt.TopicID = rt.TopicID
+			for _, rp := range rt.Partitions {
+				respp := kmsg.NewProduceResponseTopicPartition()
+				respp.Partition = rp.Partition
+				respp.ErrorCode = kerr.OutOfOrderSequenceNumber.Code
+				respt.Partitions = append(respt.Partitions, respp)
+			}
+			resp.Topics = append(resp.Topics, respt)
+		}
+		return resp, nil, true
+	})
+
+	var cl *kgo.Client
+	hookDone := make(chan error, 1)
+	var hookOnce sync.Once
+	cl, err = kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(testTopic),
+		kgo.ProducerOnDataLossDetected(func(topic string, partition int32) {
+			hookOnce.Do(func() {
+				// Produce to the very partition the callback reports.
+				hookDone <- cl.ProduceSync(ctx, kgo.StringRecord("from-hook")).FirstErr()
+			})
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("v")).FirstErr(); err != nil {
+		t.Fatalf("produce after data-loss retry errored: %v", err)
+	}
+	select {
+	case err := <-hookDone:
+		if err != nil {
+			t.Fatalf("produce from data-loss callback errored: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("data-loss callback deadlocked: producing to the reported partition blocked on recBuf.mu")
+	}
+}
+
+// TestKadmACLDefaultPatternRoundTrip: kadm ACL builders that never call
+// ResourcePatternType used to send pattern UNKNOWN(0) in describe/delete
+// filters -- rejected by real brokers at request parse (kfake now models
+// that) -- and creating without a pattern failed validation despite the
+// docs calling literal the default. Builders that never call Operations
+// generated zero filters, silently doing nothing. Now: create defaults to
+// literal, filters default to any-pattern and any-operation.
+func TestKadmACLDefaultPatternRoundTrip(t *testing.T) {
+	t.Parallel()
+	const testTopic = "kadm-acl-defaults"
+
+	c, err := NewCluster(NumBrokers(1), EnableACLs(), Superuser("PLAIN", "admin", "pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.SASL(plain.Auth{User: "admin", Pass: "pass"}.AsMechanism()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+	adm := kadm.NewClient(cl)
+
+	// Create with pattern unset: defaults to literal per the docs.
+	cb := kadm.NewACLs().Topics(testTopic).Allow("User:alice").AllowHosts().Operations(kadm.OpRead)
+	created, err := adm.CreateACLs(ctx, cb)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	for _, cr := range created {
+		if cr.Err != nil {
+			t.Fatalf("create result errored: %v", cr.Err)
+		}
+	}
+
+	// Describe with pattern AND operations unset: matches any.
+	db := kadm.NewACLs().Topics(testTopic).Allow().AllowHosts().Deny().DenyHosts()
+	described, err := adm.DescribeACLs(ctx, db)
+	if err != nil {
+		t.Fatalf("describe: %v", err)
+	}
+	var found bool
+	for _, dr := range described {
+		if dr.Err != nil {
+			t.Fatalf("describe result errored: %v", dr.Err)
+		}
+		for _, d := range dr.Described {
+			if d.Principal == "User:alice" && d.Name == testTopic {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("created ACL not described: %v", described)
+	}
+
+	// Delete with the same fully-default filter.
+	deleted, err := adm.DeleteACLs(ctx, db)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	var ndeleted int
+	for _, dr := range deleted {
+		if dr.Err != nil {
+			t.Fatalf("delete result errored: %v", dr.Err)
+		}
+		for _, d := range dr.Deleted {
+			if d.Err == nil {
+				ndeleted++
+			}
+		}
+	}
+	if ndeleted != 1 {
+		t.Fatalf("expected exactly 1 deleted ACL, got %d", ndeleted)
 	}
 }

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -821,6 +821,70 @@ func TestTransactionCommit(t *testing.T) {
 	}
 }
 
+// TestTransactSessionEndNeverJoined ensures GroupTransactSession.End returns
+// when the group has never joined. The session consumes a topic that does not
+// exist, so the group manage loop never starts and nothing runs a heartbeat
+// loop. A produce-only End(TryCommit) then commits no offsets; End used to
+// force a heartbeat regardless, blocking forever on a channel with no
+// receiver and no possible revoke/lost escape.
+func TestTransactSessionEndNeverJoined(t *testing.T) {
+	t.Parallel()
+	const produceTopic = "txn-end-never-joined"
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, produceTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	sess, err := kgo.NewGroupTransactSession(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(produceTopic),
+		kgo.TransactionalID("txn-end-never-joined"),
+		kgo.ConsumerGroup("g-txn-end-never-joined"),
+		kgo.ConsumeTopics("topic-that-never-exists"),
+		kgo.FetchMaxWait(250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sess.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := sess.Begin(); err != nil {
+		t.Fatalf("failed to begin transaction: %v", err)
+	}
+	if err := sess.ProduceSync(ctx, kgo.StringRecord("v")).FirstErr(); err != nil {
+		t.Fatalf("failed to produce: %v", err)
+	}
+
+	type endRes struct {
+		committed bool
+		err       error
+	}
+	done := make(chan endRes, 1)
+	go func() {
+		committed, err := sess.End(ctx, kgo.TryCommit)
+		done <- endRes{committed, err}
+	}()
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("End errored: %v", res.err)
+		}
+		if !res.committed {
+			t.Error("expected the produce-only transaction to commit")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("End did not return; the pre-EndTxn heartbeat force hung with no group joined")
+	}
+}
+
 func TestTransactionAbort(t *testing.T) {
 	t.Parallel()
 	const testTopic = "txn-abort-test"

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -3522,3 +3522,496 @@ func TestProduceUnknownFailLimitNotResetByOtherErrors(t *testing.T) {
 		t.Fatal("produce did not fail within 10s; interleaved errors are resetting the unknown-topic fail limit")
 	}
 }
+
+// TestEndTxnUnconfirmedErrorNoSilentJoin: an EndTxn(commit) that fails with
+// an unconfirmed outcome (here UNKNOWN_SERVER_ERROR intercepting the request
+// before the broker processes it) must not leave the client able to silently
+// join the still-ongoing broker transaction. Pre-fix, EndTransaction consumed
+// the client txn state without failing the producer ID: the documented
+// TryAbort retry no-op'd at the !inTxn guard, the next transaction produced
+// at the same pid/epoch into the ongoing transaction, and its commit
+// committed BOTH transactions' records. Post-fix, the producer ID is flagged
+// for reload; the next BeginTransaction re-inits (KIP-360), which bumps the
+// epoch and fence-aborts the ongoing transaction, so a read_committed
+// consumer sees only the second transaction's record.
+func TestEndTxnUnconfirmedErrorNoSilentJoin(t *testing.T) {
+	t.Parallel()
+	const testTopic = "txn-unconfirmed-endtxn"
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// One-shot control: fail the FIRST EndTxn with UNKNOWN_SERVER_ERROR
+	// without kfake ever processing it, leaving the broker-side
+	// transaction ongoing.
+	c.ControlKey(int16(kmsg.EndTxn), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		req := kreq.(*kmsg.EndTxnRequest)
+		resp := req.ResponseKind().(*kmsg.EndTxnResponse)
+		resp.ErrorCode = kerr.UnknownServerError.Code
+		return resp, nil, true
+	})
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(testTopic),
+		kgo.TransactionalID("txn-unconfirmed"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	if err := cl.BeginTransaction(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("txn1")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.EndTransaction(ctx, kgo.TryCommit); err == nil {
+		t.Fatal("expected EndTransaction to fail from the controlled UNKNOWN_SERVER_ERROR")
+	}
+	// The documented recovery: retry as an abort. This is a client-side
+	// no-op (state was consumed), but the producer ID is now flagged for
+	// reload.
+	if err := cl.EndTransaction(ctx, kgo.TryAbort); err != nil {
+		t.Fatalf("abort retry errored: %v", err)
+	}
+
+	if err := cl.BeginTransaction(); err != nil {
+		t.Fatalf("begin after unconfirmed end errored: %v", err)
+	}
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("txn2")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.EndTransaction(ctx, kgo.TryCommit); err != nil {
+		t.Fatalf("second commit errored: %v", err)
+	}
+
+	consumer, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.ConsumeTopics(testTopic),
+		kgo.FetchIsolationLevel(kgo.ReadCommitted()),
+		kgo.FetchMaxWait(250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+
+	// The topic has one partition: if txn1's record were committed it
+	// would arrive before txn2's. Seeing txn2 first proves txn1 aborted.
+	for {
+		fs := consumer.PollFetches(ctx)
+		if errs := fs.Errors(); len(errs) > 0 {
+			t.Fatalf("fetch errors: %v", errs)
+		}
+		var done bool
+		fs.EachRecord(func(r *kgo.Record) {
+			switch string(r.Value) {
+			case "txn1":
+				t.Error("read_committed consumer saw txn1's record; the unconfirmed transaction was silently committed by txn2")
+			case "txn2":
+				done = true
+			}
+		})
+		if done || t.Failed() {
+			break
+		}
+	}
+}
+
+// reentrantDisconnectHook re-enters the client from OnBrokerDisconnect.
+// Hooks are not documented as forbidden from doing this; pre-fix, brokers
+// were stopped while holding the brokersMu write lock, so the re-entry
+// (which read-locks brokersMu) deadlocked Close and every request path.
+type reentrantDisconnectHook struct {
+	cl    atomic.Pointer[kgo.Client]
+	fired atomic.Int32
+}
+
+func (h *reentrantDisconnectHook) OnBrokerDisconnect(kgo.BrokerMetadata, net.Conn) {
+	if cl := h.cl.Load(); cl != nil {
+		cl.DiscoveredBrokers()
+		h.fired.Add(1)
+	}
+}
+
+func TestOnBrokerDisconnectReentrantHook(t *testing.T) {
+	t.Parallel()
+	const testTopic = "hook-reentry"
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	hook := new(reentrantDisconnectHook)
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(testTopic),
+		kgo.WithHooks(hook),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hook.cl.Store(cl)
+
+	// Establish a live connection so Close has something to disconnect.
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("x")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cl.Close()
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close deadlocked: OnBrokerDisconnect hook re-entering the client blocked on brokersMu")
+	}
+	if hook.fired.Load() == 0 {
+		t.Fatal("hook never fired; test proved nothing")
+	}
+}
+
+// TestMetadataZeroPartitionsNoFakeSuccess: a buggy broker or proxy can reply
+// to metadata for an unknown topic with ErrorCode 0 and an empty partition
+// array. Pre-fix, storePartitionsUpdate promised every buffered record for
+// that topic with a NIL error: user promises fired as successes (offset
+// 0..n, producer id 0) for records that were never sent anywhere. Post-fix,
+// the client treats the reply as a retryable unknown-topic failure, bounded
+// by UnknownTopicRetries.
+func TestMetadataZeroPartitionsNoFakeSuccess(t *testing.T) {
+	t.Parallel()
+	const testTopic = "zero-partitions"
+
+	c, err := NewCluster(NumBrokers(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	addr := c.ListenAddrs()[0]
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Every metadata response reports requested topics as existing with
+	// no error and zero partitions.
+	c.ControlKey(int16(kmsg.Metadata), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		req := kreq.(*kmsg.MetadataRequest)
+		resp := req.ResponseKind().(*kmsg.MetadataResponse)
+		b := kmsg.NewMetadataResponseBroker()
+		b.NodeID = 0
+		b.Host = host
+		b.Port = int32(port)
+		resp.Brokers = append(resp.Brokers, b)
+		resp.ControllerID = 0
+		for _, rt := range req.Topics {
+			mt := kmsg.NewMetadataResponseTopic()
+			mt.Topic = rt.Topic
+			mt.ErrorCode = 0
+			resp.Topics = append(resp.Topics, mt)
+		}
+		return resp, nil, true
+	})
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(testTopic),
+		kgo.UnknownTopicRetries(1),
+		kgo.MetadataMinAge(10*time.Millisecond),
+		kgo.MetadataMaxAge(50*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	promised := make(chan error, 1)
+	cl.Produce(context.Background(), kgo.StringRecord("v"), func(_ *kgo.Record, err error) {
+		promised <- err
+	})
+
+	select {
+	case err := <-promised:
+		if err == nil {
+			t.Fatal("record promised with nil error: fabricated success for a record that was never produced")
+		}
+		if !errors.Is(err, kerr.UnknownTopicOrPartition) {
+			t.Fatalf("got %v, want UnknownTopicOrPartition", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("promise did not fire within 10s")
+	}
+}
+
+// TestOffsetFetchTopicIDOldWire: an OffsetFetch built with only TopicIDs,
+// issued by a client that neither produces nor consumes the topic, against
+// a wire version below v10 (no TopicID field on the wire). The sharder must
+// resolve the ID to a name via the metadata cache it just populated;
+// pre-fix it read the unrelated cl.id2t map (only written for
+// produced/consumed topics), sent an empty topic name, and the broker could
+// not match the topic.
+func TestOffsetFetchTopicIDOldWire(t *testing.T) {
+	t.Parallel()
+	const (
+		testTopic = "offset-fetch-by-id"
+		group     = "offset-fetch-by-id-group"
+	)
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	setup, err := kgo.NewClient(kgo.SeedBrokers(c.ListenAddrs()...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer setup.Close()
+
+	// Learn the topic's ID.
+	mreq := kmsg.NewPtrMetadataRequest()
+	mt := kmsg.NewMetadataRequestTopic()
+	mt.Topic = kmsg.StringPtr(testTopic)
+	mreq.Topics = append(mreq.Topics, mt)
+	mresp, err := mreq.RequestWith(ctx, setup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mresp.Topics) != 1 || mresp.Topics[0].ErrorCode != 0 {
+		t.Fatalf("bad metadata response: %v", mresp)
+	}
+	topicID := mresp.Topics[0].TopicID
+
+	// Commit an offset for the group (simple, generation-less commit).
+	oreq := kmsg.NewPtrOffsetCommitRequest()
+	oreq.Group = group
+	ot := kmsg.NewOffsetCommitRequestTopic()
+	ot.Topic = testTopic
+	ot.TopicID = topicID // v10+ matches by TopicID
+	op := kmsg.NewOffsetCommitRequestTopicPartition()
+	op.Partition = 0
+	op.Offset = 3
+	ot.Partitions = append(ot.Partitions, op)
+	oreq.Topics = append(oreq.Topics, ot)
+	oresp, err := oreq.RequestWith(ctx, setup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec := oresp.Topics[0].Partitions[0].ErrorCode; ec != 0 {
+		t.Fatalf("offset commit failed with code %d", ec)
+	}
+
+	// A fresh client (empty id2t: it produces and consumes nothing),
+	// pinned below OffsetFetch v10 so the topic NAME is what matters on
+	// the wire.
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.MaxVersions(kversion.V3_5_0()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	freq := kmsg.NewPtrOffsetFetchRequest()
+	fg := kmsg.NewOffsetFetchRequestGroup()
+	fg.Group = group
+	ft := kmsg.NewOffsetFetchRequestGroupTopic()
+	ft.TopicID = topicID
+	ft.Partitions = []int32{0}
+	fg.Topics = append(fg.Topics, ft)
+	freq.Groups = append(freq.Groups, fg)
+
+	fresp, err := freq.RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, g := range fresp.Groups {
+		for _, rt := range g.Topics {
+			for _, rp := range rt.Partitions {
+				if rt.Topic == testTopic && rp.Partition == 0 && rp.Offset == 3 {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("committed offset not returned; the request went out without a resolved topic name: %v", fresp)
+	}
+}
+
+// TestShareGroupIDNotFoundRejoin: if share group state vanishes under a live
+// member (coordinator state loss), every heartbeat at the member's current
+// epoch returns GROUP_ID_NOT_FOUND, and the broker only recreates a share
+// group on a member-epoch 0 heartbeat. The client must reset to epoch 0 and
+// rejoin; pre-fix it retried the same epoch forever and never healed.
+func TestShareGroupIDNotFoundRejoin(t *testing.T) {
+	t.Parallel()
+	const (
+		testTopic = "share-gid-not-found"
+		group     = "share-gid-not-found-group"
+	)
+
+	c, err := NewCluster(
+		NumBrokers(1),
+		SeedTopics(1, testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	producer, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic(testTopic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+
+	// Share groups default share.auto.offset.reset to latest; set earliest
+	// so the consumer sees the record produced before it joined.
+	acreq := kmsg.NewPtrIncrementalAlterConfigsRequest()
+	acres := kmsg.NewIncrementalAlterConfigsRequestResource()
+	acres.ResourceType = kmsg.ConfigResourceTypeGroupConfig
+	acres.ResourceName = group
+	accfg := kmsg.NewIncrementalAlterConfigsRequestResourceConfig()
+	accfg.Name = "share.auto.offset.reset"
+	accfg.Op = 0
+	accfg.Value = kmsg.StringPtr("earliest")
+	acres.Configs = append(acres.Configs, accfg)
+	acreq.Resources = append(acreq.Resources, acres)
+	acresp, err := acreq.RequestWith(ctx, producer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ec := acresp.Resources[0].ErrorCode; ec != 0 {
+		t.Fatalf("alter group config failed with code %d", ec)
+	}
+
+	if err := producer.ProduceSync(ctx, kgo.StringRecord("r1")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.ConsumeTopics(testTopic),
+		kgo.ShareGroup(group),
+		kgo.FetchMaxWait(250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	// Wait until the member is established (it received a record).
+	for {
+		fs := cl.PollFetches(ctx)
+		if fs.NumRecords() > 0 {
+			break
+		}
+		if ctx.Err() != nil {
+			t.Fatal("share consumer never received the first record")
+		}
+	}
+
+	// Simulate group state loss: every heartbeat at a live epoch gets
+	// GROUP_ID_NOT_FOUND until an epoch-0 (re)join arrives; the join
+	// passes through to kfake (which still has the group and re-admits
+	// the member) and ends the fencing, modeling the broker recreating
+	// the group.
+	rejoined := make(chan struct{})
+	var healed atomic.Bool
+	c.ControlKey(int16(kmsg.ShareGroupHeartbeat), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		if healed.Load() {
+			return nil, nil, false
+		}
+		req := kreq.(*kmsg.ShareGroupHeartbeatRequest)
+		if req.MemberEpoch > 0 {
+			resp := req.ResponseKind().(*kmsg.ShareGroupHeartbeatResponse)
+			resp.ErrorCode = kerr.GroupIDNotFound.Code
+			return resp, nil, true
+		}
+		if req.MemberEpoch == 0 && healed.CompareAndSwap(false, true) {
+			close(rejoined)
+		}
+		return nil, nil, false
+	})
+
+	select {
+	case <-rejoined:
+	case <-time.After(10 * time.Second):
+		t.Fatal("share consumer never reset to epoch 0 after GROUP_ID_NOT_FOUND; it cannot heal")
+	}
+
+	// Let the pre-reset in-flight ShareFetch drain before producing:
+	// that fetch was sent on the OLD (reset) session and can park
+	// broker-side for up to FetchMaxWait; if r2 lands in that window,
+	// the broker delivers it on the stale fetch, the client's
+	// mid-flight-reset guard discards the data (by design: its acks
+	// could not ride the new session), and r2 sits acquisition-locked
+	// for the full lock duration -- an unrelated, deliberate behavior
+	// that would mask what this test asserts. Two FetchMaxWaits bounds
+	// the drain deterministically.
+	time.Sleep(500 * time.Millisecond)
+
+	// The member rejoined; prove the group is functional again.
+	if err := producer.ProduceSync(ctx, kgo.StringRecord("r2")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		fs := cl.PollFetches(ctx)
+		var got bool
+		fs.EachRecord(func(r *kgo.Record) {
+			if string(r.Value) == "r2" {
+				got = true
+			}
+		})
+		if got {
+			break
+		}
+		if ctx.Err() != nil {
+			t.Fatal("share consumer did not resume consuming after rejoining")
+		}
+	}
+}

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -4257,3 +4257,45 @@ func TestKadmACLDefaultPatternRoundTrip(t *testing.T) {
 		t.Fatalf("expected exactly 1 deleted ACL, got %d", ndeleted)
 	}
 }
+
+// A real broker validates the ApiVersions v3+ client software name/version
+// and answers INVALID_REQUEST on a mismatch; kfake accepting anything made
+// franz-go's tests blind to clients sending invalid values.
+func TestApiVersionsSoftwareNameValidation(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewCluster(NumBrokers(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cl, err := kgo.NewClient(kgo.SeedBrokers(c.ListenAddrs()...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	req := kmsg.NewPtrApiVersionsRequest()
+	req.ClientSoftwareName = "bad name" // space: invalid
+	req.ClientSoftwareVersion = "1.0.0"
+	resp, err := req.RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ErrorCode != kerr.InvalidRequest.Code {
+		t.Errorf("got error code %d, want INVALID_REQUEST", resp.ErrorCode)
+	}
+
+	req.ClientSoftwareName = "good-name"
+	resp, err = req.RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ErrorCode != 0 {
+		t.Errorf("got error code %d for a valid name, want 0", resp.ErrorCode)
+	}
+}

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -6,6 +6,7 @@ import (
 	"hash/crc32"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -4297,5 +4298,177 @@ func TestApiVersionsSoftwareNameValidation(t *testing.T) {
 	}
 	if resp.ErrorCode != 0 {
 		t.Errorf("got error code %d for a valid name, want 0", resp.ErrorCode)
+	}
+}
+
+// An EndTxn whose outcome is unconfirmed (transport error, retries exhausted,
+// or UNKNOWN_SERVER_ERROR) restores the client's transaction state so the
+// documented retry with TryAbort heals immediately: the retry reloads the
+// producer ID, whose epoch bump fence-aborts anything still ongoing broker
+// side, and sends no second EndTxn. Previously the retry was a silent no-op
+// and the broker transaction lingered until the next transaction began (or
+// the transaction timeout fired), stalling read_committed consumers.
+func TestEndTxnUnconfirmedAbortRetry(t *testing.T) {
+	t.Parallel()
+	const topic = "txn-unconfirmed-abort"
+
+	c, err := NewCluster(NumBrokers(1), SeedTopics(1, topic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	var endTxns, initPIDs atomic.Int32
+	c.ControlKey(int16(kmsg.EndTxn), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		if endTxns.Add(1) == 1 {
+			resp := kreq.ResponseKind().(*kmsg.EndTxnResponse)
+			resp.ErrorCode = kerr.UnknownServerError.Code
+			return resp, nil, true
+		}
+		return nil, nil, false
+	})
+	c.ControlKey(int16(kmsg.InitProducerID), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		initPIDs.Add(1)
+		return nil, nil, false
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.TransactionalID("txn-unconfirmed-abort"),
+		kgo.DefaultProduceTopic(topic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	if err := cl.BeginTransaction(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("first")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.EndTransaction(ctx, kgo.TryCommit); err == nil {
+		t.Fatal("expected an error from the hijacked EndTxn commit")
+	}
+
+	preInits := initPIDs.Load()
+	if err := cl.EndTransaction(ctx, kgo.TryAbort); err != nil {
+		t.Fatalf("abort retry after unconfirmed commit errored: %v", err)
+	}
+	if got := endTxns.Load(); got != 1 {
+		t.Errorf("abort retry sent an EndTxn (saw %d total); the producer id reload is the abort", got)
+	}
+	if got := initPIDs.Load(); got != preInits+1 {
+		t.Errorf("abort retry did not reload the producer id (%d inits before, %d after)", preInits, got)
+	}
+
+	// The next transaction runs cleanly at the bumped epoch.
+	if err := cl.BeginTransaction(); err != nil {
+		t.Fatalf("begin after healed abort: %v", err)
+	}
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("second")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.EndTransaction(ctx, kgo.TryCommit); err != nil {
+		t.Fatalf("commit after healed abort: %v", err)
+	}
+
+	// read_committed sees only the second transaction: the first was
+	// fence-aborted by the reload.
+	consumer, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.ConsumeTopics(topic),
+		kgo.FetchIsolationLevel(kgo.ReadCommitted()),
+		kgo.FetchMaxWait(250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+
+	var vals []string
+	for len(vals) == 0 {
+		fs := consumer.PollFetches(ctx)
+		if err := fs.Err0(); err != nil {
+			t.Fatalf("consume: %v", err)
+		}
+		fs.EachRecord(func(r *kgo.Record) { vals = append(vals, string(r.Value)) })
+	}
+	if len(vals) != 1 || vals[0] != "second" {
+		t.Errorf("read_committed consumed %v, want only [second]", vals)
+	}
+}
+
+// Retrying a commit whose outcome is unconfirmed is refused: the prior
+// outcome is unknowable, and the retry's producer id reload may have just
+// fence-aborted it, so returning success would lie. The caller must retry
+// with TryAbort, per EndTransaction's docs.
+func TestEndTxnUnconfirmedCommitRetryRefused(t *testing.T) {
+	t.Parallel()
+	const topic = "txn-unconfirmed-commit"
+
+	c, err := NewCluster(NumBrokers(1), SeedTopics(1, topic))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	var endTxns atomic.Int32
+	c.ControlKey(int16(kmsg.EndTxn), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		if endTxns.Add(1) == 1 {
+			resp := kreq.ResponseKind().(*kmsg.EndTxnResponse)
+			resp.ErrorCode = kerr.UnknownServerError.Code
+			return resp, nil, true
+		}
+		return nil, nil, false
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.TransactionalID("txn-unconfirmed-commit"),
+		kgo.DefaultProduceTopic(topic),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	if err := cl.BeginTransaction(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("v")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.EndTransaction(ctx, kgo.TryCommit); err == nil {
+		t.Fatal("expected an error from the hijacked EndTxn commit")
+	}
+	err = cl.EndTransaction(ctx, kgo.TryCommit)
+	if err == nil || !strings.Contains(err.Error(), "unconfirmed") {
+		t.Fatalf("commit retry: got %v, want an unconfirmed-refusal error", err)
+	}
+
+	// The refusal's reload already aborted everything; a follow-up abort
+	// is a truthful no-op, and the next transaction runs cleanly.
+	if err := cl.EndTransaction(ctx, kgo.TryAbort); err != nil {
+		t.Fatalf("abort after refused commit retry: %v", err)
+	}
+	if err := cl.BeginTransaction(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("v2")).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cl.EndTransaction(ctx, kgo.TryCommit); err != nil {
+		t.Fatalf("commit after heal: %v", err)
 	}
 }

--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -1855,7 +1855,12 @@ func (cxn *brokerCxn) handleResp(pr promisedResp) {
 				cxn.b.cl.cfg.logger.Log(LogLevelDebug, "read from broker errored, killing connection", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "successful_reads", cxn.successes, "err", err)
 			} else {
 				cxn.b.cl.cfg.logger.Log(LogLevelWarn, "read from broker errored, killing connection after 0 successful responses (is SASL missing?)", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
-				if err == io.EOF { // specifically avoid checking errors.Is to ensure this is not already wrapped
+				if err == io.EOF || err == io.ErrUnexpectedEOF { // specifically avoid checking errors.Is to ensure this is not already wrapped
+					// ErrUnexpectedEOF gets the same first-read
+					// pessimism: now that it is retryable in
+					// isRetryableBrokerErr, a mid-frame close on
+					// the very first read (bad SASL cutting us off
+					// mid-response) must not retry forever either.
 					err = &ErrFirstReadEOF{kind: firstReadSASL, err: err, retry: cxn.b.cl.cfg.alwaysRetryEOF}
 				}
 			}

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -1188,6 +1188,27 @@ func (cl *Client) updateBrokers(brokers []kmsg.MetadataResponseBroker) {
 	sort.Slice(brokers, func(i, j int) bool { return brokers[i].NodeID < brokers[j].NodeID })
 	newBrokers := make([]*broker, 0, len(brokers))
 
+	// Removed or replaced brokers are stopped AFTER brokersMu is released:
+	// stopForever dies each connection, which synchronously fires the
+	// user's OnBrokerDisconnect hook, and a hook that re-enters the client
+	// (issuing a request, DiscoveredBrokers, anything needing brokersMu)
+	// would deadlock this goroutine -- the metadata loop -- under the
+	// write lock, wedging every request path client-wide. Walkthrough: a
+	// rolling restart removes node 5 from metadata; we take brokersMu and
+	// stopForever(node 5) inline; the hook calls cl.Broker(5).Request;
+	// brokerOrErr blocks on brokersMu.RLock behind our write lock forever.
+	// Same hazard reapMu had (see stopForever), one lock up. Stopping
+	// late is safe: requests racing a removed broker already contend with
+	// stopForever via b.dead / errChosenBrokerDead, and the broker is out
+	// of cl.brokers the moment we unlock (UpdateSeedBrokers already stops
+	// its old seeds this way).
+	var stopped []*broker
+	defer func() {
+		for _, b := range stopped {
+			b.stopForever()
+		}
+	}()
+
 	cl.brokersMu.Lock()
 	defer cl.brokersMu.Unlock()
 
@@ -1201,12 +1222,12 @@ func (cl *Client) updateBrokers(brokers []kmsg.MetadataResponseBroker) {
 
 		switch {
 		case ob.meta.NodeID < nb.NodeID:
-			ob.stopForever()
+			stopped = append(stopped, ob)
 			cl.brokers = cl.brokers[1:]
 
 		case ob.meta.NodeID == nb.NodeID:
 			if !ob.meta.equals(nb) {
-				ob.stopForever()
+				stopped = append(stopped, ob)
 				ob = cl.newBroker(nb.NodeID, nb.Host, nb.Port, nb.Rack)
 			}
 			newBrokers = append(newBrokers, ob)
@@ -1221,7 +1242,7 @@ func (cl *Client) updateBrokers(brokers []kmsg.MetadataResponseBroker) {
 
 	for len(cl.brokers) > 0 {
 		ob := cl.brokers[0]
-		ob.stopForever()
+		stopped = append(stopped, ob)
 		cl.brokers = cl.brokers[1:]
 	}
 
@@ -1355,12 +1376,16 @@ func (cl *Client) close(ctx context.Context) (rerr error) {
 	// stop the metadata loop and metrics loop.
 	cl.ctxCancel()
 
+	// Stop brokers outside brokersMu: stopForever fires the user's
+	// OnBrokerDisconnect hook synchronously, and a hook re-entering the
+	// client would deadlock on the held write lock (see updateBrokers).
 	cl.brokersMu.Lock()
 	cl.stopBrokers = true
-	for _, broker := range cl.brokers {
+	stopBrokers := slices.Clone(cl.brokers)
+	cl.brokersMu.Unlock()
+	for _, broker := range stopBrokers {
 		broker.stopForever()
 	}
-	cl.brokersMu.Unlock()
 	for _, broker := range cl.loadSeeds() {
 		broker.stopForever()
 	}

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -3579,21 +3579,39 @@ func (cl *offsetFetchSharder) shard(ctx context.Context, kreq kmsg.Request, last
 		nameMeta, _ = cl.resolveTopicMeta(ctx, unresolvedNames, true, 0)
 	}
 	if resolving {
+		// Fill from metaCache, which the resolve calls above populated:
+		// resolveTopicMetaByID stores into metaCache.byID (and returns
+		// nil when everything was already cached), while cl.id2t only
+		// ever holds topics this client produces or consumes -- an
+		// admin-style client fetching offsets by TopicID has the mapping
+		// ONLY in the cache. This mirrors the response-side resolution
+		// in the onResp below, which reads the cache for the same
+		// reason. id2t and the resolveTopicMeta return value remain as
+		// fallbacks. Names matter most below v10, where TopicID is
+		// structurally absent from the wire and an empty name is
+		// unmatchable by the broker (see #1312).
 		id2t := cl.id2tMap()
+		cl.metaCache.mu.Lock()
 		for i := range req.Groups {
 			g := &req.Groups[i]
 			for j := range g.Topics {
 				t := &g.Topics[j]
 				if t.Topic == "" && t.TopicID != ([16]byte{}) {
-					t.Topic = id2t[t.TopicID]
+					t.Topic = cl.metaCache.byID[t.TopicID]
+					if t.Topic == "" {
+						t.Topic = id2t[t.TopicID]
+					}
 				}
 				if t.TopicID == ([16]byte{}) && t.Topic != "" {
-					if ct, ok := nameMeta[t.Topic]; ok {
+					if ct, ok := cl.metaCache.topics[t.Topic]; ok {
+						t.TopicID = ct.id
+					} else if ct, ok := nameMeta[t.Topic]; ok {
 						t.TopicID = ct.id
 					}
 				}
 			}
 		}
+		cl.metaCache.mu.Unlock()
 	}
 
 	groups := make([]string, 0, len(req.Groups))

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -3545,6 +3545,15 @@ func (cl *offsetFetchSharder) shard(ctx context.Context, kreq kmsg.Request, last
 	dup := *req
 	req = &dup
 
+	// Deep-dup the groups: the struct copy above still shares the
+	// caller's Groups slice (and each group's Topics slice), and the
+	// Topic/TopicID resolution fill below would otherwise write into the
+	// caller's request structs in place.
+	req.Groups = slices.Clone(req.Groups)
+	for i := range req.Groups {
+		req.Groups[i].Topics = slices.Clone(req.Groups[i].Topics)
+	}
+
 	if len(req.Groups) == 0 {
 		req.Groups = append(req.Groups, offsetFetchReqToGroup(req))
 	}
@@ -3856,7 +3865,11 @@ func (*findCoordinatorSharder) shard(_ context.Context, kreq kmsg.Request, lastE
 			uniq[key] = struct{}{}
 		}
 	}
-	req.CoordinatorKeys = req.CoordinatorKeys[:0]
+	// Build the deduplicated keys in a FRESH slice: the struct copy above
+	// still shares the caller's backing array, and appending into
+	// req.CoordinatorKeys[:0] would overwrite the caller's request slice
+	// with deduplicated, map-order-shuffled keys.
+	req.CoordinatorKeys = make([]string, 0, len(uniq))
 	for key := range uniq {
 		req.CoordinatorKeys = append(req.CoordinatorKeys, key)
 	}

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -284,6 +284,26 @@ func (cfg *cfg) validate() error {
 		}
 	}
 
+	// The broker validates the ApiVersions software name and version
+	// against [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])? and rejects the
+	// whole request with INVALID_REQUEST otherwise. ApiVersions is the
+	// first request on every connection, so an invalid value bricks the
+	// client with an opaque error; fail loudly here instead.
+	for _, sw := range []struct{ name, v string }{
+		{"software name", cfg.softwareName},
+		{"software version", cfg.softwareVersion},
+	} {
+		if !validSoftwareNameVersion(sw.v) {
+			return fmt.Errorf("invalid %s %q: brokers require a non-empty alphanumeric string that may contain '-' or '.' internally", sw.name, sw.v)
+		}
+	}
+
+	// Brokers reject an empty transactional id with INVALID_REQUEST at
+	// InitProducerID; catch it here where the error can say why.
+	if cfg.txnID != nil && *cfg.txnID == "" {
+		return errors.New("invalid empty transactional id")
+	}
+
 	i64lt := func(l, r int64) (bool, string) { return l < r, "less" }
 	i64gt := func(l, r int64) (bool, string) { return l > r, "larger" }
 
@@ -2275,3 +2295,21 @@ func AutoCommitCallback(fn func(*Client, *kmsg.OffsetCommitRequest, *kmsg.Offset
 //  	return groupOpt{func(cfg *cfg) { cfg.disableNextGenBalancer = true }}
 //  }
 //
+
+// validSoftwareNameVersion mirrors the broker's ApiVersions validation
+// pattern, [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])?: non-empty
+// alphanumeric ends with dashes and dots allowed internally.
+func validSoftwareNameVersion(s string) bool {
+	alnum := func(c byte) bool {
+		return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+	}
+	if len(s) == 0 || !alnum(s[0]) || !alnum(s[len(s)-1]) {
+		return false
+	}
+	for i := 1; i < len(s)-1; i++ {
+		if c := s[i]; !alnum(c) && c != '-' && c != '.' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1203,6 +1203,15 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 			// a partition that never finished loading; SetOffsets
 			// documents those are skipped, so we keep their loads
 			// untouched.
+			//
+			// NOTE: the direct consumer's applySetOffsets translates
+			// ALL user input blindly (unlike the group path, which
+			// filters to g.uncommitted); the "extra partitions are
+			// skipped" contract holds only because this arm touches
+			// nothing beyond usingCursors and returns before the
+			// offset-loading section below. If setMatching ever gains
+			// load handling, filter never-consumed direct partitions
+			// first or they will silently start loading.
 		case assignInvalidateMatching:
 			loadOffsets.keepFilter(func(t string, p int32) bool {
 				if assignTopic, ok := assignments[t]; ok {

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -232,6 +232,14 @@ type consumer struct {
 	sourcesReadyForDraining []*source
 	fakeReadyForDraining    []Fetch
 
+	// deferredFetchHooks collects unbuffered fetch-record hook
+	// dispatches captured while c.mu/sourcesReadyMu are held (see
+	// source.hookDeferUnbuffered for the deadlock walkthrough). Guarded
+	// by sourcesReadyMu. Pollers drain it synchronously after their fill
+	// critical section releases the locks; stopSession's discard path
+	// drains it asynchronously because its callers still hold c.mu.
+	deferredFetchHooks []func()
+
 	pollWaitMu    xsync.Mutex
 	pollWaitC     *sync.Cond
 	pollWaitState uint64 // 0 == nothing, low 32 bits: # pollers, high 32: # waiting rebalances
@@ -382,6 +390,23 @@ func (c *consumer) init(cl *Client) {
 
 func (c *consumer) consuming() bool {
 	return c.g != nil || c.d != nil || c.s != nil
+}
+
+// runDeferredFetchHooks dispatches unbuffered fetch-record hooks that were
+// captured under the consumer locks. Called by pollers with no locks held,
+// after their fill critical section; each queued dispatch runs exactly once
+// (the swap under sourcesReadyMu is the ownership handoff). A concurrent
+// poller or invalidation may have queued more dispatches since ours were
+// captured; running them here too is fine -- ordering across concurrent
+// pollers is inherently unordered.
+func (c *consumer) runDeferredFetchHooks() {
+	c.sourcesReadyMu.Lock()
+	fns := c.deferredFetchHooks
+	c.deferredFetchHooks = nil
+	c.sourcesReadyMu.Unlock()
+	for _, fn := range fns {
+		fn()
+	}
 }
 
 // addSourceReadyForDraining tracks that a source needs its buffered fetch
@@ -591,6 +616,7 @@ func (cl *Client) PollRecords(ctx context.Context, maxPollRecords int) Fetches {
 	// We try filling fetches once before waiting. If we have no context,
 	// we guarantee that we just drain anything available and return.
 	fill()
+	c.runDeferredFetchHooks()
 	if len(fetches) > 0 || ctx == nil {
 		return fetches
 	}
@@ -627,6 +653,7 @@ func (cl *Client) PollRecords(ctx context.Context, maxPollRecords int) Fetches {
 	}
 
 	fill()
+	c.runDeferredFetchHooks()
 	return fetches
 }
 
@@ -1883,6 +1910,20 @@ func (c *consumer) stopSession() (listOrEpochLoads, *topicsPartitions) {
 		ready.discardBuffered()
 	}
 	c.sourcesReadyForDraining = nil
+
+	// The discards above deferred their unbuffered-hook dispatches, and
+	// they cannot run synchronously here: our callers hold c.mu (and
+	// sessionChangeMu), the very locks a re-entrant hook needs. The
+	// discarded records were never polled, so there is no user-visible
+	// ordering to preserve; dispatch async.
+	if fns := c.deferredFetchHooks; len(fns) > 0 {
+		c.deferredFetchHooks = nil
+		go func() {
+			for _, fn := range fns {
+				fn()
+			}
+		}()
+	}
 
 	// At this point, we have invalidated any buffered data from the prior
 	// session. We deliberately leave c.fakeReadyForDraining so the user can

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -2920,6 +2920,10 @@ var txnCommitContextFn = func() *string { s := "txn_commit_ctx"; return &s }()
 // default internal metadata is the client's current member ID). If fn returns
 // an error, the commit is not attempted. This context can be used in either
 // GroupTransactSession.End or in Client.EndTransaction.
+//
+// fn runs while the client's internal transaction lock is held: it must not
+// block and must not re-enter transaction functions (Begin/End/Abort), which
+// would self-deadlock. Its purpose is pure request mutation.
 func PreTxnCommitFnContext(ctx context.Context, fn func(*kmsg.TxnOffsetCommitRequest) error) context.Context {
 	return context.WithValue(ctx, txnCommitContextFn, fn)
 }
@@ -3300,6 +3304,11 @@ func (g *groupConsumer) commitOffsetsSync(
 // CommitOffsetsSync. If you commit async, the rebalance will proceed before
 // this function executes, and you will commit offsets for partitions that have
 // moved to a different consumer.
+//
+// Do not commit from within onDone: onDone runs while this commit is still
+// ordered against all other commits, so a commit issued inside onDone can
+// deadlock permanently (it always does if any sync commit is waiting). To
+// retry a failed commit, signal out of onDone and commit after it returns.
 func (cl *Client) CommitOffsets(
 	ctx context.Context,
 	uncommitted map[string]map[int32]EpochOffset,

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -264,6 +264,11 @@ func (cl *Client) LeaveGroup() {
 //
 // LeaveGroupContext is a no-op for direct (non-group) consumers.
 //
+// Leaving does not wake a concurrent PollFetches or PollRecords parked on
+// another goroutine: a parked poll returns only for buffered data, its own
+// context, or client close. To unblock a poll loop when leaving, cancel the
+// context you poll with (or Close the client).
+//
 // Do not call this function with a non-nil context synchronously from
 // within an OnPartitions callback: the leave waits for the group
 // management loop to finish, and the loop is waiting for your callback to

--- a/pkg/kgo/consumer_share.go
+++ b/pkg/kgo/consumer_share.go
@@ -1738,8 +1738,27 @@ func (s *source) shareAck(predrained []cursorAckDrain) {
 	nAcks, nStaleAcks, staleResults := filterStaleEntries(s, epoch, drains)
 
 	sc.enqueueCallback(staleResults, nStaleAcks)
+	// nAcks counts only user ack entries; gap/release ranges are filtered
+	// separately and can survive as live with zero live user entries (a
+	// partition whose acquired ranges covered only compaction holes, or
+	// whose batch failed decode and was released, buffers no records for
+	// the user to ack). The drain above already removed those gaps from
+	// the cursors, so returning here would drop them permanently: never
+	// sent, never requeued, no callback -- the broker's acquisition locks
+	// for those offsets then sit occupied until the lock timeout, which
+	// is exactly what immediate gap acking exists to avoid. Return only
+	// when nothing live at all survived the stale filter.
 	if nAcks == 0 {
-		return // everything was stale
+		var liveGaps bool
+		for i := range drains {
+			if len(drains[i].gaps) > 0 {
+				liveGaps = true
+				break
+			}
+		}
+		if !liveGaps {
+			return // everything was stale
+		}
 	}
 
 	if epoch == 0 {

--- a/pkg/kgo/consumer_share.go
+++ b/pkg/kgo/consumer_share.go
@@ -986,9 +986,18 @@ func (sc *shareConsumer) manage() {
 			return
 
 		case errors.Is(err, kerr.UnknownMemberID),
-			errors.Is(err, kerr.FencedMemberEpoch):
+			errors.Is(err, kerr.FencedMemberEpoch),
+			errors.Is(err, kerr.GroupIDNotFound):
 			// Keep the same UUID (matches the Java client) and reset
 			// to epoch 0 so the next heartbeat re-joins.
+			//
+			// GroupIDNotFound resets for liveness: the broker creates a
+			// share group only on a memberEpoch 0 heartbeat, so if group
+			// state vanished under a live member (coordinator state
+			// loss), retrying at our current epoch returns
+			// GROUP_ID_NOT_FOUND forever; only rejoining at epoch 0
+			// recreates the group. Classic and 848 groups self-heal the
+			// same way via their rejoin paths.
 			member, gen := sc.memberGen.load()
 			sc.memberGen.storeGeneration(0)
 			sc.cfg.logger.Log(LogLevelInfo, "share group heartbeat lost membership, resetting epoch",

--- a/pkg/kgo/consumer_share.go
+++ b/pkg/kgo/consumer_share.go
@@ -433,6 +433,7 @@ func (sc *shareConsumer) poll(ctx context.Context, maxPollRecords int) Fetches {
 
 	fill()
 	sc.c.mu.Unlock()
+	sc.c.runDeferredFetchHooks()
 	if len(fetches) > 0 || ctx == nil {
 		return fetches
 	}
@@ -466,6 +467,7 @@ func (sc *shareConsumer) poll(ctx context.Context, maxPollRecords int) Fetches {
 		sc.c.mu.Lock()
 		fill()
 		sc.c.mu.Unlock()
+		sc.c.runDeferredFetchHooks()
 	}
 
 	return fetches
@@ -1601,7 +1603,7 @@ func (s *sourceShare) takeBuffered(paused pausedTopics) Fetch {
 	close(s.s.sem)
 
 	f := b.fetch
-	s.s.hook(&f, false, true) // unbuffered, polled
+	s.s.hookDeferUnbuffered(&f, true) // unbuffered, polled; capture precedes the strip below
 
 	// Strip paused partitions from the returned fetch and release
 	// their records back to the broker for redelivery.
@@ -1707,9 +1709,9 @@ func (s *sourceShare) takeNBuffered(paused pausedTopics, n int) (Fetch, int, boo
 	}
 
 	if len(rstrip.Topics) > 0 {
-		s.s.hook(&rstrip, false, true)
+		s.s.hookDeferUnbuffered(&rstrip, true)
 	}
-	s.s.hook(&r, false, true) // unbuffered, polled
+	s.s.hookDeferUnbuffered(&r, true) // unbuffered, polled
 
 	drained := len(bf.Topics) == 0
 	if drained {
@@ -2534,7 +2536,7 @@ func (s *source) shareFetch(doneFetch chan<- bool) (fetched bool) {
 			doneFetch: doneFetch,
 		}
 		s.sem = make(chan struct{})
-		s.hook(&res.fetch, true, false)
+		s.hookBuffered(&res.fetch)
 		sc.c.addSourceReadyForDraining(s)
 	} else if res.allErrsStripped {
 		backoff("empty share fetch response due to all partitions having retryable errors")

--- a/pkg/kgo/consumer_share.go
+++ b/pkg/kgo/consumer_share.go
@@ -210,6 +210,21 @@ type (
 	// offset; duplicates would be rejected with INVALID_RECORD_STATE.
 	// The sc.pendingAcks counter still increments once per appended
 	// entry; subtraction at callback time uses the entry count.
+	//
+	// KNOWN WINDOW (2026-07 audit, deliberately unfixed): the
+	// offset-dedupe only covers duplicates within one build. If a
+	// drain snapshots a renew entry and the user's terminal ack
+	// lands between the drain and the build's status read, the CAS
+	// re-appends the pointer to the (new) pending list while the
+	// drained copy also reads the terminal status: two requests
+	// carry the same terminal ack, and the broker rejects the
+	// second with INVALID_RECORD_STATE at partition granularity,
+	// erroring innocent co-batched acks (they redeliver via the
+	// acquisition-lock timeout; at-least-once holds and the error
+	// is surfaced via the ack callback). Closing this needs
+	// per-state sent tracking (+8 bytes per acquired record) or a
+	// synchronized consume point; the microsecond window and
+	// loud+recoverable outcome did not justify either.
 	shareAckState struct {
 		status        atomic.Int32  // CAS target for ack transitions
 		deliveryCount int32         // broker's delivery count for this record (>= 1)

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -244,6 +244,8 @@ var (
 	// broker misbehavior surfaces in polls; the load is still retried.
 	errNegativeListedOffset = errors.New("broker replied to a ListOffsets request with an invalid negative offset")
 
+	errFetchNoProgress = errors.New("fetch response contained record batches but none contained or exceeded the requested offset")
+
 	// Injected as a fake errored fetch when an OffsetFetch response
 	// repeatedly omits a partition we requested; the group coordinator
 	// answers every requested partition, so an omission is a broker bug

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -80,7 +80,18 @@ func isRetryableBrokerErr(err error) bool {
 	}
 	// EOF can be returned if a broker kills a connection unexpectedly, and
 	// we can retry that. Same for ErrClosed.
-	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
+	//
+	// ErrUnexpectedEOF is EOF's mid-frame sibling and does NOT satisfy
+	// errors.Is(err, io.EOF): a graceful FIN landing inside a
+	// length-prefixed frame (broker shutting down mid-write, an LB or
+	// proxy draining) makes io.ReadFull return it. Without matching it
+	// here, this one disconnect shape -- alone among all of them (RST is
+	// a SyscallError, boundary FIN is io.EOF, refused is a dial error) --
+	// surfaced after zero retries: group sessions tore down, and a
+	// metadata request dying mid-read reached bumpRepeatedLoadErr with
+	// netErr=false, insta-failing buffered records on a transient
+	// network event.
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		// If the FIRST read is EOF, that is usually not a good sign,
 		// often it's from bad SASL. We err on the side of pessimism
 		// and do not retry.

--- a/pkg/kgo/errors_classify_test.go
+++ b/pkg/kgo/errors_classify_test.go
@@ -28,3 +28,28 @@ func TestUnexpectedEOFRetriable(t *testing.T) {
 		t.Error("first-read io.EOF should stay non-retryable")
 	}
 }
+
+// The broker validates ApiVersions software name/version against
+// [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])? and answers INVALID_REQUEST
+// otherwise; since ApiVersions is the first request on every connection, an
+// invalid value bricked the client with an opaque error. NewClient now
+// validates.
+func TestSoftwareNameVersionValidation(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{"", "my app", "app_1", "-app", "app-", ".app", "app/1"} {
+		if _, err := NewClient(SeedBrokers("localhost:1"), SoftwareNameAndVersion(bad, "1.0.0")); err == nil {
+			t.Errorf("software name %q: expected NewClient error", bad)
+		}
+	}
+	for _, good := range []string{"kgo", "my-app", "app.1", "a", "A9"} {
+		cl, err := NewClient(SeedBrokers("localhost:1"), SoftwareNameAndVersion(good, "1.0.0"))
+		if err != nil {
+			t.Errorf("software name %q: unexpected error %v", good, err)
+			continue
+		}
+		cl.Close()
+	}
+	if _, err := NewClient(SeedBrokers("localhost:1"), TransactionalID("")); err == nil {
+		t.Error("empty transactional id: expected NewClient error")
+	}
+}

--- a/pkg/kgo/errors_classify_test.go
+++ b/pkg/kgo/errors_classify_test.go
@@ -1,0 +1,30 @@
+package kgo
+
+import (
+	"fmt"
+	"io"
+	"testing"
+)
+
+// io.ErrUnexpectedEOF is the mid-frame sibling of io.EOF: a graceful FIN
+// landing inside a length-prefixed frame surfaces it from io.ReadFull. It
+// must classify retryable like every other disconnect shape; before the fix
+// it alone surfaced after zero retries, tearing down group sessions and
+// insta-failing buffered records via bumpRepeatedLoadErr.
+func TestUnexpectedEOFRetriable(t *testing.T) {
+	t.Parallel()
+	if !isRetryableBrokerErr(io.ErrUnexpectedEOF) {
+		t.Error("io.ErrUnexpectedEOF is not retryable")
+	}
+	if !isRetryableBrokerErr(fmt.Errorf("read fail: %w", io.ErrUnexpectedEOF)) {
+		t.Error("wrapped io.ErrUnexpectedEOF is not retryable")
+	}
+	// The first-read SASL pessimism must keep applying now that the error
+	// is retryable in general.
+	if isRetryableBrokerErr(&ErrFirstReadEOF{kind: firstReadSASL, err: io.ErrUnexpectedEOF}) {
+		t.Error("first-read io.ErrUnexpectedEOF should stay non-retryable")
+	}
+	if isRetryableBrokerErr(&ErrFirstReadEOF{kind: firstReadSASL, err: io.EOF}) {
+		t.Error("first-read io.EOF should stay non-retryable")
+	}
+}

--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -392,6 +392,11 @@ type HookFetchRecordUnbuffered interface {
 	// OnFetchRecordUnbuffered is passed a record that is being
 	// "unbuffered" within the client, and whether the record is being
 	// returned from polling.
+	//
+	// For polled records, this fires on the polling goroutine before the
+	// poll returns. For records discarded internally (an assignment
+	// invalidation dropping a buffered fetch), this fires asynchronously
+	// on a separate goroutine.
 	OnFetchRecordUnbuffered(r *Record, polled bool)
 }
 

--- a/pkg/kgo/hooks.go
+++ b/pkg/kgo/hooks.go
@@ -55,6 +55,9 @@ type HookClientClosed interface {
 //////////////////
 
 // HookBrokerConnect is called after a connection to a broker is opened.
+// This fires once per connection ATTEMPT, including internal retries: a
+// broker that refuses connections produces repeated calls (with err set),
+// not one.
 type HookBrokerConnect interface {
 	// OnBrokerConnect is passed the broker metadata, how long it took to
 	// dial and initialize the connection (issue ApiVersions and run through

--- a/pkg/kgo/legacy_message_set_test.go
+++ b/pkg/kgo/legacy_message_set_test.go
@@ -3,6 +3,7 @@ package kgo
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"hash/crc32"
 	"testing"
 
@@ -176,5 +177,69 @@ func TestLegacyMessageSetInnerOffsets(t *testing.T) {
 				t.Errorf("got next offset %d, want %d", next, wantNext)
 			}
 		})
+	}
+}
+
+// encodeV2Batch builds a v2 RecordBatch frame with a correct CRC. records is
+// the raw records section; numRecords is what the batch header CLAIMS.
+func encodeV2Batch(firstOffset int64, lastOffsetDelta, numRecords int32, records []byte) []byte {
+	b := kmsg.RecordBatch{
+		FirstOffset:          firstOffset,
+		PartitionLeaderEpoch: 0,
+		Magic:                2,
+		LastOffsetDelta:      lastOffsetDelta,
+		FirstTimestamp:       0,
+		MaxTimestamp:         0,
+		ProducerID:           -1,
+		ProducerEpoch:        -1,
+		FirstSequence:        -1,
+		NumRecords:           numRecords,
+		Records:              records,
+	}
+	raw := b.AppendTo(nil)
+	// Fix up Length (bytes after offset+length fields) and CRC (crc32c
+	// over the bytes after the CRC field, i.e. from attributes onward,
+	// which is byte 21).
+	binary.BigEndian.PutUint32(raw[8:], uint32(len(raw)-12))
+	crc := crc32.Checksum(raw[21:], crc32.MakeTable(crc32.Castagnoli))
+	binary.BigEndian.PutUint32(raw[17:], crc)
+	return raw
+}
+
+// A CRC-valid v2 batch claiming records with ZERO record bytes is corrupt:
+// the record-count clamp used to make it decode zero records "successfully"
+// and the KAFKA-5443 defer then advanced the offset past the batch's whole
+// claimed range, silently skipping offsets the broker asserts hold records.
+// The legitimate compacted-empty batch claims zero records and must still
+// advance.
+func TestEmptyBatchClaimingRecords(t *testing.T) {
+	t.Parallel()
+
+	process := func(set []byte, ask int64) (FetchPartition, int64) {
+		rp := &kmsg.FetchResponseTopicPartition{
+			Partition:     0,
+			HighWatermark: 1000,
+			RecordBatches: set,
+		}
+		opts := ProcessFetchPartitionOpts{Offset: ask, Topic: "t", Partition: 0}
+		return ProcessFetchPartition(opts, rp, DefaultDecompressor(), nil)
+	}
+
+	// Corrupt: claims 5 records, zero record bytes.
+	fp, next := process(encodeV2Batch(10, 4, 5, nil), 10)
+	if fp.Err == nil {
+		t.Error("corrupt batch (claimed records, no bytes) produced no error")
+	}
+	if next != 10 {
+		t.Errorf("corrupt batch advanced the offset to %d; want unmoved at 10", next)
+	}
+
+	// Legitimate KAFKA-5443 compacted-empty batch: claims zero, advances.
+	fp, next = process(encodeV2Batch(10, 4, 0, nil), 10)
+	if fp.Err != nil {
+		t.Errorf("compacted-empty batch errored: %v", fp.Err)
+	}
+	if next != 15 {
+		t.Errorf("compacted-empty batch advanced to %d; want 15 (past the preserved last offset)", next)
 	}
 }

--- a/pkg/kgo/legacy_message_set_test.go
+++ b/pkg/kgo/legacy_message_set_test.go
@@ -1,0 +1,180 @@
+package kgo
+
+import (
+	"bytes"
+	"compress/gzip"
+	"hash/crc32"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kbin"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// encodeLegacyMsg encodes one v0/v1 message: offset, size, then crc over
+// magic..end. For magic 1, ts sits between attributes and the key.
+func encodeLegacyMsg(magic int8, offset int64, attrs int8, ts int64, value []byte) []byte {
+	var body []byte
+	body = append(body, byte(magic), byte(attrs))
+	if magic == 1 {
+		body = kbin.AppendInt64(body, ts)
+	}
+	body = kbin.AppendInt32(body, -1) // nil key
+	body = kbin.AppendNullableBytes(body, value)
+
+	msg := kbin.AppendInt64(nil, offset)
+	msg = kbin.AppendInt32(msg, int32(4+len(body))) // crc + body
+	msg = kbin.AppendUint32(msg, crc32.ChecksumIEEE(body))
+	return append(msg, body...)
+}
+
+// wrapLegacySet gzips the concatenated inner messages into a compressed
+// wrapper message of the given magic at the given wrapper offset.
+func wrapLegacySet(magic int8, wrapperOffset int64, inner ...[]byte) []byte {
+	var raw []byte
+	for _, in := range inner {
+		raw = append(raw, in...)
+	}
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	gz.Write(raw)
+	gz.Close()
+	return encodeLegacyMsg(magic, wrapperOffset, 0x01 /* gzip */, 0, buf.Bytes())
+}
+
+func processLegacySet(t *testing.T, askOffset int64, set []byte) (FetchPartition, int64) {
+	t.Helper()
+	rp := &kmsg.FetchResponseTopicPartition{
+		Partition:     0,
+		HighWatermark: 1000,
+		RecordBatches: set,
+	}
+	opts := ProcessFetchPartitionOpts{
+		Offset:    askOffset,
+		Topic:     "t",
+		Partition: 0,
+	}
+	return ProcessFetchPartition(opts, rp, DefaultDecompressor(), nil)
+}
+
+// The log cleaner preserves retained inner messages' original offsets, so
+// compacted compressed v0/v1 message sets legally contain offset gaps. The
+// stored offsets are the truth: v1 wrappers store inner offsets relative to
+// the set's first offset with the wrapper carrying the last inner message's
+// absolute offset; v0 wrappers store absolute inner offsets. Kafka and
+// librdkafka both honor the stored offsets; we used to relabel contiguously
+// counting back from the wrapper offset, mislabeling everything before a
+// gap, so a mid-set commit skipped real records for any other client that
+// resumed from it.
+func TestLegacyMessageSetInnerOffsets(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		ask     int64
+		set     []byte
+		want    []int64
+		wantErr bool
+	}{
+		{
+			// Compacted v1: originals 10..20 with 13..19 removed;
+			// retained relatives [0 1 2 10], wrapper carries the
+			// last absolute (20). Old code yielded 17 18 19 20.
+			name: "v1 compacted gap",
+			ask:  10,
+			set: wrapLegacySet(1, 20,
+				encodeLegacyMsg(1, 0, 0, 0, []byte("a")),
+				encodeLegacyMsg(1, 1, 0, 0, []byte("b")),
+				encodeLegacyMsg(1, 2, 0, 0, []byte("c")),
+				encodeLegacyMsg(1, 10, 0, 0, []byte("d")),
+			),
+			want: []int64{10, 11, 12, 20},
+		},
+		{
+			// The common non-compacted case: relatives 0..2,
+			// wrapper 12 -> absolutes 10..12.
+			name: "v1 contiguous",
+			ask:  10,
+			set: wrapLegacySet(1, 12,
+				encodeLegacyMsg(1, 0, 0, 0, []byte("a")),
+				encodeLegacyMsg(1, 1, 0, 0, []byte("b")),
+				encodeLegacyMsg(1, 2, 0, 0, []byte("c")),
+			),
+			want: []int64{10, 11, 12},
+		},
+		{
+			// Resuming mid-set past a gap: only offsets >= 12 kept.
+			name: "v1 mid-set resume",
+			ask:  12,
+			set: wrapLegacySet(1, 20,
+				encodeLegacyMsg(1, 0, 0, 0, []byte("a")),
+				encodeLegacyMsg(1, 1, 0, 0, []byte("b")),
+				encodeLegacyMsg(1, 2, 0, 0, []byte("c")),
+				encodeLegacyMsg(1, 10, 0, 0, []byte("d")),
+			),
+			want: []int64{12, 20},
+		},
+		{
+			// Wrapper offset 0: inner offsets are used as-is
+			// (certain versions of librdkafka produced this).
+			name: "v1 wrapper offset zero",
+			ask:  0,
+			set: wrapLegacySet(1, 0,
+				encodeLegacyMsg(1, 0, 0, 0, []byte("a")),
+				encodeLegacyMsg(1, 1, 0, 0, []byte("b")),
+			),
+			want: []int64{0, 1},
+		},
+		{
+			// A wrapper offset below the last inner offset is an
+			// invalid set: error, no guessing.
+			name: "v1 wrapper below last inner",
+			ask:  0,
+			set: wrapLegacySet(1, 5,
+				encodeLegacyMsg(1, 0, 0, 0, []byte("a")),
+				encodeLegacyMsg(1, 10, 0, 0, []byte("b")),
+			),
+			wantErr: true,
+		},
+		{
+			// v0 wrappers carry ABSOLUTE inner offsets (magic-0-era
+			// brokers rewrote sets server-side); gaps preserved.
+			name: "v0 compacted gap",
+			ask:  10,
+			set: wrapLegacySet(0, 20,
+				encodeLegacyMsg(0, 10, 0, 0, []byte("a")),
+				encodeLegacyMsg(0, 11, 0, 0, []byte("b")),
+				encodeLegacyMsg(0, 12, 0, 0, []byte("c")),
+				encodeLegacyMsg(0, 20, 0, 0, []byte("d")),
+			),
+			want: []int64{10, 11, 12, 20},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fp, next := processLegacySet(t, tc.ask, tc.set)
+			if tc.wantErr {
+				if fp.Err == nil {
+					t.Fatal("expected an error, got none")
+				}
+				return
+			}
+			if fp.Err != nil {
+				t.Fatalf("unexpected error: %v", fp.Err)
+			}
+			var got []int64
+			for _, r := range fp.Records {
+				got = append(got, r.Offset)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got offsets %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got offsets %v, want %v", got, tc.want)
+				}
+			}
+			if wantNext := tc.want[len(tc.want)-1] + 1; next != wantNext {
+				t.Errorf("got next offset %d, want %d", next, wantNext)
+			}
+		})
+	}
+}

--- a/pkg/kgo/produce_request_encode_test.go
+++ b/pkg/kgo/produce_request_encode_test.go
@@ -1,0 +1,46 @@
+package kgo
+
+import (
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// A batch whose records were concurrently taken (failAllRecords) or that is
+// failing from a load error serializes as a null-records placeholder. On
+// flexible versions (v9+), that placeholder previously skipped the
+// per-partition tagged-field terminator, leaving the request one byte short
+// per failed batch and desyncing the broker's parse of the entire request.
+// Round-trip the hand-rolled encoding through kmsg's generated decoder to
+// pin the wire shape.
+func TestProduceRequestNullBatchEncoding(t *testing.T) {
+	t.Parallel()
+
+	for _, version := range []int16{8, 9} { // last non-flexible, first flexible
+		req := &produceRequest{
+			version: version,
+			acks:    -1,
+			timeout: 1000,
+		}
+		req.batches.addBatch("t", [16]byte{1}, 0, 0, &recBatch{}) // records nil: the null placeholder arm
+		req.batches.addBatch("t", [16]byte{1}, 1, 0, &recBatch{})
+
+		raw := req.AppendTo(nil)
+
+		var decoded kmsg.ProduceRequest
+		decoded.SetVersion(version)
+		if err := decoded.ReadFrom(raw); err != nil {
+			t.Errorf("v%d: hand-rolled produce request does not decode: %v", version, err)
+			continue
+		}
+		if len(decoded.Topics) != 1 || len(decoded.Topics[0].Partitions) != 2 {
+			t.Errorf("v%d: decoded %d topics / %v partitions, want 1 topic with 2 partitions", version, len(decoded.Topics), decoded.Topics)
+			continue
+		}
+		for _, p := range decoded.Topics[0].Partitions {
+			if p.Records != nil {
+				t.Errorf("v%d partition %d: records not null", version, p.Partition)
+			}
+		}
+	}
+}

--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -68,9 +68,16 @@ type producer struct {
 	// production.
 	onBatchPromiseBroadcast func(moreQueued bool)
 
-	txnMu   xsync.Mutex
-	inTxn   bool
-	tx890p2 atomic.Bool
+	txnMu xsync.Mutex
+	inTxn bool
+	// endUnconfirmed, guarded by txnMu, is set when an attempted EndTxn
+	// outcome is unconfirmed (transport error, retries exhausted, or
+	// UNKNOWN_SERVER_ERROR). EndTransaction restores the transaction
+	// state it consumed so the documented TryAbort retry can heal via
+	// producer id reload; this flag tells the retry that the reload is
+	// the abort and no EndTxn should be sent.
+	endUnconfirmed bool
+	tx890p2        atomic.Bool
 
 	// producedInTxn is set when a record is buffered within the current
 	// transaction and reset by BeginTransaction. EndTransaction consults

--- a/pkg/kgo/sharder_mutation_test.go
+++ b/pkg/kgo/sharder_mutation_test.go
@@ -1,0 +1,26 @@
+package kgo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// The findCoordinator sharder previously deduplicated the request's keys
+// into the CALLER's backing array, rewriting the user's request with
+// deduplicated, map-order-shuffled keys.
+func TestFindCoordinatorSharderDoesNotMutateRequest(t *testing.T) {
+	t.Parallel()
+	req := kmsg.NewPtrFindCoordinatorRequest()
+	req.CoordinatorKeys = []string{"a", "a", "b"}
+	if _, _, err := (*findCoordinatorSharder)(nil).shard(context.Background(), req, nil); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a", "a", "b"}
+	for i, k := range req.CoordinatorKeys {
+		if k != want[i] {
+			t.Fatalf("caller request keys mutated: %v", req.CoordinatorKeys)
+		}
+	}
+}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1172,7 +1172,15 @@ func (s *sink) handleReqRespBatch(
 			return false, false
 		}
 		if s.cl.cfg.onDataLoss != nil {
-			s.cl.cfg.onDataLoss(topic, rp.Partition)
+			// Dispatch on a fresh goroutine: we hold this partition's
+			// recBuf.mu here, and the natural reaction to "data loss
+			// on (topic, partition)" is to produce to that partition
+			// -- which re-enters recBuf.mu on this goroutine and
+			// deadlocks it forever, wedging the partition and this
+			// sink's response processing. The callback is an
+			// informational notification with no ordering contract
+			// (same dispatch style as HookProduceBatchWritten).
+			go s.cl.cfg.onDataLoss(topic, rp.Partition)
 		}
 
 		// For OOOSN, and UnknownProducerID

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -2491,6 +2491,16 @@ func (p *produceRequest) AppendTo(dst []byte) []byte {
 			if batch.records == nil || batch.isFailingFromLoadErr { // concurrent failAllRecords OR concurrent bumpRepeatedLoadErr
 				if flexible {
 					dst = kbin.AppendCompactNullableBytes(dst, nil)
+					// Flexible versions terminate EVERY partition
+					// element with a tagged-field count; the healthy
+					// arm appends it after the batch bytes below.
+					// Skipping it here left the request one byte
+					// short per failed batch, desyncing the broker's
+					// parse of every following partition: the whole
+					// request was corrupt, the broker killed the
+					// connection, and every healthy batch in the
+					// request rode the connection-death path.
+					dst = append(dst, 0)
 				} else {
 					dst = kbin.AppendNullableBytes(dst, nil)
 				}

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1278,6 +1278,7 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				continue
 			}
 
+			priorOffset := partOffset.offset
 			fp := partOffset.processRespPartition(br, rp, s.cl.cfg.decompressor, s.cl.cfg.hooks)
 			if fp.Err != nil {
 				if moving := kmove.maybeAddFetchPartition(resp, rp, c); moving {
@@ -1285,6 +1286,25 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 					continue
 				}
 				updateWhy.add(topic, partition, fp.Err)
+			}
+
+			// A response can carry batch data for a partition yet
+			// advance nothing: every batch's last offset below our
+			// requested offset (a broker violating "return the batch
+			// containing the fetch offset"). Nothing buffers, no error
+			// is set, and the cursor re-enables at the same offset --
+			// without intervention the next fetch re-requests
+			// immediately and the loop runs hot at round-trip pace,
+			// silently, forever. Strip the partition: if the WHOLE
+			// response is such non-progress, the allErrsStripped
+			// backoff below paces us like any other all-stripped
+			// response. Legitimate empties are excluded: a caught-up
+			// partition has no batch bytes, control/aborted records
+			// advance the offset even when not kept, and a compacted
+			// empty batch advances via its preserved last offset.
+			if fp.Err == nil && len(fp.Records) == 0 && partOffset.offset == priorOffset && len(rp.RecordBatches) > 0 {
+				strip(topic, partition, errFetchNoProgress)
+				continue
 			}
 
 			// We only keep the partition if it has no error, or an

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -2008,18 +2008,53 @@ out:
 		return 0, uncompressedBytes
 	}
 
-	firstOffset := message.Offset - int64(len(innerMessages)) + 1
+	// Inner offsets: the log cleaner preserves each retained inner
+	// message's original offset, so a compacted compressed message set
+	// legally contains offset gaps. For a v1 wrapper, inner offsets are
+	// stored relative to the set's first offset and the wrapper carries
+	// the absolute offset of the LAST inner message, so absolute =
+	// (wrapper - lastInner) + inner. We previously relabeled inner
+	// messages contiguously counting back from the wrapper offset, which
+	// mislabels every record before a gap; a commit taken mid-set then
+	// names an offset that skips real records for any other client
+	// reading the log honestly. Kafka and librdkafka both honor the
+	// stored offsets; downstream we already handle gapped offsets (see
+	// maybeKeepRecord's compaction comment).
+	//
+	// Two wrapper quirks, matching Kafka's own consumer: a wrapper
+	// offset of 0 means the inner offsets are used as-is (certain
+	// versions of librdkafka produced wrapper offset 0), and a wrapper
+	// offset below the last inner offset is an invalid set that we
+	// surface rather than guess at.
+	innerOffset := func(m readerFrom) int64 {
+		switch m := m.(type) {
+		case *kmsg.MessageV0:
+			return m.Offset
+		case *kmsg.MessageV1:
+			return m.Offset
+		}
+		return 0
+	}
+	var base int64
+	if message.Offset != 0 {
+		lastInner := innerOffset(innerMessages[len(innerMessages)-1])
+		if message.Offset < lastInner {
+			fp.Err = fmt.Errorf("invalid compressed message set: wrapper offset %d is less than the last inner offset %d", message.Offset, lastInner)
+			return 0, uncompressedBytes
+		}
+		base = message.Offset - lastInner
+	}
 	for i := range innerMessages {
 		innerMessage := innerMessages[i]
 		switch innerMessage := innerMessage.(type) {
 		case *kmsg.MessageV0:
-			innerMessage.Offset = firstOffset + int64(i)
+			innerMessage.Offset += base
 			innerMessage.Attributes |= int8(compression)
 			if !o.processV0Message(fp, innerMessage) {
 				return i, uncompressedBytes
 			}
 		case *kmsg.MessageV1:
-			innerMessage.Offset = firstOffset + int64(i)
+			innerMessage.Offset += base
 			innerMessage.Attributes |= int8(compression)
 			if !o.processV1Message(fp, innerMessage) {
 				return i, uncompressedBytes
@@ -2099,11 +2134,16 @@ func (o *ProcessFetchPartitionOpts) processV0OuterMessage(
 		return 0, uncompressedBytes
 	}
 
-	firstOffset := message.Offset - int64(len(innerMessages)) + 1
+	// For a v0 wrapper, inner offsets are stored ABSOLUTE (magic-0-era
+	// brokers rewrote compressed sets server-side on append), so we use
+	// them as-is; Kafka's own consumer does the same. The log cleaner
+	// preserves retained messages' offsets, so gaps from compaction are
+	// legal and handled downstream (see maybeKeepRecord). We previously
+	// relabeled contiguously counting back from the wrapper offset,
+	// mislabeling every record before a gap.
 	for i := range innerMessages {
 		innerMessage := &innerMessages[i]
 		innerMessage.Attributes |= int8(compression)
-		innerMessage.Offset = firstOffset + int64(i)
 		if !o.processV0Message(fp, innerMessage) {
 			return i, uncompressedBytes
 		}

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1861,6 +1861,19 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 		return 0, 0
 	}
 	if numRecords > len(rawRecords) {
+		// A batch claiming records with ZERO record bytes deserves a
+		// special word: the clamp below would make it decode zero
+		// records "successfully", and the KAFKA-5443 defer would then
+		// advance the offset past the batch's whole claimed range -- a
+		// silent skip of offsets the broker asserts hold records. The
+		// legitimate compacted-empty batch (KAFKA-5443) claims ZERO
+		// records, so claiming more with no bytes is corruption; error
+		// loudly like the Java client's InvalidRecordException instead
+		// of silently skipping.
+		if len(rawRecords) == 0 {
+			fp.Err = fmt.Errorf("invalid record batch: %d claimed records with no record bytes", numRecords)
+			return 0, uncompressedBytes
+		}
 		numRecords = len(rawRecords)
 	}
 	var krecords []kmsg.Record

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -426,22 +426,13 @@ type bufferedFetch struct {
 	usedOffsets usedOffsets // what the offsets will be next if this fetch is used
 }
 
-func (s *source) hook(f *Fetch, buffered, polled bool) {
+func (s *source) hookBuffered(f *Fetch) {
 	// Collect matching hooks once, then fuse dispatch with the metrics walk
 	// so we visit each record exactly once regardless of hook count.
-	var (
-		bufH []HookFetchRecordBuffered
-		unbH []HookFetchRecordUnbuffered
-	)
+	var bufH []HookFetchRecordBuffered
 	s.cl.cfg.hooks.each(func(h Hook) {
-		if buffered {
-			if h, ok := h.(HookFetchRecordBuffered); ok {
-				bufH = append(bufH, h)
-			}
-		} else {
-			if h, ok := h.(HookFetchRecordUnbuffered); ok {
-				unbH = append(unbH, h)
-			}
+		if h, ok := h.(HookFetchRecordBuffered); ok {
+			bufH = append(bufH, h)
 		}
 	})
 
@@ -458,19 +449,91 @@ func (s *source) hook(f *Fetch, buffered, polled bool) {
 				for _, h := range bufH {
 					h.OnFetchRecordBuffered(r)
 				}
-				for _, h := range unbH {
-					h.OnFetchRecordUnbuffered(r, polled)
-				}
 			}
 		}
 	}
-	if buffered {
-		s.cl.consumer.bufferedRecords.Add(int64(nrecs))
-		s.cl.consumer.bufferedBytes.Add(nbytes)
-	} else {
-		s.cl.consumer.bufferedRecords.Add(-int64(nrecs))
-		s.cl.consumer.bufferedBytes.Add(-nbytes)
+	s.cl.consumer.bufferedRecords.Add(int64(nrecs))
+	s.cl.consumer.bufferedBytes.Add(nbytes)
+}
+
+// hookDeferUnbuffered is the unbuffered counterpart of hookBuffered, split
+// because its dispatch must NOT run at the call sites: every take/discard
+// path holds c.sourcesReadyMu, and the poll path additionally holds c.mu
+// (the invalidation path holds c.mu and sessionChangeMu too). User hook
+// code invoked there can re-enter the client -- the hook docs bless
+// interceptor usage and warn only about slowness -- and a re-entrant call
+// that needs c.mu (polling, AddConsumeTopics, ...) would park forever with
+// c.mu held, wedging every future poll, every rebalance's assign, and
+// Close. So this captures what dispatch needs NOW and queues the user-code
+// dispatch on the consumer, to run once the locks release.
+//
+// The capture must be eager for a second reason: callers compact the
+// fetch's Topics/Partitions slices in place after this returns (pause
+// stripping reuses the same backing arrays), so a closure over f would
+// observe a corrupted view. Records themselves are never mutated; we
+// flatten the record pointers. Gauge accounting is atomic and happens
+// immediately -- only user code is deferred, and only when an unbuffered
+// hook is actually registered.
+//
+// Must be called with c.sourcesReadyMu held.
+func (s *source) hookDeferUnbuffered(f *Fetch, polled bool) {
+	var unbH []HookFetchRecordUnbuffered
+	s.cl.cfg.hooks.each(func(h Hook) {
+		if h, ok := h.(HookFetchRecordUnbuffered); ok {
+			unbH = append(unbH, h)
+		}
+	})
+
+	c := &s.cl.consumer
+	var nrecs int
+	var nbytes int64
+	if len(unbH) == 0 {
+		// No hook to dispatch. The gauges still need the walk (bytes
+		// are per-record), but nothing is captured and nothing is
+		// allocated.
+		for i := range f.Topics {
+			t := &f.Topics[i]
+			for j := range t.Partitions {
+				p := &t.Partitions[j]
+				nrecs += len(p.Records)
+				for k := range p.Records {
+					nbytes += p.Records[k].userSize()
+				}
+			}
+		}
+		c.bufferedRecords.Add(-int64(nrecs))
+		c.bufferedBytes.Add(-nbytes)
+		return
 	}
+
+	var recs []*Record
+	for i := range f.Topics {
+		t := &f.Topics[i]
+		for j := range t.Partitions {
+			p := &t.Partitions[j]
+			nrecs += len(p.Records)
+			for k := range p.Records {
+				r := p.Records[k]
+				nbytes += r.userSize()
+				recs = append(recs, r)
+			}
+		}
+	}
+	c.bufferedRecords.Add(-int64(nrecs))
+	c.bufferedBytes.Add(-nbytes)
+
+	if len(recs) == 0 {
+		return
+	}
+	c.deferredFetchHooks = append(c.deferredFetchHooks, func() {
+		// unbH is almost always length one; keeping it outermost keeps
+		// the per-record loop free of the hook-slice ranging.
+		for _, h := range unbH {
+			for _, r := range recs {
+				h.OnFetchRecordUnbuffered(r, polled)
+			}
+		}
+	})
 }
 
 // takeBuffered drains a buffered fetch and updates offsets.
@@ -658,9 +721,9 @@ func (s *source) takeNBuffered(paused pausedTopics, n int) (Fetch, int, bool) {
 	}
 
 	if len(rstrip.Topics) > 0 {
-		s.hook(&rstrip, false, true)
+		s.hookDeferUnbuffered(&rstrip, true)
 	}
-	s.hook(&r, false, true) // unbuffered, polled
+	s.hookDeferUnbuffered(&r, true) // unbuffered, polled
 
 	drained := len(bf.Topics) == 0
 	if drained {
@@ -676,7 +739,7 @@ func (s *source) takeBufferedFn(polled bool, offsetFn func(usedOffsets)) Fetch {
 	r.doneFetch <- true
 	close(s.sem)
 
-	s.hook(&r.fetch, false, polled) // unbuffered, potentially polled
+	s.hookDeferUnbuffered(&r.fetch, polled) // unbuffered, potentially polled
 
 	return r.fetch
 }
@@ -1102,7 +1165,7 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- bool) 
 			usedOffsets: req.usedOffsets,
 		}
 		s.sem = make(chan struct{})
-		s.hook(&fetch, true, false) // buffered, not polled
+		s.hookBuffered(&fetch) // buffered, not polled
 		s.cl.consumer.addSourceReadyForDraining(s)
 	} else if allErrsStripped {
 		// If we stripped all errors from the response, we are likely

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -422,9 +422,25 @@ func (cl *Client) storePartitionsUpdate(topic string, l *topicPartitions, lv *to
 	// the waiting goroutine that a try happened. It is possible the
 	// goroutine is quitting and will not be draining unknownWait, so we do
 	// not require the send.
-	if len(lv.partitions) == 0 && kerr.IsRetriable(lv.loadErr) {
+	//
+	// A load with NO error and NO partitions gets the same treatment with
+	// a synthesized error. Conformant brokers answer unknown topics with
+	// an error and existing topics with at least one partition, but a
+	// buggy broker or proxy can reply ErrorCode 0 with an empty partition
+	// array; the comprehensive-partition check in fetchTopicMetadata
+	// passes vacuously on empty, so loadErr is nil here. Falling through
+	// would hit the fatal-or-partition arm below and promise every
+	// buffered record with a NIL error: fabricated success (offset 0..n,
+	// producer id 0) for records that were never sent anywhere. We
+	// synthesize UnknownTopicOrPartition so the waiter both retries and
+	// counts the try against the max-unknown-failures bound.
+	if len(lv.partitions) == 0 && (lv.loadErr == nil || kerr.IsRetriable(lv.loadErr)) {
+		err := lv.loadErr
+		if err == nil {
+			err = kerr.UnknownTopicOrPartition
+		}
 		select {
-		case unknown.wait <- lv.loadErr:
+		case unknown.wait <- err:
 		default:
 		}
 		return

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -834,6 +834,17 @@ func (k *kip951move) ensureBrokers(cl *Client) {
 	// new objects with new connections, which breaks the single-
 	// connection-per-broker ordering guarantee that Kafka requires
 	// for idempotent/transactional produce.
+	// Replaced brokers are stopped after brokersMu is released: stopForever
+	// fires the user's OnBrokerDisconnect hook synchronously, and a hook
+	// re-entering the client would deadlock on the held write lock (see
+	// updateBrokers for the walkthrough).
+	var stopped []*broker
+	defer func() {
+		for _, b := range stopped {
+			b.stopForever()
+		}
+	}()
+
 	cl.brokersMu.Lock()
 	defer cl.brokersMu.Unlock()
 
@@ -856,7 +867,7 @@ func (k *kip951move) ensureBrokers(cl *Client) {
 			}
 			found = true
 			if !existing.meta.equals(nb) {
-				existing.stopForever()
+				stopped = append(stopped, existing)
 				cl.brokers[i] = cl.newBroker(b.NodeID, b.Host, b.Port, b.Rack)
 				changed = true
 			}

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -56,6 +56,11 @@ type GroupTransactSession struct {
 // occurs at any time before ending a transaction with a commit, this will
 // abort the transaction.
 //
+// Do not call End synchronously from within an OnPartitionsRevoked or
+// OnPartitionsLost callback: the session's internal callback wrappers hold
+// the same lock End needs, deadlocking permanently. (The plain client's
+// documented Close/LeaveGroup-from-callback restriction applies here too.)
+//
 // This leaves the risk that ending the transaction itself exceeds the
 // rebalance timeout, but this is just one request with no cpu logic. With a
 // proper rebalance timeout, this single request will not fail and the commit

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -692,8 +692,13 @@ func (cl *Client) UnsafeAbortBufferedRecords() {
 // If the producer ID has an error and you are trying to commit, this will
 // return with kerr.OperationNotAttempted. If this happened, retry
 // EndTransaction with TryAbort. If this returns kerr.TransactionAbortable, you
-// can retry with TryAbort. You should not retry this function on any other
-// error.
+// can retry with TryAbort. If a commit attempt's outcome is unconfirmed (a
+// transport error, or the broker replied UNKNOWN_SERVER_ERROR), the error is
+// returned and you should also retry with TryAbort: the retry aborts by
+// reloading the producer ID, which bumps the epoch and fence-aborts anything
+// still ongoing broker-side; retrying with TryCommit instead is refused, since
+// the prior outcome is unknowable. You should not retry this function on any
+// other error.
 //
 // It may be possible for the client to recover in a new transaction via
 // BeginTransaction if an error is returned from this function:
@@ -716,6 +721,13 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 		return nil
 	}
 	cl.producer.inTxn = false
+
+	// If a prior EndTxn attempt's outcome was unconfirmed, this call is the
+	// documented TryAbort retry (state was restored so we could get here).
+	// Remember and clear; restored again below if this attempt also fails
+	// before confirming anything.
+	unconfirmed := cl.producer.endUnconfirmed
+	cl.producer.endUnconfirmed = false
 
 	cl.producer.producingTxn.Store(false) // forbid any new produces while ending txn
 
@@ -807,6 +819,7 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 				g.offsetsAddedToTxn = true
 			}
 			cl.producer.inTxn = true
+			cl.producer.endUnconfirmed = unconfirmed
 			return kerr.OperationNotAttempted
 		}
 
@@ -818,6 +831,28 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 		if didRecover {
 			return nil
 		}
+	}
+
+	// This is the retry after an unconfirmed EndTxn outcome, and the
+	// producerID call above succeeded -- which, with the ID failed as
+	// errReloadProducerID, means it re-ran InitProducerID at our prior
+	// id/epoch: the broker bumped the epoch and fence-aborted anything
+	// still ongoing from the unconfirmed attempt. That reload IS the
+	// abort; issuing EndTxn now would end an empty transaction at the
+	// fresh epoch, which pre-KIP-890p2 brokers reject with
+	// INVALID_TXN_STATE. A commit retry is refused: the prior outcome is
+	// unknowable and the reload above may have just aborted it, so
+	// "success" here would lie to the caller.
+	if unconfirmed {
+		if commit {
+			return errors.New("cannot retry a commit whose outcome is unconfirmed: the transaction may already be aborted; retry with TryAbort")
+		}
+		cl.cfg.logger.Log(LogLevelInfo, "aborting an unconfirmed transaction via producer id reload; the epoch bump fence-aborted anything still ongoing",
+			"transactional_id", *cl.cfg.txnID,
+			"id", id,
+			"epoch", epoch,
+		)
+		return nil
 	}
 
 	cl.cfg.logger.Log(LogLevelInfo, "ending transaction",
@@ -881,17 +916,64 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 		return nil
 	})
 
-	// If the returned error is still a Kafka error, this is fatal and we
-	// need to fail our producer ID we loaded above.
+	// Any error after an attempted EndTxn must fail the producer ID.
+	// Walkthrough of what a healthy-PID + consumed-state combination
+	// would otherwise allow: EndTxn(commit) dies on a
+	// transport error the request may never have reached the broker, so
+	// the broker transaction is still ongoing; the documented TryAbort
+	// retry returns nil at the !inTxn guard above without sending
+	// anything; the next BeginTransaction succeeds (PID error-free) and
+	// produces run at the SAME id/epoch (nothing ever bumped it), so
+	// under KIP-890p2 they implicitly join the still-ongoing transaction;
+	// the next commit then commits the prior "failed" transaction's
+	// records too -- records the caller already rewound and reprocessed.
 	//
-	// UNKNOWN_SERVER_ERROR can theoretically be returned (not all brokers
-	// do). This technically is fatal, but we do not really know whether it
-	// is. We can just return this error and let the caller decide to
-	// continue, if the caller does continue, we will try something and
-	// eventually then receive our proper transactional error, if any.
-	var ke *kerr.Error
-	if errors.As(err, &ke) && !ke.Retriable && ke.Code != kerr.UnknownServerError.Code {
-		cl.failProducerID(id, epoch, err)
+	// How we fail the PID depends on what we know:
+	//
+	//   - A non-retriable Kafka error (fenced, invalid mapping, etc.) is a
+	//     definitive broker answer: fail with that error so recovery flows
+	//     through maybeRecoverProducerID's classification.
+	//
+	//   - Everything else -- a transport error, a retriable error that
+	//     outlived retries, or UNKNOWN_SERVER_ERROR (which some brokers
+	//     return where the outcome is unknowable) -- leaves the commit or
+	//     abort UNCONFIRMED. Fail with errReloadProducerID: the next
+	//     produce or BeginTransaction re-runs InitProducerID at our
+	//     current id/epoch, which bumps the epoch and fence-aborts any
+	//     transaction still ongoing broker-side (the same KIP-360 heal
+	//     maybeRecoverProducerID relies on). If the EndTxn actually did
+	//     complete, the re-init is harmless. Either way the caller saw an
+	//     error and reprocesses: at-least-once, never a silent join.
+	//
+	// failProducerID only swaps over an error-free PID, so this cannot
+	// clobber an already-fatal producer state.
+	//
+	// We also restore everything this call consumed and mark the outcome
+	// unconfirmed, so the documented TryAbort retry heals NOW instead of
+	// at the next transaction: the retry re-enters with transaction state
+	// intact, its producerID call reloads the failed ID (the epoch bump
+	// fence-aborts anything still ongoing broker-side), and the retry
+	// returns nil above without sending an EndTxn. For a definitively
+	// failed ID (fenced, invalid mapping), the retry instead flows
+	// through maybeRecoverProducerID's classification, same as an abort
+	// after a pre-attempt producerID failure. producingTxn stays false:
+	// produces between the failure and the retry fail fast rather than
+	// buffering against a failed producer ID.
+	if err != nil {
+		var ke *kerr.Error
+		if errors.As(err, &ke) && !ke.Retriable && ke.Code != kerr.UnknownServerError.Code {
+			cl.failProducerID(id, epoch, err)
+		} else {
+			cl.failProducerID(id, epoch, errReloadProducerID)
+		}
+		for _, rb := range addedSwapped {
+			rb.addedToTxn.Store(true)
+		}
+		if offsetsWereAdded {
+			g.offsetsAddedToTxn = true
+		}
+		cl.producer.inTxn = true
+		cl.producer.endUnconfirmed = true
 	}
 
 	return err

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -355,25 +355,54 @@ func (s *GroupTransactSession) End(ctx context.Context, commit TransactionEndTry
 	// We should not be booted from the group if we receive an ok
 	// heartbeat, meaning that, as mentioned, we should be able to end the
 	// transaction safely.
+	//
+	// If the commit carried no offsets (the user produced but polled
+	// nothing), we skip the heartbeat: its only purpose is to secure the
+	// rebalance-timeout window so a rebalance cannot hand our committed
+	// offsets to another consumer before our EndTxn writes the markers.
+	// With nothing committed, membership is irrelevant to the transaction
+	// and an empty end is always safe. Skipping also matters for liveness:
+	// the force below is received only by a running heartbeat loop, and
+	// the manage loop that runs it starts only once a metadata update
+	// discovers a topic to consume. Walkthrough of the hang this avoids:
+	// the session consumes a topic that does not exist yet, the user
+	// begins, produces, and ends -- the group never joined, so nothing
+	// receives heartbeatForceCh, and no revoke or lost callback can ever
+	// fire to close revokedCh/lostCh; every select arm below blocks
+	// forever and End never returns.
+	//
+	// The ctx arms bound the remaining offsets-committed case: a
+	// first-ever join can legally block for the full rebalance timeout
+	// with the heartbeat loop not yet running, and the group could also
+	// never complete a join at all. Cancellation leaves okHeartbeat false
+	// and falls into the abort path below, same as a failed heartbeat.
 	var okHeartbeat bool
 	var heartbeatRebalance bool
 	if g != nil && commitErr == nil {
-		waitHeartbeat := make(chan struct{})
-		var heartbeatErr error
-		select {
-		case g.heartbeatForceCh <- func(err error) {
-			defer close(waitHeartbeat)
-			heartbeatErr = err
-		}:
+		if len(postcommit) == 0 {
+			okHeartbeat = true
+		} else {
+			waitHeartbeat := make(chan struct{})
+			var heartbeatErr error
 			select {
-			case <-waitHeartbeat:
-				okHeartbeat = heartbeatErr == nil
-				heartbeatRebalance = errors.Is(heartbeatErr, kerr.RebalanceInProgress)
+			case g.heartbeatForceCh <- func(err error) {
+				defer close(waitHeartbeat)
+				heartbeatErr = err
+			}:
+				select {
+				case <-waitHeartbeat:
+					okHeartbeat = heartbeatErr == nil
+					heartbeatRebalance = errors.Is(heartbeatErr, kerr.RebalanceInProgress)
+				case <-s.revokedCh:
+				case <-s.lostCh:
+				case <-ctx.Done():
+				case <-s.cl.ctx.Done():
+				}
 			case <-s.revokedCh:
 			case <-s.lostCh:
+			case <-ctx.Done():
+			case <-s.cl.ctx.Done():
 			}
-		case <-s.revokedCh:
-		case <-s.lostCh:
 		}
 	}
 


### PR DESCRIPTION
A second Claude Fable audit wave (the first was #1348): five rounds over kgo plus the first-ever audits of kadm and the generate/definitions DSL, with every fork finding independently re-verified by full-function reads before fixing.

Important fixes:

- **Corrupt produce request on v9+ when a batch fails during serialization**: the null-records placeholder arm skipped the per-partition tagged-field terminator, desyncing the broker's parse of the entire request -- connection killed, every healthy batch failed; silent with acks=0. Round-trip regression test fails pre-fix at exactly v9.
- **EndTransaction with an unconfirmed outcome consumed txn state without failing the producer ID**: the documented retry-with-abort became a wire no-op and the next transaction silently joined the still-ongoing broker transaction under KIP-890 part 2 (EOS duplicates). The producer ID is now failed for reload, fence-aborting anything ongoing.
- **GroupTransactSession.End hung forever (ignoring its context) if the group never joined** and the transaction committed no offsets.
- **io.ErrUnexpectedEOF classified non-retryable**: a graceful disconnect landing mid-frame tore down group sessions after zero retries and could insta-fail buffered produce records.
- **Legacy (pre-0.11) compressed message sets now honor stored inner offsets** (Java/librdkafka parity); contiguous relabeling skipped records over compaction gaps when another client resumed from a franz-go commit.
- **kadm**: broadcast list APIs no longer return silently short results with a nil error; ACL filter builders no longer send the broker-rejected UNKNOWN pattern when unset (unset now means any); ACL list setters are last-call-wins; ListOffsets special listings no longer rewrite the broker's -1 answer; plus a batch of smaller fixes.
- **User callbacks moved off internal locks** (unbuffered fetch hooks, data-loss callback, OnBrokerDisconnect) so re-entrant calls cannot deadlock the client; callbacks that intentionally run under ordering locks now document their constraints.
- **kmsg**: DescribeTopicPartitions ResponsePartitionLimit default corrected to Kafka's 2000; gofumpt dropped from the generation pipeline. (Version bumps for unreleased Kafka 4.4 APIs live on the kafka-4.4 hold branch, per the definitions-must-not-exceed-released-Kafka CI check.)
- **kfake**: validates ACL filters and ApiVersions software name/version like a real broker (both had made tests structurally blind to real-broker rejections).

The full generate/definitions DSL was diffed field-by-field against Kafka's message JSON schemas (all 95 files): zero wire drift found anywhere; the two known remaining validator deltas (TxnOffsetCommit v6, streams-adjacent) are handled on the kafka-4.4 hold branch.

CHANGELOG entry is drafted locally and will land separately.
