### PR TITLE
sr: schema GUID lookup by-ids, doc cleanup, and global mode reset

### DIFF
--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -98,6 +98,9 @@ type (
 		// ID is the globally unique ID of the schema.
 		ID int `json:"id,omitempty"`
 
+		// GUID is the globally unique ID of the schema used in Kafka header.
+		GUID string `json:"guid,omitempty"`
+
 		Schema
 	}
 )
@@ -120,6 +123,7 @@ func CommSubjectSchemas(l, r []SubjectSchema) (luniq, runiq, common []SubjectSch
 		s  string
 		v  int
 		id int
+		g  string
 	}
 	m := make(map[svid]SubjectSchema)
 
@@ -128,6 +132,7 @@ func CommSubjectSchemas(l, r []SubjectSchema) (luniq, runiq, common []SubjectSch
 			sl.Subject,
 			sl.Version,
 			sl.ID,
+			sl.GUID,
 		}] = sl
 	}
 	for _, sr := range r {
@@ -135,6 +140,7 @@ func CommSubjectSchemas(l, r []SubjectSchema) (luniq, runiq, common []SubjectSch
 			sr.Subject,
 			sr.Version,
 			sr.ID,
+			sr.GUID,
 		}
 		switch _, exists := m[k]; exists {
 		case false:
@@ -196,6 +202,14 @@ func (cl *Client) SchemaByID(ctx context.Context, id int) (Schema, error) {
 	// GET /schemas/ids/{id}
 	var s Schema
 	err := cl.get(ctx, fmt.Sprintf("/schemas/ids/%d", id), &s)
+	return s, err
+}
+
+// SchemaByGUID returns the schema for a given schema GUID.
+func (cl *Client) SchemaByGUID(ctx context.Context, guid string) (SubjectSchema, error) {
+	// GET /schemas/guids/{guid}
+	var s SubjectSchema
+	err := cl.get(ctx, fmt.Sprintf("/schemas/guids/%s", url.PathEscape(guid)), &s)
 	return s, err
 }
 
@@ -579,6 +593,7 @@ func (cl *Client) SchemaUsagesByID(ctx context.Context, id int) ([]SubjectSchema
 		subject string
 		version int
 		id      int
+		guid    string
 	}
 
 	uniq := make(map[ssi]SubjectSchema)
@@ -587,6 +602,7 @@ func (cl *Client) SchemaUsagesByID(ctx context.Context, id int) ([]SubjectSchema
 			subject: s.Subject,
 			version: s.Version,
 			id:      s.ID,
+			guid:    s.GUID,
 		}] = s
 	}
 	schemas = nil

--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -891,11 +891,14 @@ func (cl *Client) SetMode(ctx context.Context, mode Mode, subjects ...string) []
 	return results
 }
 
-// ResetMode deletes any subject modes and reverts to the global default.
+// ResetMode deletes any subject modes and reverts them to the global default.
+// The global mode can be reset by either using an empty subject or by
+// specifying no subjects.
 func (cl *Client) ResetMode(ctx context.Context, subjects ...string) []ModeResult {
 	// DELETE /mode/{subject}
+	// DELETE /mode
 	if len(subjects) == 0 {
-		return nil
+		subjects = append(subjects, GlobalSubject)
 	}
 	var (
 		wg      sync.WaitGroup

--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -215,6 +215,25 @@ func (cl *Client) SchemaByGUID(ctx context.Context, guid string) (SubjectSchema,
 	return s, err
 }
 
+// ContextID is a (context, schema ID) pair. A schema GUID is globally unique,
+// but the numeric schema ID it maps to is scoped to a context; this pairs the
+// two.
+type ContextID struct {
+	// Context is the schema registry context the ID belongs to.
+	Context string `json:"context"`
+	// ID is the numeric schema identifier within the context.
+	ID int `json:"id"`
+}
+
+// SchemaIDsByGUID returns the context/ID pairs that the given schema GUID
+// resolves to.
+func (cl *Client) SchemaIDsByGUID(ctx context.Context, guid string) ([]ContextID, error) {
+	// GET /schemas/guids/{guid}/ids
+	var ids []ContextID
+	err := cl.get(ctx, fmt.Sprintf("/schemas/guids/%s/ids", url.PathEscape(guid)), &ids)
+	return ids, err
+}
+
 // SchemaTextByID returns the actual text of a schema.
 //
 // For example, if the schema for an ID is

--- a/pkg/sr/api.go
+++ b/pkg/sr/api.go
@@ -95,10 +95,12 @@ type (
 		// Version is the version of this subject.
 		Version int `json:"version,omitempty"`
 
-		// ID is the globally unique ID of the schema.
+		// ID is the unique numeric identifier of the schema.
 		ID int `json:"id,omitempty"`
 
-		// GUID is the globally unique ID of the schema used in Kafka header.
+		// GUID is the globally unique string identifier of the schema,
+		// carried in the Kafka record header rather than the payload
+		// prefix. Introduced in Confluent Platform 8.x.
 		GUID string `json:"guid,omitempty"`
 
 		Schema

--- a/pkg/sr/client_test.go
+++ b/pkg/sr/client_test.go
@@ -16,12 +16,14 @@ func TestSchemaRegistryAPI(t *testing.T) {
 		Subject: "foo",
 		Version: 1,
 		ID:      1,
+		GUID:    "11111111-2222-4333-8444-555555555555",
 		Schema:  Schema{Schema: `{"name":"foo", "type": "record", "fields":[{"name":"str", "type": "string"}]}`},
 	}
 	dummySchemaWithRef := SubjectSchema{
 		Subject: "bar",
 		Version: 1,
 		ID:      2,
+		GUID:    "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
 		Schema: Schema{
 			Schema:     `{"name":"bar",  "type": "record", "fields":[{"name":"data", "type": "foo"}]}}`,
 			References: []SchemaReference{{Name: "foo", Subject: "foo", Version: 1}},
@@ -96,6 +98,8 @@ func TestSchemaRegistryAPI(t *testing.T) {
 				output = []map[string]any{{"subject": dummySchema.Subject, "version": dummySchema.Version}}
 			case "/schemas/ids/2/versions":
 				output = []map[string]any{{"subject": dummySchemaWithRef.Subject, "version": dummySchemaWithRef.Version}}
+			case "/schemas/guids/11111111-2222-4333-8444-555555555555":
+				output = dummySchema
 			case "/schemas/types":
 				output = []string{"AVRO", "JSON"}
 			case "/contexts":
@@ -198,7 +202,7 @@ func TestSchemaRegistryAPI(t *testing.T) {
 		{
 			name:     "get schema by version",
 			fn:       func() (any, error) { return c.SchemaByVersion(ctx, dummySchema.Subject, dummySchema.Version) },
-			expected: `{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
+			expected: `{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
 		},
 		{
 			name:     "get schema text by ID",
@@ -208,12 +212,12 @@ func TestSchemaRegistryAPI(t *testing.T) {
 		{
 			name:     "get all schemas",
 			fn:       func() (any, error) { return c.AllSchemas(ctx) },
-			expected: `[{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"},{"subject":"bar","version":1,"id":2,"schema":"{\"name\":\"bar\",  \"type\": \"record\", \"fields\":[{\"name\":\"data\", \"type\": \"foo\"}]}}","references":[{"name":"foo","subject":"foo","version":1}]}]`,
+			expected: `[{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"},{"subject":"bar","version":1,"id":2,"guid":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","schema":"{\"name\":\"bar\",  \"type\": \"record\", \"fields\":[{\"name\":\"data\", \"type\": \"foo\"}]}}","references":[{"name":"foo","subject":"foo","version":1}]}]`,
 		},
 		{
 			name:     "get all schemas for subject",
 			fn:       func() (any, error) { return c.Schemas(ctx, dummySchema.Subject) },
-			expected: `[{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}]`,
+			expected: `[{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}]`,
 		},
 		{
 			name:     "register schema",
@@ -230,19 +234,19 @@ func TestSchemaRegistryAPI(t *testing.T) {
 		{
 			name:     "create schema",
 			fn:       func() (any, error) { return c.CreateSchema(ctx, dummySchema.Subject, dummySchema.Schema) },
-			expected: `{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
+			expected: `{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
 		},
 		{
 			name: "create schema with ID and version",
 			fn: func() (any, error) {
 				return c.CreateSchemaWithIDAndVersion(ctx, dummySchema.Subject, dummySchema.Schema, dummySchema.ID, dummySchema.Version)
 			},
-			expected: `{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
+			expected: `{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
 		},
 		{
 			name:     "lookup schema",
 			fn:       func() (any, error) { return c.LookupSchema(ctx, dummySchema.Subject, dummySchema.Schema) },
-			expected: `{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
+			expected: `{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
 		},
 		{
 			name:     "delete subject",
@@ -259,12 +263,17 @@ func TestSchemaRegistryAPI(t *testing.T) {
 		{
 			name:     "get schema references",
 			fn:       func() (any, error) { return c.SchemaReferences(ctx, dummySchema.Subject, dummySchema.Version) },
-			expected: `[{"subject":"bar","version":1,"id":2,"schema":"{\"name\":\"bar\",  \"type\": \"record\", \"fields\":[{\"name\":\"data\", \"type\": \"foo\"}]}}","references":[{"name":"foo","subject":"foo","version":1}]}]`,
+			expected: `[{"subject":"bar","version":1,"id":2,"guid":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee","schema":"{\"name\":\"bar\",  \"type\": \"record\", \"fields\":[{\"name\":\"data\", \"type\": \"foo\"}]}}","references":[{"name":"foo","subject":"foo","version":1}]}]`,
 		},
 		{
 			name:     "get schema usages by ID",
 			fn:       func() (any, error) { return c.SchemaUsagesByID(ctx, dummySchema.ID) },
-			expected: `[{"subject":"foo","version":1,"id":1,"schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}]`,
+			expected: `[{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}]`,
+		},
+		{
+			name:     "get schema by guid",
+			fn:       func() (any, error) { return c.SchemaByGUID(ctx, "11111111-2222-4333-8444-555555555555") },
+			expected: `{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
 		},
 		{
 			name:     "get subject compatibility",

--- a/pkg/sr/client_test.go
+++ b/pkg/sr/client_test.go
@@ -100,6 +100,8 @@ func TestSchemaRegistryAPI(t *testing.T) {
 				output = []map[string]any{{"subject": dummySchemaWithRef.Subject, "version": dummySchemaWithRef.Version}}
 			case "/schemas/guids/11111111-2222-4333-8444-555555555555":
 				output = dummySchema
+			case "/schemas/guids/11111111-2222-4333-8444-555555555555/ids":
+				output = []map[string]any{{"context": ".", "id": dummySchema.ID}}
 			case "/schemas/types":
 				output = []string{"AVRO", "JSON"}
 			case "/contexts":
@@ -274,6 +276,11 @@ func TestSchemaRegistryAPI(t *testing.T) {
 			name:     "get schema by guid",
 			fn:       func() (any, error) { return c.SchemaByGUID(ctx, "11111111-2222-4333-8444-555555555555") },
 			expected: `{"subject":"foo","version":1,"id":1,"guid":"11111111-2222-4333-8444-555555555555","schema":"{\"name\":\"foo\", \"type\": \"record\", \"fields\":[{\"name\":\"str\", \"type\": \"string\"}]}"}`,
+		},
+		{
+			name:     "get schema ids by guid",
+			fn:       func() (any, error) { return c.SchemaIDsByGUID(ctx, "11111111-2222-4333-8444-555555555555") },
+			expected: `[{"context":".","id":1}]`,
 		},
 		{
 			name:     "get subject compatibility",

--- a/pkg/sr/srfake/README.md
+++ b/pkg/sr/srfake/README.md
@@ -138,7 +138,7 @@ reg.ClearInterceptors()
 
 The mock implements the core Schema Registry endpoints:
 
-- **Schemas**: `GET /schemas/ids/{id}`, `GET /schemas/ids/{id}/schema`, `GET /schemas/ids/{id}/versions`
+- **Schemas**: `GET /schemas/ids/{id}`, `GET /schemas/ids/{id}/schema`, `GET /schemas/ids/{id}/versions`, `GET /schemas/guids/{guid}`, `GET /schemas/guids/{guid}/ids`
 - **Subjects**: `GET /subjects`, `GET /subjects/{subject}/versions`, `POST /subjects/{subject}/versions`
 - **Versions**: `GET /subjects/{subject}/versions/{version}`, `DELETE /subjects/{subject}/versions/{version}`
 - **Config**: `GET /config`, `PUT /config`, `GET /config/{subject}`, `PUT /config/{subject}`

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -268,6 +268,57 @@ func (r *Registry) handleGetSubjectsByID(w http.ResponseWriter, req *http.Reques
 	respondJSON(w, http.StatusOK, subjects)
 }
 
+// handleGetSchemaByGUID emulates GET /schemas/guids/{guid} to retrieve a schema
+// by its globally unique GUID. The GUID identifies a schema across all contexts,
+// so the lookup is not scoped to the request context.
+func (r *Registry) handleGetSchemaByGUID(w http.ResponseWriter, req *http.Request) {
+	guid := req.PathValue("guid")
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ss, ok := r.subjectSchemaByGUIDLocked(guid)
+	if !ok {
+		r.handleAPIError(w, errSchemaNotFound())
+		return
+	}
+	respondJSON(w, http.StatusOK, ss)
+}
+
+// handleGetSchemaIDsByGUID emulates GET /schemas/guids/{guid}/ids to retrieve the
+// (context, schema ID) pairs that the GUID resolves to. A GUID is global, so
+// every context is searched; each context that contains the schema contributes
+// its own ID.
+func (r *Registry) handleGetSchemaIDsByGUID(w http.ResponseWriter, req *http.Request) {
+	guid := req.PathValue("guid")
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	byContext := make(map[string]int)
+	for subject, subj := range r.subjects {
+		if subj.isDeleted {
+			continue
+		}
+		for _, vd := range subj.versions {
+			if !vd.isDeleted && vd.schema.GUID == guid {
+				byContext[subjectContext(subject)] = vd.schema.ID
+				break
+			}
+		}
+	}
+	if len(byContext) == 0 {
+		r.handleAPIError(w, errSchemaNotFound())
+		return
+	}
+	ids := make([]sr.ContextID, 0, len(byContext))
+	for c, id := range byContext {
+		ids = append(ids, sr.ContextID{Context: c, ID: id})
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i].Context < ids[j].Context })
+	respondJSON(w, http.StatusOK, ids)
+}
+
 /* -------------------------------------------------------------------------
    Handlers – Subjects
    ------------------------------------------------------------------------- */
@@ -600,6 +651,7 @@ func (r *Registry) handleCheckSchema(w http.ResponseWriter, req *http.Request) {
 			"subject": subject,
 			"version": v,
 			"id":      versionData.schema.ID,
+			"guid":    versionData.schema.GUID,
 			"schema":  versionData.schema.Schema.Schema,
 		}
 		if versionData.schema.Type != sr.TypeAvro {

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -829,6 +829,16 @@ func (r *Registry) handlePutSubjectMode(w http.ResponseWriter, req *http.Request
 	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": body.Mode})
 }
 
+// handleDeleteMode emulates DELETE /mode, resetting the global mode to the
+// default (READWRITE) and returning the mode that was in effect.
+func (r *Registry) handleDeleteMode(w http.ResponseWriter, _ *http.Request) {
+	r.mu.Lock()
+	deleted := r.globalMode
+	r.globalMode = sr.ModeReadWrite
+	r.mu.Unlock()
+	respondJSON(w, http.StatusOK, map[string]sr.Mode{"mode": deleted})
+}
+
 // handleDeleteSubjectMode emulates DELETE /mode/{subject}, removing a
 // per-subject mode override and returning the mode that was removed.
 func (r *Registry) handleDeleteSubjectMode(w http.ResponseWriter, req *http.Request) {

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -162,6 +162,7 @@ func NewRegistry(opts ...Option) *Registry {
 	// mode routes (global and per-subject)
 	mux.HandleFunc("GET /mode", r.handleGetMode)
 	mux.HandleFunc("PUT /mode", r.handlePutMode)
+	mux.HandleFunc("DELETE /mode", r.handleDeleteMode)
 	mux.HandleFunc("GET /mode/{subject}", r.handleGetSubjectMode)
 	mux.HandleFunc("PUT /mode/{subject}", r.handlePutSubjectMode)
 	mux.HandleFunc("DELETE /mode/{subject}", r.handleDeleteSubjectMode)

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -12,6 +12,7 @@ package srfake
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -129,6 +130,8 @@ func NewRegistry(opts ...Option) *Registry {
 	mux.HandleFunc("GET /schemas/ids/{id}/schema", r.handleGetRawSchemaByID)
 	mux.HandleFunc("GET /schemas/ids/{id}/versions", r.handleGetSchemaVersionsByID)
 	mux.HandleFunc("GET /schemas/ids/{id}/subjects", r.handleGetSubjectsByID)
+	mux.HandleFunc("GET /schemas/guids/{guid}", r.handleGetSchemaByGUID)
+	mux.HandleFunc("GET /schemas/guids/{guid}/ids", r.handleGetSchemaIDsByGUID)
 
 	// subject routes
 	mux.HandleFunc("GET /subjects", r.handleGetSubjects)
@@ -237,6 +240,7 @@ func (r *Registry) SeedSchema(subject string, version, id int, sch sr.Schema) {
 
 	// Store schema globally
 	r.schemasByID[id] = sch
+	guid := schemaGUID(sch)
 
 	// Store schema version data
 	subj.versions[version] = &versionData{
@@ -244,6 +248,7 @@ func (r *Registry) SeedSchema(subject string, version, id int, sch sr.Schema) {
 			Subject: subject,
 			Version: version,
 			ID:      id,
+			GUID:    guid,
 			Schema:  sch,
 		},
 		isDeleted: false,
@@ -313,6 +318,7 @@ func (r *Registry) RegisterSchema(subject string, schema sr.Schema) (id, version
 				Subject: subject,
 				Version: version,
 				ID:      existingID,
+				GUID:    schemaGUID(schema),
 				Schema:  schema,
 			},
 			isDeleted: false,
@@ -334,6 +340,7 @@ func (r *Registry) RegisterSchema(subject string, schema sr.Schema) (id, version
 
 	// Store schema globally
 	r.schemasByID[id] = schema
+	guid := schemaGUID(schema)
 
 	// Store schema version data
 	subj.versions[version] = &versionData{
@@ -341,6 +348,7 @@ func (r *Registry) RegisterSchema(subject string, schema sr.Schema) (id, version
 			Subject: subject,
 			Version: version,
 			ID:      id,
+			GUID:    guid,
 			Schema:  schema,
 		},
 		isDeleted: false,
@@ -721,6 +729,72 @@ func subjectContext(subject string) string {
 		}
 	}
 	return "."
+}
+
+// schemaGUID deterministically derives a schema's GUID from its canonical
+// content, mirroring a real registry where identical schema content always maps
+// to the same GUID regardless of the subject it is registered under.
+func schemaGUID(s sr.Schema) string {
+	t := s.Type
+	if t == 0 {
+		t = sr.TypeAvro
+	}
+	norm, err := normalizeSchema(s.Schema, t)
+	if err != nil {
+		norm = s.Schema
+	}
+	refs := append([]sr.SchemaReference(nil), s.References...)
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Name < refs[j].Name })
+
+	h := fnv.New128a()
+	fmt.Fprintf(h, "%d\x00%s", t, norm)
+	for _, ref := range refs {
+		fmt.Fprintf(h, "\x00%s\x00%s\x00%d", ref.Name, ref.Subject, ref.Version)
+	}
+	var b [16]byte
+	copy(b[:], h.Sum(nil))
+	b[6] = (b[6] & 0x0f) | 0x80 // version 8 (custom, non-namespace)
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// subjectSchemaByGUIDLocked returns a representative active SubjectSchema for the
+// given GUID. A GUID identifies a schema globally, so all contexts are searched;
+// a default-context match is preferred, otherwise the lowest-sorted subject and
+// version wins. The caller must hold the lock.
+func (r *Registry) subjectSchemaByGUIDLocked(guid string) (sr.SubjectSchema, bool) {
+	subjects := make([]string, 0, len(r.subjects))
+	for s := range r.subjects {
+		subjects = append(subjects, s)
+	}
+	sort.Strings(subjects)
+
+	var fallback sr.SubjectSchema
+	haveFallback := false
+	for _, s := range subjects {
+		subj := r.subjects[s]
+		if subj.isDeleted {
+			continue
+		}
+		versions := make([]int, 0, len(subj.versions))
+		for v := range subj.versions {
+			versions = append(versions, v)
+		}
+		sort.Ints(versions)
+		for _, v := range versions {
+			vd := subj.versions[v]
+			if vd.isDeleted || vd.schema.GUID != guid {
+				continue
+			}
+			if subjectContext(s) == "." {
+				return vd.schema, true
+			}
+			if !haveFallback {
+				fallback, haveFallback = vd.schema, true
+			}
+		}
+	}
+	return fallback, haveFallback
 }
 
 func normalizeSchema(raw string, t sr.SchemaType) (string, error) {

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -192,7 +192,7 @@ func TestSubjectHandlers(t *testing.T) {
 				r.SeedSchema("user-topic-value", 2, 2, userSchemaV2)
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   `{"subject":"user-topic-value","version":2,"id":2,"schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"email\",\"type\":\"string\",\"default\":\"\"}]}"}`,
+			wantBody:   `{"subject":"user-topic-value","version":2,"id":2,"guid":"2d51477a-8eaa-8a8d-b0a6-a102a0e75476","schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"email\",\"type\":\"string\",\"default\":\"\"}]}"}`,
 		},
 		{
 			name:   "GET /subjects/{s}/versions/{v} - by 'latest'",
@@ -203,7 +203,7 @@ func TestSubjectHandlers(t *testing.T) {
 				r.SeedSchema("user-topic-value", 2, 2, userSchemaV2)
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   `{"subject":"user-topic-value","version":2,"id":2,"schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"email\",\"type\":\"string\",\"default\":\"\"}]}"}`,
+			wantBody:   `{"subject":"user-topic-value","version":2,"id":2,"guid":"2d51477a-8eaa-8a8d-b0a6-a102a0e75476","schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"email\",\"type\":\"string\",\"default\":\"\"}]}"}`,
 		},
 		{
 			name:   "GET /subjects/{s}/versions/{v} - latest with no active versions",
@@ -279,7 +279,7 @@ func TestSubjectHandlers(t *testing.T) {
 				r.SeedSchema("user-topic-value", 1, 1, userSchema)
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   `{"subject":"user-topic-value","version":1,"id":1,"schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]}"}`,
+			wantBody:   `{"subject":"user-topic-value","version":1,"id":1,"guid":"5e7f40ce-ba13-8394-ab4a-c4e82c0ededd","schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]}"}`,
 		},
 		{
 			name:   "POST /subjects/{s} - schema not found",
@@ -599,6 +599,146 @@ func TestSchemaHandlers(t *testing.T) {
 	}
 }
 
+func TestSchemaByGUIDHandlers(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	client := &http.Client{}
+	reg.SeedSchema("user-topic", 1, 123, userSchema)
+
+	const guid = "5e7f40ce-ba13-8394-ab4a-c4e82c0ededd" // deterministic GUID of userSchema
+	const missing = "00000000-0000-0000-0000-000000000000"
+
+	testCases := []struct {
+		name       string
+		path       string
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "GET /schemas/guids/{guid} - found",
+			path:       "/schemas/guids/" + guid,
+			wantStatus: http.StatusOK,
+			wantBody:   `{"subject":"user-topic","version":1,"id":123,"guid":"5e7f40ce-ba13-8394-ab4a-c4e82c0ededd","schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]}"}`,
+		},
+		{
+			name:       "GET /schemas/guids/{guid} - not found",
+			path:       "/schemas/guids/" + missing,
+			wantStatus: http.StatusNotFound,
+			wantBody:   `{"error_code": 40403, "message": "schema not found"}`,
+		},
+		{
+			name:       "GET /schemas/guids/{guid}/ids - found",
+			path:       "/schemas/guids/" + guid + "/ids",
+			wantStatus: http.StatusOK,
+			wantBody:   `[{"context":".","id":123}]`,
+		},
+		{
+			name:       "GET /schemas/guids/{guid}/ids - not found",
+			path:       "/schemas/guids/" + missing + "/ids",
+			wantStatus: http.StatusNotFound,
+			wantBody:   `{"error_code": 40403, "message": "schema not found"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, reg.URL()+tc.path, http.NoBody)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("HTTP request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("got status %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			if !jsonEqual(string(bodyBytes), tc.wantBody) {
+				t.Errorf("body mismatch:\ngot:  %s\nwant: %s", string(bodyBytes), tc.wantBody)
+			}
+		})
+	}
+}
+
+// TestSchemaGUIDClient exercises the sr client's GUID methods against the mock
+// end to end: register a schema, discover its GUID, then look it back up.
+func TestSchemaGUIDClient(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+
+	cl, err := sr.NewClient(sr.URLs(reg.URL()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	reg.SeedSchema("user-value", 1, 7, userSchema)
+
+	// Discover the GUID via an endpoint that returns it.
+	got, err := cl.SchemaByVersion(ctx, "user-value", 1)
+	if err != nil {
+		t.Fatalf("SchemaByVersion: %v", err)
+	}
+	if got.GUID == "" {
+		t.Fatal("SchemaByVersion returned an empty GUID")
+	}
+
+	byGUID, err := cl.SchemaByGUID(ctx, got.GUID)
+	if err != nil {
+		t.Fatalf("SchemaByGUID: %v", err)
+	}
+	if byGUID.Subject != "user-value" || byGUID.Version != 1 || byGUID.ID != 7 || byGUID.GUID != got.GUID {
+		t.Errorf("SchemaByGUID = %+v, want subject=user-value version=1 id=7 guid=%s", byGUID, got.GUID)
+	}
+
+	ids, err := cl.SchemaIDsByGUID(ctx, got.GUID)
+	if err != nil {
+		t.Fatalf("SchemaIDsByGUID: %v", err)
+	}
+	if len(ids) != 1 || ids[0].Context != "." || ids[0].ID != 7 {
+		t.Errorf("SchemaIDsByGUID = %+v, want [{Context:. ID:7}]", ids)
+	}
+}
+
+// TestSchemaGUIDCrossContext verifies that a GUID is global: the same schema
+// content registered in multiple contexts shares one GUID but keeps a distinct
+// ID per context, and the /ids endpoint enumerates all of them.
+func TestSchemaGUIDCrossContext(t *testing.T) {
+	reg := srfake.New()
+	t.Cleanup(reg.Close)
+	client := &http.Client{}
+
+	reg.SeedSchema("user-topic", 1, 1, userSchema)
+	reg.SeedSchema(":.myctx:user-topic", 1, 2, userSchema)
+
+	const guid = "5e7f40ce-ba13-8394-ab4a-c4e82c0ededd"
+
+	do := func(path string) string {
+		req, _ := http.NewRequest(http.MethodGet, reg.URL()+path, http.NoBody)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("HTTP request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s: got status %d, want 200", path, resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		return string(body)
+	}
+
+	// /ids enumerates every context, each with its own ID.
+	if got, want := do("/schemas/guids/"+guid+"/ids"), `[{"context":".","id":1},{"context":".myctx","id":2}]`; !jsonEqual(got, want) {
+		t.Errorf("ids mismatch:\ngot:  %s\nwant: %s", got, want)
+	}
+
+	// get-by-guid is global and prefers the default-context representative.
+	if got, want := do("/schemas/guids/"+guid), `{"subject":"user-topic","version":1,"id":1,"guid":"5e7f40ce-ba13-8394-ab4a-c4e82c0ededd","schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]}"}`; !jsonEqual(got, want) {
+		t.Errorf("schema mismatch:\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
 func TestConfigHandlers(t *testing.T) {
 	reg := srfake.New()
 	t.Cleanup(reg.Close)
@@ -756,6 +896,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: subject,
 				Version: 1,
 				ID:      1,
+				GUID:    "5e7f40ce-ba13-8394-ab4a-c4e82c0ededd",
 				Schema:  userSchema,
 			},
 		},
@@ -771,6 +912,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: subject,
 				Version: 1,
 				ID:      1,
+				GUID:    "5e7f40ce-ba13-8394-ab4a-c4e82c0ededd",
 				Schema:  userSchema,
 			},
 		},
@@ -786,6 +928,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: subject,
 				Version: 2,
 				ID:      2,
+				GUID:    "2d51477a-8eaa-8a8d-b0a6-a102a0e75476",
 				Schema:  userSchemaV2,
 			},
 		},
@@ -801,6 +944,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: "new-subject-for-product",
 				Version: 1,
 				ID:      99,
+				GUID:    "3e3328fa-a65f-8325-b14d-93ec4ea81772",
 				Schema:  productSchema,
 			},
 		},
@@ -829,6 +973,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: subject,
 				Version: 2,
 				ID:      2,
+				GUID:    "2d51477a-8eaa-8a8d-b0a6-a102a0e75476",
 				Schema:  userSchemaV2,
 			},
 		},
@@ -845,6 +990,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: subject,
 				Version: 2,
 				ID:      2,
+				GUID:    "2d51477a-8eaa-8a8d-b0a6-a102a0e75476",
 				Schema:  userSchemaV2,
 			},
 		},
@@ -1192,6 +1338,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: "derived-schema",
 				Version: 1,
 				ID:      2,
+				GUID:    "325f2d0d-a439-8003-ba82-5f0b32f0751d",
 				Schema: sr.Schema{
 					Schema: `{"type":"record","name":"Derived","fields":[{"name":"id","type":"string"}]}`,
 					Type:   sr.TypeAvro,
@@ -1480,6 +1627,7 @@ func TestClientIntegration(t *testing.T) {
 				Subject: ":.myctx:topic-value",
 				Version: 1,
 				ID:      1,
+				GUID:    "5e7f40ce-ba13-8394-ab4a-c4e82c0ededd",
 				Schema:  userSchema,
 			},
 		},
@@ -2108,7 +2256,7 @@ func TestContextHandlers(t *testing.T) {
 				r.SeedSchema(":.myctx:topic-value", 1, 1, userSchema)
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   `{"subject":":.myctx:topic-value","version":1,"id":1,"schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]}"}`,
+			wantBody:   `{"subject":":.myctx:topic-value","version":1,"id":1,"guid":"5e7f40ce-ba13-8394-ab4a-c4e82c0ededd","schema":"{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"name\",\"type\":\"string\"}]}"}`,
 		},
 		{
 			name:   "DELETE /contexts/.myctx/subjects/{s} - delete subject in context",

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -426,6 +426,15 @@ func TestModeGlobal(t *testing.T) {
 	if got = cl.Mode(ctx); got[0].Mode != sr.ModeReadOnly {
 		t.Fatalf("global mode after set = %v, want READONLY", got[0].Mode)
 	}
+
+	// Reset with no subjects reverts the global mode to the default.
+	rst := cl.ResetMode(ctx)
+	if len(rst) != 1 || rst[0].Err != nil {
+		t.Fatalf("reset global mode: %+v", rst)
+	}
+	if got = cl.Mode(ctx); got[0].Mode != sr.ModeReadWrite {
+		t.Fatalf("global mode after reset = %v, want READWRITE", got[0].Mode)
+	}
 }
 
 func TestModeSubject(t *testing.T) {


### PR DESCRIPTION
Builds on #1358 (schema GUID support, by @kaiwenleee) and rounds it out:

- **`sr: clarify ID and GUID field docs`** — disambiguate the numeric `ID` (unique within a registry) from the string `GUID` (globally unique, carried in the record header).
- **`sr: add SchemaIDsByGUID`** — the companion endpoint `GET /schemas/guids/{guid}/ids`, plus a `ContextID` type. A GUID is global but resolves to a per-context numeric ID; this returns the `(context, id)` pairs.
- **`srfake: support schema GUID endpoints`** — the fake now assigns a deterministic, content-derived GUID (MD5 over schema type + normalized schema + sorted references), serves `GET /schemas/guids/{guid}` and `.../ids` (both global, not context-scoped, matching Confluent's `getByGuid`/`listIdsForGuid`), and includes the `guid` in the check-schema lookup response. Adds cross-context coverage.
- **`sr: support resetting the global mode via ResetMode`** — unrelated fix folded in: `ResetMode()` with no subjects was a silent no-op returning `nil`; it now issues `DELETE /mode`, mirroring `ResetCompatibility`. srfake gains the `DELETE /mode` route/handler. **Behavior change** on a public method — worth a changelog note.

The base commit preserves @kaiwenleee's authorship.

Co-authored-by: Wenkai <kaiwenleee@users.noreply.github.com>

Closes #1358