### PR TITLE
kfake: model topic deletion and recreation faithfully

### DIFF
--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -112,8 +112,12 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 				maxBytes:     rp.PartitionMaxBytes,
 				currentEpoch: rp.CurrentLeaderEpoch,
 			})
-			// Update session with this partition's state
-			session.updatePartition(rt.Topic, rp.Partition, rp.FetchOffset, rp.PartitionMaxBytes, rp.CurrentLeaderEpoch)
+			// Update session with this partition's state. An
+			// unresolvable v13 topic ID is answered above but not
+			// tracked: "" is not a valid session key.
+			if rt.Topic != "" || req.Version < 13 {
+				session.updatePartition(rt.Topic, rt.TopicID, rp.Partition, rp.FetchOffset, rp.PartitionMaxBytes, rp.CurrentLeaderEpoch)
+			}
 		}
 	}
 
@@ -126,9 +130,19 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		}
 		for key, sp := range session.partitions {
 			if !inRequest[key] {
+				topic := key.t
+				if sp.topicID != (uuid{}) {
+					// v13+ entries are addressed by the ID they
+					// were added with: if it no longer resolves
+					// (deleted, or recreated with a new ID), the
+					// lookups below miss and the entry answers
+					// UNKNOWN_TOPIC_ID with the stored ID, like a
+					// real broker. It never re-addresses by name.
+					topic = c.data.id2t[sp.topicID]
+				}
 				toFetch = append(toFetch, fetchPartition{
-					topic:        key.t,
-					topicID:      c.data.t2id[key.t],
+					topic:        topic,
+					topicID:      sp.topicID,
 					partition:    key.p,
 					fetchOffset:  sp.fetchOffset,
 					maxBytes:     sp.maxBytes,
@@ -229,11 +243,15 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 	tidx := make(map[string]int)
 
 	donet := func(t string, id uuid) *kmsg.FetchResponseTopic {
-		if i, ok := tidx[t]; ok {
+		key := t
+		if t == "" {
+			key = string(id[:]) // unresolvable v13 IDs each get their own entry
+		}
+		if i, ok := tidx[key]; ok {
 			return &resp.Topics[i]
 		}
 		id2t[id] = t
-		tidx[t] = len(resp.Topics)
+		tidx[key] = len(resp.Topics)
 		st := kmsg.NewFetchResponseTopic()
 		st.Topic = t
 		st.TopicID = id
@@ -459,6 +477,11 @@ type fetchSession struct {
 
 // fetchSessionPartition tracks per-partition state within a session.
 type fetchSessionPartition struct {
+	// topicID is what the requester addressed this partition by (zero
+	// below fetch v13). v13+ sessions are topic-ID addressed: if this ID
+	// stops resolving (topic deleted, or recreated under a new ID), the
+	// entry answers UNKNOWN_TOPIC_ID rather than re-addressing by name.
+	topicID      uuid
 	fetchOffset  int64
 	maxBytes     int32
 	currentEpoch int32
@@ -542,18 +565,20 @@ func (fs *fetchSessions) getOrCreate(brokerNode, sessionID, sessionEpoch int32, 
 	return session, false, 0
 }
 
-func (s *fetchSession) updatePartition(topic string, partition int32, fetchOffset int64, maxBytes, currentEpoch int32) {
+func (s *fetchSession) updatePartition(topic string, topicID uuid, partition int32, fetchOffset int64, maxBytes, currentEpoch int32) {
 	if s == nil {
 		return
 	}
 	key := tp{topic, partition}
 	if existing, ok := s.partitions[key]; ok {
+		existing.topicID = topicID
 		existing.fetchOffset = fetchOffset
 		existing.maxBytes = maxBytes
 		existing.currentEpoch = currentEpoch
 		s.partitions[key] = existing
 	} else {
 		s.partitions[key] = fetchSessionPartition{
+			topicID:            topicID,
 			fetchOffset:        fetchOffset,
 			maxBytes:           maxBytes,
 			currentEpoch:       currentEpoch,

--- a/pkg/kfake/02_list_offsets.go
+++ b/pkg/kfake/02_list_offsets.go
@@ -91,6 +91,15 @@ func (c *Cluster) handleListOffsets(creq *clientReq) (kmsg.Response, error) {
 			switch rp.Timestamp {
 			case -2:
 				sp.Offset = pd.logStartOffset
+				// The epoch accompanying a listed offset is the epoch
+				// of the record at that offset (a real broker answers
+				// from its leader-epoch cache), not the partition's
+				// current epoch: a freshly reset consumer must not
+				// believe it consumed an epoch above the historical
+				// records it is about to read.
+				if segIdx, metaIdx, ok, atEnd := pd.searchOffset(pd.logStartOffset); ok && !atEnd {
+					sp.LeaderEpoch = pd.segments[segIdx].index[metaIdx].epoch
+				}
 			case -1:
 				if req.IsolationLevel == 1 {
 					sp.Offset = pd.lastStableOffset
@@ -106,6 +115,7 @@ func (c *Cluster) handleListOffsets(creq *clientReq) (kmsg.Response, error) {
 				} else {
 					sp.Offset = m.firstOffset + int64(m.lastOffsetDelta)
 					sp.Timestamp = m.maxTimestamp
+					sp.LeaderEpoch = m.epoch
 				}
 			default:
 				// Two-level binary search for the first batch whose maxTimestamp >= requested timestamp.
@@ -115,6 +125,7 @@ func (c *Cluster) handleListOffsets(creq *clientReq) (kmsg.Response, error) {
 				} else {
 					sp.Offset = meta.firstOffset
 					sp.Timestamp = meta.firstTimestamp
+					sp.LeaderEpoch = meta.epoch
 					// Read the full batch to iterate records for precise timestamp
 					batch, err := c.readBatchFull(pd, segIdx, meta)
 					if err != nil {

--- a/pkg/kfake/18_api_versions.go
+++ b/pkg/kfake/18_api_versions.go
@@ -2,6 +2,7 @@ package kfake
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 
@@ -73,7 +74,11 @@ func (c *Cluster) handleApiVersions(kreq kmsg.Request) (kmsg.Response, error) {
 		}
 		resp.ApiKeys = capped
 	} else {
-		resp.ApiKeys = apiVersionsSorted
+		// Clone: the response is handed to ControlKey interceptors,
+		// which may mutate it. Handing out the shared package-global
+		// slice would let one interceptor corrupt every later
+		// ApiVersions response process-wide.
+		resp.ApiKeys = slices.Clone(apiVersionsSorted)
 	}
 
 	// Build SupportedFeatures (what we can support) and FinalizedFeatures

--- a/pkg/kfake/20_delete_topics.go
+++ b/pkg/kfake/20_delete_topics.go
@@ -90,6 +90,9 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 			// Producer state is per-log and dies with the topic: a
 			// recreated topic rehydrates empty state, accepting any
 			// first sequence (the 2.5+ broker semantics we model).
+			// Transactional REGISTRATIONS survive (the coordinator is
+			// name-keyed on a real broker); endTx re-resolves current
+			// partition data when writing markers.
 			for _, pidinf := range c.pids.ids {
 				delete(pidinf.windows, td.topic)
 			}

--- a/pkg/kfake/20_delete_topics.go
+++ b/pkg/kfake/20_delete_topics.go
@@ -96,6 +96,15 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 			for _, pidinf := range c.pids.ids {
 				delete(pidinf.windows, td.topic)
 			}
+			// Share-partition state is topic-ID-keyed on a real broker
+			// and dies with the topic; kfake keys by name, so clear it
+			// explicitly: a recreated topic starts share consumption
+			// fresh (SPSO per group config, no acquired records).
+			for _, sg := range c.shareGroups.gs {
+				sg.mu.Lock()
+				delete(sg.partitions, td.topic)
+				sg.mu.Unlock()
+			}
 		}
 	}()
 	for _, rt := range req.Topics {

--- a/pkg/kfake/20_delete_topics.go
+++ b/pkg/kfake/20_delete_topics.go
@@ -87,6 +87,12 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 			delete(c.data.treplicas, td.topic)
 			delete(c.data.tcfgs, td.topic)
 			delete(c.data.tnorms, normalizeTopicName(td.topic))
+			// Producer state is per-log and dies with the topic: a
+			// recreated topic rehydrates empty state, accepting any
+			// first sequence (the 2.5+ broker semantics we model).
+			for _, pidinf := range c.pids.ids {
+				delete(pidinf.windows, td.topic)
+			}
 		}
 	}()
 	for _, rt := range req.Topics {

--- a/pkg/kfake/shutdown_cancel_test.go
+++ b/pkg/kfake/shutdown_cancel_test.go
@@ -63,7 +63,12 @@ func TestAuditProduceAfterCloseFailsKnownTopic(t *testing.T) {
 
 	// With the record failed, the buffer count returns to zero, so a Flush
 	// does not hang (pre-fix the orphan pinned BufferedProduceRecords above
-	// zero forever).
+	// zero forever). The count decrements AFTER the promise fires, so poll
+	// briefly rather than racing that bookkeeping.
+	deadline := time.Now().Add(2 * time.Second)
+	for cl.BufferedProduceRecords() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
 	if n := cl.BufferedProduceRecords(); n != 0 {
 		t.Errorf("BufferedProduceRecords = %d after the failed promise, want 0", n)
 	}

--- a/pkg/kfake/txns.go
+++ b/pkg/kfake/txns.go
@@ -737,25 +737,39 @@ func (pidinf *pidinfo) endTx(commit bool) {
 	b.Length = int32(len(benc) - 12)
 	b.CRC = int32(crc32.Checksum(benc[21:], crc32c))
 
-	pidinf.txParts.each(func(t string, p int32, pd *partData) {
+	pidinf.txParts.each(func(t string, p int32, _ *partData) {
+		c := pidinf.pids.c
+		// Markers resolve the partition by name at write time, like the
+		// coordinator's marker writes on a real broker: if the topic
+		// was deleted there is nowhere to write, and if it was deleted
+		// and recreated the marker belongs to the CURRENT log at the
+		// current log's offsets (where any post-recreation by-name
+		// writes of this transaction landed). Writing through the
+		// registration-time pointer would corrupt a recreated topic's
+		// fresh log via the shared on-disk path.
+		pd, ok := c.data.tps.getp(t, p)
+		if !ok {
+			return
+		}
+
+		firstUncommitted, hadUncommitted := pd.uncommittedPIDs[pidinf.id]
 		delete(pd.uncommittedPIDs, pidinf.id)
 
-		c := pidinf.pids.c
 		controlOffset := c.pushBatch(pd, len(benc), b, false) // control record is not itself transactional
 		if controlOffset < 0 {
 			c.cfg.logger.Logf(LogLevelError, "endTx: failed to persist control batch for %s p%d pid %d", t, p, pidinf.id)
 			pd.recalculateLSO()
 			return
 		}
-		if !commit {
-			firstOffset, ok := pidinf.txPartFirstOffsets.getp(t, p)
-			if ok {
-				pd.abortedTxns = append(pd.abortedTxns, abortedTxnEntry{
-					producerID:  pidinf.id,
-					firstOffset: *firstOffset,
-					lastOffset:  controlOffset,
-				})
-			}
+		// The aborted range comes from this log's own uncommitted
+		// bookkeeping, not the transaction's registration-time offsets,
+		// which can reference a dead incarnation.
+		if !commit && hadUncommitted {
+			pd.abortedTxns = append(pd.abortedTxns, abortedTxnEntry{
+				producerID:  pidinf.id,
+				firstOffset: firstUncommitted,
+				lastOffset:  controlOffset,
+			})
 		}
 		pd.recalculateLSO()
 		// Count the now-committed bytes for readCommitted watchers.


### PR DESCRIPTION
Seven kfake commits, split out of the topic-recreation work so they can merge early: they fix real modeling divergences (and two unrelated bugs found along the way) and are independent of any kgo change — the full kfake suite passes against master's kgo.

Broker faithfulness around topic deletion/recreation:

- **Fetch sessions address v13 entries by topic ID.** Name-keyed session entries re-addressed incremental fetches to a recreated topic's new incarnation and answered zero topic IDs; a real broker answers UNKNOWN_TOPIC_ID for the addressed (dead) ID.
- **Deleting a topic drops its producer-state windows.** Producer state is per-log on a real broker and dies with it; kfake kept name-keyed sequence windows, so a client correctly restarting at sequence 0 against a recreated topic got OUT_OF_ORDER_SEQUENCE_NUMBER where a real 2.5+ broker accepts on empty state.
- **Transaction markers resolve partition data by name at write time.** endTx wrote markers through the partData pointers captured at partition registration; across a recreation the stale pointer shares an on-disk path with the new incarnation and corrupted its log (a marker carrying the dead log's offsets landed physically first in the new segment). A real coordinator resolves marker writes by name: deleted topics get no marker, a recreated topic takes the marker at its own offsets. The aborted-range bookkeeping now also comes from the log's own uncommitted state rather than registration-time offsets. Registrations themselves survive deletion, matching the name-keyed coordinator.
- **Deleting a topic clears its share-partition state.** Share state is topic-ID-keyed on a real broker; kfake keys by name and let a recreated topic inherit stale SPSO and acquired-record state instead of starting fresh.
- **ListOffsets returns the epoch of the record at the resolved offset.** It answered every lookup with the partition's current leader epoch; a real broker answers from its epoch cache (first batch's epoch for earliest, the found batch's epoch for timestamp lookups). The current epoch made every freshly reset consumer look as if it had consumed an epoch above the historical records it was about to read.

Unrelated fixes found while testing:

- **ApiVersions responses no longer hand controls the shared package-global key slice.** A control mutating its response corrupted every later response process-wide.
- **The shutdown audit test's buffered-count assert raced** promise completion (the count decrements after promises fire).

The kgo topic-recreation branch builds on these; it follows separately.