### PR TITLE
kgo: add StreamingCompression, compressed-size-bound batch coalescing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -263,6 +263,55 @@ cycles to minimize allocations. The `isLingering` bool tracks whether the timer
 is active (rather than checking `lingering == nil`) because the timer object
 persists even when stopped.
 
+### Streaming compression (drain-time coalescing)
+
+Batches are bounded by `ProducerBatchMaxBytes` measured on UNCOMPRESSED
+records, so with compression ratio R a backlog drains in ~R times more produce
+round trips per partition than the broker's `max.message.bytes` requires. With
+the opt-in `StreamingCompression` option (gzip/zstd/lz4 only; snappy is a
+one-shot block codec), the sink's drain loop coalesces each partition's backlog
+into batches bounded by their exact COMPRESSED size, via freeze-steal-merge
+(`sink.go:mergeBacklog`):
+
+1. **Steal** (under `recBuf.mu`): the span of consecutive never-sent batches at
+   the drain index is marked `merging`, which blocks admission appends
+   (`tryBuffer`) and drains (`createReq` skips merging batches) WITHOUT
+   removing them from `recBuf.batches` - a concurrent `failAllRecords`/purge
+   sweep must still own their promises.
+2. **Merge** (no `recBuf.mu`; compression never stalls admission): the span's
+   records stream through a pooled compressor (`compression.go:
+   streamCompressor`, bufio-staged writes) with a worst-case
+   decide-before-write bound: bytes since the last flush plus the candidate
+   record are assumed incompressible; a flush tightens the bound only when
+   that worst case would overflow, and a final overflow cuts BEFORE writing.
+   The compressed batch provably never exceeds the limit and the compressor
+   only ever holds accepted records, so sealing is always a clean close - no
+   splitting, no footer surgery. A cut mid-source moves the source's remaining
+   records into a fresh tail batch (legal: never-sent batches have no
+   sequence; sequences are assigned at `tryAddBatch`). Each source's records
+   are read under its `batch.mu`, aborting if a sweep nil'd them.
+3. **Splice** (under `recBuf.mu`): validated against the CURRENT drain index -
+   responses completing mid-merge pop finished front batches and shift
+   indices, which moves the span without touching it, so the merge survives;
+   only a sweep or a retry rewind (drain head frozen) discards it. A discarded
+   merge restores the span records' stored length/timestamp-delta stamps
+   (phase 2 re-stamped them merge-relative; the legacy path serializes from
+   those stamps, and a stale stamp whose varint width differs would desync the
+   wire). On success the consumed sources are replaced by the merged batch
+   (+ tail).
+
+Sealed merged batches cache their compressed blob: `appendSealedTo` writes a
+fresh header + CRC per attempt around the cached bytes, so retries never
+recompress, and `sealStream` overwrites `wireLength` with the exact wire size
+so request packing uses real bytes. Only never-frozen batches merge (frozen ==
+possibly sent: content and sequence are immutable), preserving idempotent and
+transactional semantics exactly. Every odd case (compressor error, produce
+version below the codec's floor) demotes the batch to the legacy
+serialize-at-drain path; records are always kept, so that fallback is always
+available. Merging requires a backlog of two or more never-sent batches - an
+idle or keeping-up partition drains byte-for-byte identically to the option
+being off.
+
 ### When can a batch fail?
 
 This is subtle and important for idempotency. The rules:

--- a/compressbench/compressbench.go
+++ b/compressbench/compressbench.go
@@ -1,0 +1,296 @@
+// Package compressbench is a throwaway experiment (branch compress-density)
+// comparing two Kafka record-batch packing strategies:
+//
+//	A (what franz-go does today): accumulate records until their UNCOMPRESSED
+//	  wire size would exceed maxBatch, then compress the batch once. Simple and
+//	  exact, but the compressed batch ends up ~1/ratio of the limit -> under-packed.
+//
+//	B (proposed): stream records through a compressor and cut by COMPRESSED size.
+//	  Uses decide-before-write with a worst-case (incompressible) reservation for
+//	  the candidate record plus a flush-to-tighten only when nearing the boundary,
+//	  so it never overflows, never splits, and never Closes a polluted compressor.
+//
+// The question this answers: does B's denser packing (fewer, bigger batches ->
+// fewer produce requests) beat the compression-ratio tax of the boundary flushes?
+package compressbench
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"math/rand"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const (
+	batchHeader    = 61 // record batch v2 header bytes (fixed)
+	framingReserve = 5  // worst-case flexible (v9+) COMPACT_BYTES uvarint prefix
+)
+
+// ---- record wire encoding (mirrors franz-go promisedRec.appendTo) ----
+
+func appendVarint(dst []byte, v int32) []byte {
+	uv := uint32(v<<1) ^ uint32(v>>31) // zigzag
+	for uv >= 0x80 {
+		dst = append(dst, byte(uv)|0x80)
+		uv >>= 7
+	}
+	return append(dst, byte(uv))
+}
+
+func appendVarlong(dst []byte, v int64) []byte {
+	uv := uint64(v<<1) ^ uint64(v>>63)
+	for uv >= 0x80 {
+		dst = append(dst, byte(uv)|0x80)
+		uv >>= 7
+	}
+	return append(dst, byte(uv))
+}
+
+func appendVarintBytes(dst, b []byte) []byte {
+	dst = appendVarint(dst, int32(len(b)))
+	return append(dst, b...)
+}
+
+// recordWire returns the on-wire bytes of one record (length-prefixed body),
+// exactly as franz-go serializes it into the (to-be-compressed) records blob.
+func recordWire(key, val []byte, offsetDelta int32) []byte {
+	var body []byte
+	body = append(body, 0)        // attributes
+	body = appendVarlong(body, 0) // timestampDelta
+	body = appendVarint(body, offsetDelta)
+	body = appendVarintBytes(body, key)
+	body = appendVarintBytes(body, val)
+	body = appendVarint(body, 0) // header count
+	var dst []byte
+	dst = appendVarint(dst, int32(len(body)))
+	return append(dst, body...)
+}
+
+// ---- streaming compressor adapter ----
+
+type stream interface {
+	write(p []byte)
+	flush()             // sync flush; retains dictionary
+	compressedLen() int // valid only right after flush()/close()
+	close() []byte      // finalize (emit footer), return full compressed bytes
+	reset()             // reset for reuse (as if pooled)
+	footerMax() int     // upper bound on bytes close() appends beyond the last flush
+}
+
+type gzipStream struct {
+	buf *bytes.Buffer
+	w   *gzip.Writer
+}
+
+func newGzip(level int) func() stream {
+	return func() stream {
+		buf := new(bytes.Buffer)
+		w, _ := gzip.NewWriterLevel(buf, level)
+		return &gzipStream{buf, w}
+	}
+}
+func (g *gzipStream) write(p []byte)     { g.w.Write(p) }
+func (g *gzipStream) flush()             { g.w.Flush() }
+func (g *gzipStream) compressedLen() int { return g.buf.Len() }
+func (g *gzipStream) close() []byte      { g.w.Close(); return g.buf.Bytes() }
+func (g *gzipStream) reset()             { g.buf.Reset(); g.w.Reset(g.buf) }
+func (*gzipStream) footerMax() int       { return 8 } // gzip CRC32 + ISIZE
+
+type zstdStream struct {
+	buf *bytes.Buffer
+	enc *zstd.Encoder
+}
+
+func newZstd(level zstd.EncoderLevel) func() stream {
+	opts := []zstd.EOption{
+		zstd.WithEncoderLevel(level),
+		zstd.WithWindowSize(64 << 10),
+		zstd.WithEncoderConcurrency(1),
+		zstd.WithZeroFrames(true),
+	}
+	return func() stream {
+		buf := new(bytes.Buffer)
+		enc, _ := zstd.NewWriter(buf, opts...)
+		return &zstdStream{buf, enc}
+	}
+}
+func (z *zstdStream) write(p []byte)     { z.enc.Write(p) }
+func (z *zstdStream) flush()             { z.enc.Flush() }
+func (z *zstdStream) compressedLen() int { return z.buf.Len() }
+func (z *zstdStream) close() []byte      { z.enc.Close(); return z.buf.Bytes() }
+func (z *zstdStream) reset()             { z.buf.Reset(); z.enc.Reset(z.buf) }
+func (*zstdStream) footerMax() int       { return 16 } // zstd frame epilogue (generous)
+
+// ---- packing strategies ----
+
+// packA is today's franz-go behavior: bound the batch by uncompressed wire size,
+// compress once at seal. onBatch (optional) receives each sealed batch's
+// compressed length (excluding header/framing).
+func packA(wires [][]byte, maxBatch int, newStream func() stream, onBatch func(int)) (nBatches, totalWire int) {
+	s := newStream()
+	uncompressed, nInBatch := 0, 0
+	seal := func() {
+		c := s.close()
+		nBatches++
+		totalWire += batchHeader + len(c)
+		if onBatch != nil {
+			onBatch(len(c))
+		}
+		s.reset()
+		uncompressed, nInBatch = 0, 0
+	}
+	for _, w := range wires {
+		if nInBatch > 0 && batchHeader+uncompressed+len(w)+framingReserve > maxBatch {
+			seal()
+		}
+		s.write(w)
+		uncompressed += len(w)
+		nInBatch++
+	}
+	if nInBatch > 0 {
+		seal()
+	}
+	return
+}
+
+// packB is the proposed streaming, compressed-size-bound packing. It decides
+// BEFORE writing each record (so the compressor only ever holds accepted
+// records and close() is clean), reserving the candidate's uncompressed size as
+// its worst-case compressed contribution, and flushing to tighten the estimate
+// only when the worst case would exceed the limit.
+func packB(wires [][]byte, maxBatch int, newStream func() stream, onBatch func(int)) (nBatches, totalWire int) {
+	s := newStream()
+	reserve := batchHeader + s.footerMax() + framingReserve
+	checkpoint := 0 // exact compressed length at last flush
+	sinceFlush := 0 // uncompressed bytes written since last flush
+	nInBatch := 0
+	seal := func() {
+		c := s.close()
+		nBatches++
+		totalWire += batchHeader + len(c)
+		if onBatch != nil {
+			onBatch(len(c))
+		}
+		s.reset()
+		checkpoint, sinceFlush, nInBatch = 0, 0, 0
+	}
+	for _, w := range wires {
+		// Worst case if we accept w: everything since the last flush plus w
+		// might be incompressible.
+		if reserve+checkpoint+sinceFlush+len(w) > maxBatch && nInBatch > 0 {
+			s.flush() // tighten: convert sinceFlush into real compressed bytes
+			checkpoint = s.compressedLen()
+			sinceFlush = 0
+			if reserve+checkpoint+len(w) > maxBatch {
+				seal() // even tightened, w won't fit -> cut before writing it
+			}
+		}
+		s.write(w)
+		sinceFlush += len(w)
+		nInBatch++
+	}
+	if nInBatch > 0 {
+		seal()
+	}
+	return
+}
+
+// packAdaptive is packB with a cheap incompressibility guard: once a boundary
+// flush reveals the batch is compressing poorly (< ~10%), it stops flushing and
+// falls back to A's uncompressed bound for the rest of the run. That kills the
+// gzip-on-incompressible flush tax while keeping B's density on compressible
+// data (which is the only place density is available anyway). The guard is
+// sticky per run: a uniformly incompressible stream probes once, then behaves
+// like A.
+func packAdaptive(wires [][]byte, maxBatch int, newStream func() stream, onBatch func(int)) (nBatches, totalWire int) {
+	s := newStream()
+	reserve := batchHeader + s.footerMax() + framingReserve
+	checkpoint, sinceFlush, uncomp, nInBatch := 0, 0, 0, 0
+	incompressible := false
+	seal := func() {
+		c := s.close()
+		nBatches++
+		totalWire += batchHeader + len(c)
+		if onBatch != nil {
+			onBatch(len(c))
+		}
+		s.reset()
+		checkpoint, sinceFlush, uncomp, nInBatch = 0, 0, 0, 0
+	}
+	for _, w := range wires {
+		if incompressible {
+			if nInBatch > 0 && batchHeader+uncomp+len(w)+framingReserve > maxBatch {
+				seal()
+			}
+			s.write(w)
+			uncomp += len(w)
+			nInBatch++
+			continue
+		}
+		if reserve+checkpoint+sinceFlush+len(w) > maxBatch && nInBatch > 0 {
+			s.flush()
+			checkpoint = s.compressedLen()
+			sinceFlush = 0
+			if checkpoint > (uncomp*9)/10 { // < ~10% compression -> stop trying
+				incompressible = true
+			}
+			if reserve+checkpoint+len(w) > maxBatch {
+				seal()
+			}
+		}
+		s.write(w)
+		sinceFlush += len(w)
+		uncomp += len(w)
+		nInBatch++
+	}
+	if nInBatch > 0 {
+		seal()
+	}
+	return
+}
+
+// ---- workload generation ----
+
+// genFn produces one record value given a deterministic rng and record index.
+type genFn = func(rng *rand.Rand, i int) []byte
+
+// mixVal builds a value that is a repeated JSON-ish template with randFrac of
+// its bytes replaced by incompressible random, giving a tunable compression
+// ratio (0.15 -> ~5x, 0.55 -> ~1.8x, 1.0 -> ~1x). This models real payloads
+// (logs/JSON with some high-entropy fields), not a pure-redundancy strawman.
+func mixVal(size int, randFrac float64) genFn {
+	tmpl := []byte(`{"event":"click","user":"user-000000","session":"sess-0000","page":"/home/index","ts":1700000000000,"props":{"a":"x","b":"y","c":"z"}}`)
+	nRand := int(float64(size) * randFrac)
+	nTmpl := size - nRand
+	return func(rng *rand.Rand, _ int) []byte {
+		v := make([]byte, 0, size)
+		for len(v) < nTmpl {
+			v = append(v, tmpl...)
+		}
+		v = v[:nTmpl]
+		for j := 0; j < 4 && nTmpl > 4; j++ { // vary a few bytes so records differ
+			v[rng.Intn(nTmpl)] = byte('0' + rng.Intn(10))
+		}
+		r := make([]byte, nRand)
+		rng.Read(r)
+		return append(v, r...)
+	}
+}
+
+func highCompressVal(size int) genFn { return mixVal(size, 0.15) } // ~5x
+func medCompressVal(size int) genFn  { return mixVal(size, 0.55) } // ~1.8x
+func lowCompressVal(size int) genFn  { return mixVal(size, 1.0) }  // ~1x
+
+// genWires produces nRecords serialized record wires with the given value size
+// and compressibility. Keys are small and structured.
+func genWires(nRecords, _ int, genVal func(*rand.Rand, int) []byte) [][]byte {
+	rng := rand.New(rand.NewSource(1))
+	wires := make([][]byte, nRecords)
+	for i := range wires {
+		key := []byte(fmt.Sprintf("key-%08d", i))
+		wires[i] = recordWire(key, genVal(rng, i), int32(i))
+	}
+	return wires
+}

--- a/compressbench/compressbench_test.go
+++ b/compressbench/compressbench_test.go
@@ -1,0 +1,137 @@
+package compressbench
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const maxBatch = 1 << 20 // 1 MiB
+
+type codec struct {
+	name string
+	new  func() stream
+}
+
+func codecs() []codec {
+	return []codec{
+		{"gzip", newGzip(6)},
+		{"zstd", newZstd(zstd.SpeedDefault)},
+	}
+}
+
+var payloads = []struct {
+	name string
+	gen  func(size int) genFn
+}{
+	{"high", highCompressVal},
+	{"med", medCompressVal},
+	{"low", lowCompressVal},
+}
+
+// TestReport prints the density comparison. Run:
+//
+//	go test -run TestReport -v ./compressbench/
+func TestReport(t *testing.T) {
+	const targetBytes = 8 << 20 // ~8 MiB uncompressed per config
+	valSizes := []int{128, 1024, 16384}
+
+	fmt.Printf("\nmaxBatch=%d KiB   (A = uncompressed-bound/today, B = compressed-bound/proposed)\n", maxBatch>>10)
+	fmt.Printf("%-6s %-5s %-6s | %6s %11s %7s | %6s %11s %7s | %7s %7s\n",
+		"codec", "data", "valB", "A:nBt", "A:wire", "A:rec/bt", "B:nBt", "B:wire", "B:rec/bt", "batchX", "wire%")
+	fmt.Println("-----------------------------------------------------------------------------------------------------")
+
+	for _, c := range codecs() {
+		for _, p := range payloads {
+			for _, vs := range valSizes {
+				n := targetBytes / vs
+				wires := genWires(n, vs, p.gen(vs))
+				na, wa := packA(wires, maxBatch, c.new, nil)
+				nb, wb := packB(wires, maxBatch, c.new, nil)
+				fmt.Printf("%-6s %-5s %-6d | %6d %11d %7d | %6d %11d %7d | %6.2fx %6.1f%%\n",
+					c.name, p.name, vs,
+					na, wa, n/max1(na),
+					nb, wb, n/max1(nb),
+					float64(na)/float64(max1(nb)),
+					100*float64(wb)/float64(max1(wa)))
+			}
+		}
+		fmt.Println()
+	}
+}
+
+// TestInvariantNeverOverflow fuzzes packB and asserts every sealed batch fits,
+// including near-batch-size and incompressible records (the reservation's worst
+// case).
+func TestInvariantNeverOverflow(t *testing.T) {
+	worst := []struct {
+		name string
+		gen  func(size int) genFn
+	}{
+		{"high", highCompressVal},
+		{"low", lowCompressVal},
+	}
+	for _, c := range codecs() {
+		for _, p := range worst {
+			for _, vs := range []int{64, 512, 4096, 100_000} {
+				wires := genWires((16<<20)/vs, vs, p.gen(vs))
+				maxSeen := 0
+				packB(wires, maxBatch, c.new, func(clen int) {
+					framed := batchHeader + clen + framingReserve
+					if framed > maxSeen {
+						maxSeen = framed
+					}
+					if framed > maxBatch {
+						t.Fatalf("%s/%s/val=%d: batch framed size %d exceeds maxBatch %d",
+							c.name, p.name, vs, framed, maxBatch)
+					}
+				})
+				t.Logf("%s/%s/val=%-6d max framed batch = %d (%.1f%% of limit)",
+					c.name, p.name, vs, maxSeen, 100*float64(maxSeen)/maxBatch)
+			}
+		}
+	}
+}
+
+func BenchmarkPack(b *testing.B) {
+	const targetBytes = 2 << 20 // ~2 MiB per op
+	configs := []struct {
+		payload string
+		valSize int
+		gen     genFn
+	}{
+		{"high", 1024, highCompressVal(1024)},
+		{"low", 1024, lowCompressVal(1024)},
+	}
+	for _, c := range codecs() {
+		for _, cfg := range configs {
+			wires := genWires(targetBytes/cfg.valSize, cfg.valSize, cfg.gen)
+			b.Run(fmt.Sprintf("%s/%s/A", c.name, cfg.payload), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					packA(wires, maxBatch, c.new, nil)
+				}
+			})
+			b.Run(fmt.Sprintf("%s/%s/B", c.name, cfg.payload), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					packB(wires, maxBatch, c.new, nil)
+				}
+			})
+			b.Run(fmt.Sprintf("%s/%s/AD", c.name, cfg.payload), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					packAdaptive(wires, maxBatch, c.new, nil)
+				}
+			})
+		}
+	}
+}
+
+func max1(v int) int {
+	if v < 1 {
+		return 1
+	}
+	return v
+}

--- a/pkg/kfake/config.go
+++ b/pkg/kfake/config.go
@@ -57,11 +57,23 @@ type cfg struct {
 	// persistence. This allows tests to share a memFS across
 	// cluster restarts without touching the real disk.
 	injectFS fs
+
+	blackholeProduce bool
 }
 
 // NumBrokers sets the number of brokers to start in the fake cluster.
 func NumBrokers(n int) Opt {
 	return opt{func(cfg *cfg) { cfg.nbrokers = n }}
+}
+
+// BlackholeProduce makes the cluster accept produce requests and reply success
+// without persisting the records to segments: offsets still advance and
+// idempotent/transactional sequence validation still runs, but the record bytes
+// are discarded and no fetch/index state is built. This keeps broker-side
+// storage from dominating produce-throughput benchmarks. Do not consume from a
+// blackholed cluster; there is nothing to read.
+func BlackholeProduce() Opt {
+	return opt{func(cfg *cfg) { cfg.blackholeProduce = true }}
 }
 
 // Ports sets the ports to listen on, overriding randomly choosing NumBrokers

--- a/pkg/kfake/data.go
+++ b/pkg/kfake/data.go
@@ -235,6 +235,28 @@ func (c *Cluster) newPartData(p int32) func() *partData {
 // If transactional, the producer's PID is registered in uncommittedPIDs
 // so the LSO stays at the earliest uncommitted offset.
 func (c *Cluster) pushBatch(pd *partData, nbytes int, b kmsg.RecordBatch, inTx bool) int64 {
+	// Blackhole: advance offset/txn/lso accounting so the client sees a
+	// well-formed produce response and idempotent sequences keep flowing, but
+	// discard the records (no segment write, no index, no fetch watches). Keeps
+	// broker storage out of produce-throughput benchmarks.
+	if c.cfg.blackholeProduce {
+		firstOffset := pd.highWatermark
+		pd.highWatermark += int64(b.NumRecords)
+		if inTx {
+			if pd.uncommittedPIDs == nil {
+				pd.uncommittedPIDs = make(map[int64]int64)
+			}
+			if existing, ok := pd.uncommittedPIDs[b.ProducerID]; !ok || firstOffset < existing {
+				pd.uncommittedPIDs[b.ProducerID] = firstOffset
+			}
+		}
+		if len(pd.uncommittedPIDs) == 0 {
+			pd.lastStableOffset += int64(b.NumRecords)
+		}
+		pd.nbytes += int64(nbytes)
+		return firstOffset
+	}
+
 	maxEarlierTimestamp := b.FirstTimestamp
 	if maxEarlierTimestamp < pd.maxFirstTimestamp {
 		maxEarlierTimestamp = pd.maxFirstTimestamp

--- a/pkg/kfake/produce_bench_test.go
+++ b/pkg/kfake/produce_bench_test.go
@@ -1,0 +1,186 @@
+package kfake
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// mixValue builds a value of the given size with randFrac incompressible bytes
+// (0.15 -> ~5x compressible, 1.0 -> ~1x).
+func mixValue(size int, randFrac float64) []byte {
+	tmpl := []byte(`{"event":"click","user":"user-000000","session":"sess-0000","page":"/home/index","ts":1700000000000,"props":{"a":"x","b":"y","c":"z"}}`)
+	nRand := int(float64(size) * randFrac)
+	v := make([]byte, 0, size)
+	for len(v) < size-nRand {
+		v = append(v, tmpl...)
+	}
+	v = v[:size-nRand]
+	r := make([]byte, nRand)
+	rand.New(rand.NewSource(1)).Read(r)
+	return append(v, r...)
+}
+
+type produceReqCounter struct{ n *atomic.Int64 }
+
+func (c produceReqCounter) OnBrokerWrite(_ kgo.BrokerMetadata, key int16, _ int, _, _ time.Duration, _ error) {
+	if key == 0 { // Produce
+		c.n.Add(1)
+	}
+}
+
+// BenchmarkProduceBlackhole measures end-to-end produce throughput and batch
+// density (records per produce request) against a blackholing kfake, with and
+// without StreamingCompression. Run:
+//
+//	go test -run xxx -bench BenchmarkProduceBlackhole -benchtime=300000x ./
+func BenchmarkProduceBlackhole(b *testing.B) {
+	codecs := []struct {
+		name string
+		c    kgo.CompressionCodec
+	}{
+		{"none", kgo.NoCompression()},
+		{"gzip", kgo.GzipCompression()},
+		{"zstd", kgo.ZstdCompression()},
+		{"lz4", kgo.Lz4Compression()},
+	}
+	lingers := []struct {
+		name string
+		d    time.Duration
+	}{
+		{"linger0", 0},
+		{"linger1ms", time.Millisecond},
+	}
+	const valSize = 512
+
+	for _, codec := range codecs {
+		for _, linger := range lingers {
+			for _, stream := range []bool{false, true} {
+				mode := "legacy"
+				if stream {
+					mode = "stream"
+				}
+				b.Run(codec.name+"/"+linger.name+"/"+mode, func(b *testing.B) {
+					c, err := NewCluster(NumBrokers(1), BlackholeProduce(), SeedTopics(4, "bench"))
+					if err != nil {
+						b.Fatal(err)
+					}
+					defer c.Close()
+
+					var reqs atomic.Int64
+					opts := []kgo.Opt{
+						kgo.SeedBrokers(c.ListenAddrs()...),
+						kgo.DefaultProduceTopic("bench"),
+						kgo.ProducerBatchCompression(codec.c),
+						kgo.MaxBufferedRecords(1 << 20),
+						kgo.WithHooks(produceReqCounter{&reqs}),
+					}
+					if linger.d > 0 {
+						opts = append(opts, kgo.ProducerLinger(linger.d))
+					}
+					if stream {
+						opts = append(opts, kgo.StreamingCompression())
+					}
+					cl, err := kgo.NewClient(opts...)
+					if err != nil {
+						b.Fatal(err)
+					}
+					defer cl.Close()
+
+					val := mixValue(valSize, 0.15)
+					b.SetBytes(int64(valSize))
+					b.ResetTimer()
+
+					var wg sync.WaitGroup
+					wg.Add(b.N)
+					for i := 0; i < b.N; i++ {
+						cl.Produce(context.Background(), &kgo.Record{Value: val}, func(_ *kgo.Record, err error) {
+							if err != nil {
+								b.Error(err)
+							}
+							wg.Done()
+						})
+					}
+					wg.Wait()
+					b.StopTimer()
+
+					if n := reqs.Load(); n > 0 {
+						b.ReportMetric(float64(b.N)/float64(n), "rec/req")
+					}
+				})
+			}
+		}
+	}
+}
+
+// BenchmarkProduceBlackholePar is BenchmarkProduceBlackhole with 4x GOMAXPROCS
+// producing goroutines.
+func BenchmarkProduceBlackholePar(b *testing.B) {
+	for _, codec := range []struct {
+		name string
+		c    kgo.CompressionCodec
+	}{
+		{"none", kgo.NoCompression()},
+		{"gzip", kgo.GzipCompression()},
+		{"zstd", kgo.ZstdCompression()},
+	} {
+		for _, stream := range []bool{false, true} {
+			mode := "legacy"
+			if stream {
+				mode = "stream"
+			}
+			b.Run(codec.name+"/"+mode, func(b *testing.B) {
+				c, err := NewCluster(NumBrokers(1), BlackholeProduce(), SeedTopics(4, "bench"))
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer c.Close()
+
+				var reqs atomic.Int64
+				opts := []kgo.Opt{
+					kgo.SeedBrokers(c.ListenAddrs()...),
+					kgo.DefaultProduceTopic("bench"),
+					kgo.ProducerBatchCompression(codec.c),
+					kgo.MaxBufferedRecords(1 << 20),
+					kgo.WithHooks(produceReqCounter{&reqs}),
+				}
+				if stream {
+					opts = append(opts, kgo.StreamingCompression())
+				}
+				cl, err := kgo.NewClient(opts...)
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer cl.Close()
+
+				val := mixValue(512, 0.15)
+				b.SetBytes(512)
+				b.SetParallelism(4)
+				b.ResetTimer()
+
+				var wg sync.WaitGroup
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						wg.Add(1)
+						cl.Produce(context.Background(), &kgo.Record{Value: val}, func(_ *kgo.Record, err error) {
+							if err != nil {
+								b.Error(err)
+							}
+							wg.Done()
+						})
+					}
+				})
+				wg.Wait()
+				b.StopTimer()
+				if n := reqs.Load(); n > 0 {
+					b.ReportMetric(float64(b.N)/float64(n), "rec/req")
+				}
+			})
+		}
+	}
+}

--- a/pkg/kfake/stream_compress_test.go
+++ b/pkg/kfake/stream_compress_test.go
@@ -1,0 +1,560 @@
+package kfake
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// These tests exercise kgo.StreamingCompression end to end. kfake validates
+// every produced batch's CRC, batch length, magic, compression type, and
+// idempotent sequences, and the consume side decompresses and re-parses every
+// record, so passing runs prove the merged wire bytes are well formed and
+// sequence-correct, not merely accepted.
+
+type streamCodec struct {
+	name       string
+	c          kgo.CompressionCodec
+	streamable bool
+}
+
+func streamCodecs() []streamCodec {
+	return []streamCodec{
+		{"gzip", kgo.GzipCompression(), true},
+		{"zstd", kgo.ZstdCompression(), true},
+		{"lz4", kgo.Lz4Compression(), true},
+		{"snappy", kgo.SnappyCompression(), false}, // one-shot block codec: option is a no-op
+		{"none", kgo.NoCompression(), false},       // option is a no-op
+	}
+}
+
+// streamWorkload deterministically generates n records with mixed sizes,
+// headers, and nil values, ~5x compressible.
+func streamWorkload(n int) (recs []*kgo.Record, expected map[string][]byte) {
+	rng := rand.New(rand.NewSource(2))
+	base := mixValue(2048, 0.15)
+	expected = make(map[string][]byte, n)
+	recs = make([]*kgo.Record, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("k-%06d", i)
+		var val []byte
+		switch i % 5 {
+		case 0:
+			val = base[:16]
+		case 1:
+			val = base[:512]
+		case 2:
+			val = base[:2048]
+		case 3:
+			val = base[rng.Intn(1024) : 1024+rng.Intn(1024)]
+		case 4:
+			val = nil
+		}
+		expected[key] = val
+		r := &kgo.Record{Key: []byte(key), Value: val}
+		if i%7 == 0 {
+			r.Headers = []kgo.RecordHeader{{Key: "h1", Value: []byte("v1")}, {Key: "h2", Value: base[:32]}}
+		}
+		recs[i] = r
+	}
+	return recs, expected
+}
+
+// consumeExactly consumes from topic until exactly n records are seen,
+// verifying values byte-for-byte against expected and that no extra records
+// arrive. Returns the number of records that carried headers.
+func consumeExactly(t *testing.T, addrs []string, topic string, n int, expected map[string][]byte) int {
+	t.Helper()
+	consumer, err := kgo.NewClient(
+		kgo.SeedBrokers(addrs...),
+		kgo.ConsumeTopics(topic),
+		kgo.FetchMaxWait(250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+
+	got := make(map[string][]byte, n)
+	total, headered := 0, 0
+	perPart := map[int32][2]int64{} // partition -> {count, maxOffset}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	for total < n {
+		fs := consumer.PollFetches(ctx)
+		if err := fs.Err0(); err != nil {
+			// Diagnostic: where is each partition vs the broker's end offset?
+			req := kmsg.NewPtrListOffsetsRequest()
+			rt := kmsg.NewListOffsetsRequestTopic()
+			rt.Topic = topic
+			for p := int32(0); p < 4; p++ {
+				rp := kmsg.NewListOffsetsRequestTopicPartition()
+				rp.Partition = p
+				rp.Timestamp = -1
+				rt.Partitions = append(rt.Partitions, rp)
+			}
+			req.Topics = append(req.Topics, rt)
+			for p, st := range perPart {
+				t.Logf("DIAG p=%d consumed=%d maxOffsetSeen=%d", p, st[0], st[1])
+			}
+			if kresp, kerr2 := consumer.Request(context.Background(), req); kerr2 != nil {
+				t.Logf("DIAG listoffsets request error: %v", kerr2)
+			} else {
+				for _, rt := range kresp.(*kmsg.ListOffsetsResponse).Topics {
+					for _, rp := range rt.Partitions {
+						t.Logf("DIAG p=%d brokerEndOffset=%d err=%d", rp.Partition, rp.Offset, rp.ErrorCode)
+						st, seen := perPart[rp.Partition]
+						if rp.ErrorCode != 0 || rp.Offset == 0 || (seen && st[1]+1 >= rp.Offset) {
+							continue
+						}
+						// Stuck: raw-fetch at the next unconsumed offset and
+						// dump what the broker serves there.
+						at := int64(0)
+						if seen {
+							at = st[1] + 1
+						}
+						freq := kmsg.NewPtrFetchRequest()
+						freq.MaxWaitMillis = 100
+						freq.MaxBytes = 50 << 20
+						ft := kmsg.NewFetchRequestTopic()
+						ft.Topic = topic
+						fpr := kmsg.NewFetchRequestTopicPartition()
+						fpr.Partition = rp.Partition
+						fpr.FetchOffset = at
+						fpr.PartitionMaxBytes = 1 << 20
+						ft.Partitions = append(ft.Partitions, fpr)
+						freq.Topics = append(freq.Topics, ft)
+						fresp, ferr := consumer.Request(context.Background(), freq)
+						if ferr != nil {
+							t.Logf("DIAG p=%d rawfetch@%d error: %v", rp.Partition, at, ferr)
+							continue
+						}
+						for _, frt := range fresp.(*kmsg.FetchResponse).Topics {
+							for _, frp := range frt.Partitions {
+								raw := frp.RecordBatches
+								t.Logf("DIAG p=%d rawfetch@%d err=%d hwm=%d rawbytes=%d", frp.Partition, at, frp.ErrorCode, frp.HighWatermark, len(raw))
+								for len(raw) > 12 {
+									var b kmsg.RecordBatch
+									if err := b.ReadFrom(raw); err != nil {
+										t.Logf("DIAG   batch parse err after header: %v (rem=%d)", err, len(raw))
+										break
+									}
+									whole := 12 + int(b.Length)
+									trunc := whole > len(raw)
+									t.Logf("DIAG   batch first=%d nrec=%d lod=%d len=%d attrs=%x truncated=%v", b.FirstOffset, b.NumRecords, b.LastOffsetDelta, b.Length, b.Attributes, trunc)
+									if trunc {
+										break
+									}
+									raw = raw[whole:]
+								}
+							}
+						}
+					}
+				}
+			}
+			t.Fatalf("poll error with %d/%d consumed: %v", total, n, err)
+		}
+		fs.EachRecord(func(r *kgo.Record) {
+			total++
+			got[string(r.Key)] = r.Value
+			if len(r.Headers) > 0 {
+				headered++
+			}
+			st := perPart[r.Partition]
+			st[0]++
+			if r.Offset > st[1] {
+				st[1] = r.Offset
+			}
+			perPart[r.Partition] = st
+		})
+	}
+	// One more short poll: nothing else should arrive (no duplicates).
+	extraCtx, extraCancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer extraCancel()
+	extra := 0
+	consumer.PollFetches(extraCtx).EachRecord(func(*kgo.Record) { extra++ })
+	if extra != 0 {
+		t.Fatalf("consumed %d duplicate/extra records after the expected %d", extra, n)
+	}
+	if len(got) != n {
+		t.Fatalf("consumed %d records but only %d unique keys (duplicates?)", total, len(got))
+	}
+	for k, want := range expected {
+		gotv, ok := got[k]
+		if !ok {
+			t.Fatalf("missing key %s", k)
+		}
+		if !bytes.Equal(gotv, want) {
+			t.Fatalf("key %s: value mismatch (got %d bytes, want %d)", k, len(gotv), len(want))
+		}
+	}
+	return headered
+}
+
+// TestStreamCompressRoundTrip produces with and without StreamingCompression
+// across all codecs, verifies every record byte-for-byte, and asserts the
+// density win: with manual flushing (so batches roll purely on the size
+// bound), streaming codecs must pack materially more records per produce
+// request than the same codec without the option.
+func TestStreamCompressRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var results sync.Map // "codec/mode" -> rec/req
+
+	t.Run("matrix", func(t *testing.T) {
+		for _, codec := range streamCodecs() {
+			for _, stream := range []bool{false, true} {
+				mode := "legacy"
+				if stream {
+					mode = "stream"
+				}
+				t.Run(codec.name+"/"+mode, func(t *testing.T) {
+					t.Parallel()
+					c, err := NewCluster(NumBrokers(1), SeedTopics(2, "rt"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer c.Close()
+
+					var produceReqs atomic.Int64
+					opts := []kgo.Opt{
+						kgo.SeedBrokers(c.ListenAddrs()...),
+						kgo.DefaultProduceTopic("rt"),
+						kgo.ProducerBatchCompression(codec.c),
+						kgo.MaxBufferedRecords(200_000),
+						// Manual flushing so batches roll purely on the size
+						// bound rather than drain cadence.
+						kgo.ManualFlushing(),
+						kgo.WithHooks(produceReqCounter{&produceReqs}),
+					}
+					if stream {
+						opts = append(opts, kgo.StreamingCompression())
+					}
+					cl, err := kgo.NewClient(opts...)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer cl.Close()
+
+					const n = 40_000
+					recs, expected := streamWorkload(n)
+					var wg sync.WaitGroup
+					wg.Add(n)
+					var failed atomic.Int64
+					for _, r := range recs {
+						cl.Produce(context.Background(), r, func(_ *kgo.Record, err error) {
+							if err != nil {
+								failed.Add(1)
+							}
+							wg.Done()
+						})
+					}
+					if err := cl.Flush(context.Background()); err != nil {
+						t.Fatalf("flush: %v", err)
+					}
+					wg.Wait()
+					if f := failed.Load(); f > 0 {
+						t.Fatalf("%d produces failed", f)
+					}
+
+					recPerReq := float64(n) / float64(produceReqs.Load())
+					results.Store(codec.name+"/"+mode, recPerReq)
+					t.Logf("%s/%s: %d records in %d produce requests (%.0f rec/req)", codec.name, mode, n, produceReqs.Load(), recPerReq)
+
+					headered := consumeExactly(t, c.ListenAddrs(), "rt", n, expected)
+					if want := n / 7; headered < want {
+						t.Errorf("saw %d headered records, want >= %d", headered, want)
+					}
+				})
+			}
+		}
+	})
+
+	loadf := func(name string) float64 {
+		v, ok := results.Load(name)
+		if !ok {
+			t.Fatalf("missing result for %s", name)
+		}
+		return v.(float64)
+	}
+	for _, codec := range streamCodecs() {
+		legacy, stream := loadf(codec.name+"/legacy"), loadf(codec.name+"/stream")
+		if codec.streamable {
+			if stream < 2.5*legacy {
+				t.Errorf("%s: streaming packed %.0f rec/req, want >= 2.5x legacy's %.0f", codec.name, stream, legacy)
+			}
+		} else if stream < 0.7*legacy || stream > 1.5*legacy {
+			t.Errorf("%s: option should be a no-op, got stream %.0f vs legacy %.0f rec/req", codec.name, stream, legacy)
+		}
+	}
+}
+
+// TestStreamCompressRetry fails the first produce request with a retriable
+// error AFTER merged batches were formed (manual flushing builds the backlog,
+// so the flush drain merges before the first send). The retry must resend the
+// merged batches verbatim: kfake's idempotent sequence validation rejects any
+// gap or reorder, and consuming verifies exactly-once delivery.
+func TestStreamCompressRetry(t *testing.T) {
+	t.Parallel()
+	c, err := NewCluster(NumBrokers(1), SeedTopics(2, "rt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	var failed atomic.Int64
+	c.ControlKey(0, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		// Single-shot: fail every partition of the first produce request.
+		failed.Add(1)
+		req := kreq.(*kmsg.ProduceRequest)
+		resp := req.ResponseKind().(*kmsg.ProduceResponse)
+		for _, t := range req.Topics {
+			st := kmsg.NewProduceResponseTopic()
+			st.Topic = t.Topic
+			st.TopicID = t.TopicID
+			for _, p := range t.Partitions {
+				sp := kmsg.NewProduceResponseTopicPartition()
+				sp.Partition = p.Partition
+				sp.ErrorCode = kerr.NotLeaderForPartition.Code
+				st.Partitions = append(st.Partitions, sp)
+			}
+			resp.Topics = append(resp.Topics, st)
+		}
+		return resp, nil, true
+	})
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic("rt"),
+		kgo.ProducerBatchCompression(kgo.ZstdCompression()),
+		kgo.StreamingCompression(),
+		kgo.MaxBufferedRecords(200_000),
+		kgo.ManualFlushing(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	const n = 20_000
+	recs, expected := streamWorkload(n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	var perr atomic.Int64
+	for _, r := range recs {
+		cl.Produce(context.Background(), r, func(_ *kgo.Record, err error) {
+			if err != nil {
+				perr.Add(1)
+			}
+			wg.Done()
+		})
+	}
+	if err := cl.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	wg.Wait()
+	if e := perr.Load(); e > 0 {
+		t.Fatalf("%d produces failed", e)
+	}
+	if failed.Load() == 0 {
+		t.Fatal("control never fired; retry path not exercised")
+	}
+	consumeExactly(t, c.ListenAddrs(), "rt", n, expected)
+}
+
+// slowProduce installs a persistent control that delays every produce request,
+// so a backlog (and merging) builds while requests are in flight.
+func slowProduce(c *Cluster, d time.Duration) {
+	c.ControlKey(0, func(kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		c.SleepControl(func() { time.Sleep(d) })
+		return nil, nil, false
+	})
+}
+
+// TestStreamCompressPurge purges the topic while merged and merging batches
+// are buffered and in flight against a slow broker: every produce promise must
+// fire exactly once (success or purge error), with no hang and no double
+// promise (the waitgroup would panic on a double Done).
+func TestStreamCompressPurge(t *testing.T) {
+	t.Parallel()
+	c, err := NewCluster(NumBrokers(1), SeedTopics(2, "rt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	slowProduce(c, 15*time.Millisecond)
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic("rt"),
+		kgo.ProducerBatchCompression(kgo.GzipCompression()),
+		kgo.StreamingCompression(),
+		kgo.MaxBufferedRecords(200_000),
+		kgo.ProducerLinger(time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	const n = 10_000
+	recs, _ := streamWorkload(n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	var oks, errs atomic.Int64
+	for _, r := range recs {
+		cl.Produce(context.Background(), r, func(_ *kgo.Record, err error) {
+			if err != nil {
+				errs.Add(1)
+			} else {
+				oks.Add(1)
+			}
+			wg.Done()
+		})
+	}
+	time.Sleep(60 * time.Millisecond) // let some requests fly and merges happen
+	cl.PurgeTopicsFromClient("rt")
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("hang: %d/%d promises fired (ok=%d err=%d)", oks.Load()+errs.Load(), n, oks.Load(), errs.Load())
+	}
+	if got := oks.Load() + errs.Load(); got != n {
+		t.Fatalf("promises fired %d times, want %d", got, n)
+	}
+	t.Logf("purge: %d delivered, %d failed (all promised exactly once)", oks.Load(), errs.Load())
+}
+
+// TestStreamCompressClose closes the client while merged and merging batches
+// are buffered and in flight against a slow broker: every promise must fire
+// exactly once and Close must return.
+func TestStreamCompressClose(t *testing.T) {
+	t.Parallel()
+	c, err := NewCluster(NumBrokers(1), SeedTopics(2, "rt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	slowProduce(c, 15*time.Millisecond)
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic("rt"),
+		kgo.ProducerBatchCompression(kgo.ZstdCompression()),
+		kgo.StreamingCompression(),
+		kgo.MaxBufferedRecords(200_000),
+		kgo.ProducerLinger(time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 10_000
+	recs, _ := streamWorkload(n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	var oks, errs atomic.Int64
+	var badErr atomic.Value
+	for _, r := range recs {
+		cl.Produce(context.Background(), r, func(_ *kgo.Record, err error) {
+			switch {
+			case err == nil:
+				oks.Add(1)
+			case errors.Is(err, kgo.ErrClientClosed) || strings.Contains(err.Error(), "closed"):
+				errs.Add(1)
+			default:
+				errs.Add(1)
+				badErr.Store(err)
+			}
+			wg.Done()
+		})
+	}
+	time.Sleep(60 * time.Millisecond)
+
+	closed := make(chan struct{})
+	go func() { cl.Close(); close(closed) }()
+	select {
+	case <-closed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Close hung")
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("hang: %d/%d promises fired", oks.Load()+errs.Load(), n)
+	}
+	if got := oks.Load() + errs.Load(); got != n {
+		t.Fatalf("promises fired %d times, want %d", got, n)
+	}
+	if be := badErr.Load(); be != nil {
+		t.Logf("note: some records failed with %v (accepted: close-time failures vary)", be)
+	}
+	t.Logf("close: %d delivered, %d failed (all promised exactly once)", oks.Load(), errs.Load())
+}
+
+// TestStreamCompressLiveDrain exercises merging in the LIVE drain path (no
+// manual flushing): a slow broker builds a backlog while linger paces
+// admission, merges happen between requests, and everything must arrive
+// exactly once, byte for byte.
+func TestStreamCompressLiveDrain(t *testing.T) {
+	t.Parallel()
+	c, err := NewCluster(NumBrokers(1), SeedTopics(2, "rt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	slowProduce(c, 5*time.Millisecond)
+
+	cl, err := kgo.NewClient(
+		kgo.SeedBrokers(c.ListenAddrs()...),
+		kgo.DefaultProduceTopic("rt"),
+		kgo.ProducerBatchCompression(kgo.Lz4Compression()),
+		kgo.StreamingCompression(),
+		kgo.MaxBufferedRecords(200_000),
+		kgo.ProducerLinger(time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	const n = 20_000
+	recs, expected := streamWorkload(n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	var perr atomic.Int64
+	for _, r := range recs {
+		cl.Produce(context.Background(), r, func(_ *kgo.Record, err error) {
+			if err != nil {
+				perr.Add(1)
+			}
+			wg.Done()
+		})
+	}
+	if err := cl.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	wg.Wait()
+	if e := perr.Load(); e > 0 {
+		t.Fatalf("%d produces failed", e)
+	}
+	consumeExactly(t, c.ListenAddrs(), "rt", n, expected)
+}

--- a/pkg/kgo/compression.go
+++ b/pkg/kgo/compression.go
@@ -1,6 +1,7 @@
 package kgo
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
@@ -317,6 +318,154 @@ func (c *compressor) Compress(dst *bytes.Buffer, src []byte, flags ...CompressFl
 	}
 
 	return out, use
+}
+
+// streamableCodec reports whether a codec supports the incremental Flush
+// needed for compressed-size-bound batching. gzip, zstd, and lz4 stream;
+// snappy (one-shot block s2) does not, so its batches stay bound by
+// uncompressed size.
+func streamableCodec(codec CompressionCodecType) bool {
+	return codec == CodecGzip || codec == CodecZstd || codec == CodecLz4
+}
+
+// pickCodec mirrors Compress's codec selection for a produce version: the
+// first configured option, skipping zstd when the version is below 7
+// (KIP-110: zstd requires produce v7+). An unknown version (-1, not yet
+// negotiated) optimistically assumes a modern broker; if the negotiated
+// version turns out to be ancient, sealStream demotes the batch to the
+// legacy path, which re-picks with the real version.
+func (c *compressor) pickCodec(produceVersion int32) CompressionCodecType {
+	disableZstd := produceVersion >= 0 && produceVersion < 7
+	for _, option := range c.options {
+		if option == CodecZstd && disableZstd {
+			continue
+		}
+		return option
+	}
+	return CodecNone
+}
+
+// streamStagePool holds the buffered writers that sit in front of a
+// streamCompressor's codec. Records are written one at a time (a few hundred
+// bytes each) but the codecs have real per-Write overhead; staging feeds them
+// in large chunks, matching the efficiency of the legacy whole-batch Compress.
+var streamStagePool = sync.Pool{New: func() any { return bufio.NewWriterSize(nil, 32<<10) }}
+
+// streamCompressor incrementally compresses a batch's records into dst. It lets
+// the buffering path decide batch membership by compressed size (cut a batch
+// just before the compressed bytes would exceed the wire limit) instead of the
+// conservative uncompressed bound, packing ~ratio-x more records per request.
+type streamCompressor struct {
+	c     *compressor
+	codec CompressionCodecType
+	dst   *bytes.Buffer
+	stage *bufio.Writer
+	gz    *gzip.Writer
+	zstd  *zstdEncoder
+	lz4   *lz4.Writer
+}
+
+// stream returns a streaming compressor writing into dst for a streamable
+// codec, or nil otherwise. release must be called when finished.
+func (c *compressor) stream(codec CompressionCodecType, dst *bytes.Buffer) *streamCompressor {
+	sc := &streamCompressor{c: c, codec: codec, dst: dst}
+	switch codec {
+	case CodecGzip:
+		sc.gz = c.gzPool.Get().(*gzip.Writer)
+		sc.gz.Reset(dst)
+	case CodecZstd:
+		sc.zstd = c.zstdPool.Get().(*zstdEncoder)
+		sc.zstd.inner.Reset(dst)
+	case CodecLz4:
+		sc.lz4 = c.lz4Pool.Get().(*lz4.Writer)
+		sc.lz4.Reset(dst)
+	default:
+		return nil
+	}
+	sc.stage = streamStagePool.Get().(*bufio.Writer)
+	switch codec {
+	case CodecGzip:
+		sc.stage.Reset(sc.gz)
+	case CodecZstd:
+		sc.stage.Reset(sc.zstd.inner)
+	case CodecLz4:
+		sc.stage.Reset(sc.lz4)
+	default: // unreachable: the switch above returned nil
+	}
+	return sc
+}
+
+func (sc *streamCompressor) write(p []byte) error {
+	_, err := sc.stage.Write(p)
+	return err
+}
+
+// flush flushes buffered input to dst (retaining the compression window) so
+// that len reflects everything written so far.
+func (sc *streamCompressor) flush() error {
+	if err := sc.stage.Flush(); err != nil {
+		return err
+	}
+	switch sc.codec {
+	case CodecGzip:
+		return sc.gz.Flush()
+	case CodecZstd:
+		return sc.zstd.inner.Flush()
+	case CodecLz4:
+		return sc.lz4.Flush()
+	default: // unreachable: stream() only builds streamable codecs
+		return nil
+	}
+}
+
+// len is the compressed byte count; meaningful only right after flush/finish.
+func (sc *streamCompressor) len() int { return sc.dst.Len() }
+
+// finish finalizes the stream (emits the codec footer) and returns the full
+// compressed records blob. The compressor holds only accepted records, so this
+// is always a clean, well-formed frame.
+func (sc *streamCompressor) finish() ([]byte, error) {
+	if err := sc.stage.Flush(); err != nil {
+		return nil, err
+	}
+	switch sc.codec {
+	case CodecGzip:
+		if err := sc.gz.Close(); err != nil {
+			return nil, err
+		}
+	case CodecZstd:
+		if err := sc.zstd.inner.Close(); err != nil {
+			return nil, err
+		}
+	case CodecLz4:
+		if err := sc.lz4.Close(); err != nil {
+			return nil, err
+		}
+	default: // unreachable: stream() only builds streamable codecs
+	}
+	return sc.dst.Bytes(), nil
+}
+
+// release returns the underlying writer to its pool. The zstd encoder is Reset
+// to a nil writer first: the pool's other consumer (Compress) uses EncodeAll
+// without Resetting, exactly matching how the pool's New creates encoders
+// (zstd.NewWriter(nil, ...)), so we must hand back an encoder in that same
+// EncodeAll-usable state rather than one with a closed stream attached. gzip
+// needs no equivalent because Compress always Resets it before use.
+func (sc *streamCompressor) release() {
+	sc.stage.Reset(nil)
+	streamStagePool.Put(sc.stage)
+	sc.stage = nil
+	switch sc.codec {
+	case CodecGzip:
+		sc.c.gzPool.Put(sc.gz)
+	case CodecZstd:
+		sc.zstd.inner.Reset(nil)
+		sc.c.zstdPool.Put(sc.zstd)
+	case CodecLz4:
+		sc.c.lz4Pool.Put(sc.lz4)
+	default: // unreachable: stream() only builds streamable codecs
+	}
 }
 
 type decompressor struct {

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -143,6 +143,8 @@ type cfg struct {
 	partitioner Partitioner
 	compressor  Compressor
 
+	streamCompression bool
+
 	stopOnDataLoss bool
 	onDataLoss     func(string, int32)
 
@@ -1429,6 +1431,39 @@ func ProducerLinger(linger time.Duration) ProducerOpt {
 // have already been produced and not flushed will return ErrMaxBuffered.
 func ManualFlushing() ProducerOpt {
 	return producerOpt{func(cfg *cfg) { cfg.manualFlushing = true }}
+}
+
+// StreamingCompression opts the producer into compressed-size-bound batch
+// coalescing: whenever a partition has a backlog of two or more unsent
+// batches and the compression codec supports streaming (gzip or zstd), the
+// backlog is merged at drain time into batches bounded by their COMPRESSED
+// wire size rather than their uncompressed size.
+//
+// Batches are normally bounded by ProducerBatchMaxBytes measured on the
+// UNCOMPRESSED records, so with a compression ratio R, batches arrive at the
+// broker ~R times smaller than the broker's max.message.bytes allows. With
+// this option, a backlog drains in ~R times fewer batches and therefore ~R
+// times fewer produce round trips per partition, which raises per-partition
+// throughput whenever round trips are the bottleneck (real network RTT,
+// bounded in-flight requests). The merged batch never exceeds
+// ProducerBatchMaxBytes compressed - membership is decided against the actual
+// compressed size before each record is committed to the batch, so this
+// cannot cause MESSAGE_TOO_LARGE (unlike manually over-provisioning
+// ProducerBatchMaxBytes against an assumed ratio). Merged batches also cache
+// their compressed bytes, so retries do not recompress.
+//
+// Merging only engages on a backlog; with an idle or keeping-up partition,
+// producing and draining behave exactly as without this option. Compression
+// of merged batches happens on the sink goroutine outside the buffering lock,
+// so producing is never stalled behind compression. Records are merged only
+// from batches that have never been attempted on the wire, preserving
+// idempotent and transactional sequence semantics exactly.
+//
+// This option has no effect with snappy (a block codec that cannot be sized
+// incrementally), with a custom Compressor, or against brokers older than
+// 0.11 (message sets).
+func StreamingCompression() ProducerOpt {
+	return producerOpt{func(cfg *cfg) { cfg.streamCompression = true }}
 }
 
 // RecordDeliveryTimeout sets a rough time of how long a record can sit around

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -127,6 +127,15 @@ func (s *sink) createReq(id int64, epoch int16) (*produceRequest, *kmsg.AddParti
 		}
 
 		batch := recBuf.batches[recBuf.batchDrainIdx]
+		if batch.merging {
+			// A concurrent merge (only possible from another sink's drain
+			// during a sink migration overlap) is reading this batch's
+			// records; sending it now would race the merge's splice into a
+			// duplicate. Merges are bounded; retry shortly.
+			recBuf.mu.Unlock()
+			moreToDrain = true
+			continue
+		}
 		if added := req.tryAddBatch(s.produceVersion.Load(), recBuf, batch); !added {
 			recBuf.mu.Unlock()
 			moreToDrain = true
@@ -269,6 +278,12 @@ func (s *sink) drain() {
 	again := true
 	for again {
 		s.maybeBackoff()
+
+		// Coalesce any per-partition backlog into compressed-size-bound
+		// batches before building the request. This runs outside all locks
+		// (the compression itself never blocks admission) and is a no-op
+		// unless StreamingCompression is enabled and a backlog exists.
+		s.mergeBacklogs()
 
 		sem := s.inflightSem.Load().(chan struct{})
 		select {
@@ -1297,6 +1312,7 @@ func (cl *Client) finishBatch(batch *recBatch, producerID int64, producerEpoch i
 	batch.mu.Lock()
 	records, attrs := batch.records, batch.attrs
 	batch.records = nil
+	batch.releaseStream()
 	batch.mu.Unlock()
 
 	cl.producer.promiseBatch(batchPromise{
@@ -1657,10 +1673,12 @@ func (recBuf *recBuf) bufferRecord(pr promisedRec, abortOnNewBatch bool) bool {
 
 		switch {
 		case aborted: // not processed
+			newBatch.releaseStream()
 			recBuf.cl.prsPool.put(newBatch.records)
 			return false
 		case appended: // we return true below
 		default: // processed as failure
+			newBatch.releaseStream()
 			recBuf.cl.prsPool.put(newBatch.records)
 			recBuf.cl.producer.promiseRecord(pr,
 				fmt.Errorf("%w (uncompressed_bytes=%d)", kerr.MessageTooLarge, pr.userSize()),
@@ -1822,6 +1840,7 @@ func (recBuf *recBuf) failAllRecords(err error) {
 		batch.mu.Lock()
 		records := batch.records
 		batch.records = nil
+		batch.releaseStream()
 		batch.mu.Unlock()
 
 		recBuf.cl.producer.promiseBatch(batchPromise{
@@ -1886,6 +1905,14 @@ type recBatch struct {
 	// Once this batch is actually selected to be sent in a produce request,
 	// we freeze it. No more records can be added.
 	frozen bool
+	// merging is set (under the owner recBuf's mu) while the drain-time
+	// coalescer is reading this batch's records outside the mu to merge them
+	// into a compressed-size-bound batch. It blocks admission appends
+	// (tryBuffer) and drains (createReq skips it) without removing the batch
+	// from recBuf.batches, so a concurrent failAllRecords sweep still owns
+	// these records' promises; the coalescer detects such a sweep and
+	// discards its merge. Only never-frozen batches are ever marked.
+	merging bool
 	// We can only fail a batch if we have never issued it, or we have
 	// issued it and have received a response. If we do not receive a
 	// response, we cannot know whether we actually wrote bytes that Kafka
@@ -1915,6 +1942,14 @@ type recBatch struct {
 
 	mu      xsync.Mutex   // guards appendTo's reading of records against failAllRecords emptying it
 	records []promisedRec // record w/ length, ts calculated
+
+	// stream, if non-nil, is this batch's streaming-compression state: the
+	// batch is bounded by compressed size and drains its sealed blob rather
+	// than re-serializing+recompressing records. Nil for non-streamable
+	// codecs, unknown produce versions, custom compressors, and demoted
+	// batches. Guarded like records: recBuf.mu for buffering/sealing,
+	// batch.mu wherever a concurrent AppendTo could be reading.
+	stream *batchStream
 }
 
 // Returns an error if the batch should fail.
@@ -1963,22 +1998,26 @@ func (b *recBatch) appendRecord(pr promisedRec, nums recordNumbers) {
 	b.records = append(b.records, pr)
 }
 
+// recordBatchOverhead is the wire size of a record batch's framing plus header
+// with no records: the 4-byte NULLABLE_BYTES length prefix plus the 61-byte
+// v2 batch header.
+const recordBatchOverhead = 4 + // array len
+	8 + // firstOffset
+	4 + // batchLength
+	4 + // partitionLeaderEpoch
+	1 + // magic
+	4 + // crc
+	2 + // attributes
+	4 + // lastOffsetDelta
+	8 + // firstTimestamp
+	8 + // maxTimestamp
+	8 + // producerID
+	2 + // producerEpoch
+	4 + // seq
+	4 // record array length
+
 // newRecordBatch returns a new record batch for a topic and partition.
 func (recBuf *recBuf) newRecordBatch() *recBatch {
-	const recordBatchOverhead = 4 + // array len
-		8 + // firstOffset
-		4 + // batchLength
-		4 + // partitionLeaderEpoch
-		1 + // magic
-		4 + // crc
-		2 + // attributes
-		4 + // lastOffsetDelta
-		8 + // firstTimestamp
-		8 + // maxTimestamp
-		8 + // producerID
-		2 + // producerEpoch
-		4 + // seq
-		4 // record array length
 	return &recBatch{
 		owner:      recBuf,
 		records:    recBuf.cl.prsPool.get()[:0],
@@ -1986,6 +2025,72 @@ func (recBuf *recBuf) newRecordBatch() *recBatch {
 
 		canFailFromLoadErrs: true, // until we send this batch, we can fail it
 	}
+}
+
+// newStreamBatch returns a new record batch that compresses records
+// incrementally as they are appended, so that batch membership can be decided
+// by COMPRESSED size. Only the drain-time coalescer creates these (on the sink
+// goroutine); admission-time batches are always plain.
+func (recBuf *recBuf) newStreamBatch(cc *compressor, codec CompressionCodecType) *recBatch {
+	b := recBuf.newRecordBatch()
+	// The blob buffer is deliberately NOT pooled: the sealed blob aliases it
+	// and lives until the batch dies (possibly inside an in-flight request),
+	// so pooling would require a proven-safe put-back point; GC ownership
+	// needs none.
+	buf := new(bytes.Buffer)
+	if sc := cc.stream(codec, buf); sc != nil {
+		b.stream = &batchStream{sc: sc, buf: buf, codec: codec}
+	}
+	return b
+}
+
+// batchStream is a recBatch's streaming-compression state: records are
+// serialized and fed through the compressor as they are appended (by the
+// drain-time coalescer) so that batch membership can be decided by compressed
+// size, and the sealed compressed blob is written directly at drain (see
+// appendSealedTo), which also makes retries free of recompression.
+type batchStream struct {
+	sc    *streamCompressor
+	buf   *bytes.Buffer // sc writes here; blob aliases it once sealed
+	codec CompressionCodecType
+
+	checkpoint   int    // exact compressed length at the last flush
+	sinceFlush   int    // uncompressed record bytes written since the last flush
+	uncompressed int    // total uncompressed record bytes in the batch
+	scratch      []byte // per-record serialization scratch, reused
+
+	sealed bool
+	blob   []byte // the finished compressed records payload; GC-owned
+}
+
+// streamReserve is the worst-case wire overhead around a streaming batch's
+// compressed records: the length-prefix framing (4 bytes non-flexible, up to 5
+// flexible), the 61-byte batch header, and slack for the codec's close footer
+// after a flush (gzip final block + 8-byte trailer; zstd end block + checksum).
+const streamReserve = 96
+
+// streamMergeMaxUncompressed caps how many uncompressed record bytes one
+// merged batch may accumulate. The compressed bound alone admits up to
+// ratio-x the wire limit of uncompressed bytes, and at pathological ratios
+// (highly redundant data) that total could overflow the batch's int32
+// wireLength bookkeeping on the demote paths. 256MiB is far beyond any sane
+// batch while leaving int32 arithmetic comfortably safe.
+const streamMergeMaxUncompressed = 256 << 20
+
+// releaseStream releases streaming-compression resources when a batch dies
+// (failed, aborted, or finished). Idempotent. Callers hold batch.mu when the
+// batch could concurrently be in a produce request's AppendTo; the
+// never-escaped bufferRecord arms call it lock-free.
+func (b *recBatch) releaseStream() {
+	st := b.stream
+	if st == nil {
+		return
+	}
+	if st.sc != nil {
+		st.sc.release()
+		st.sc = nil
+	}
+	b.stream = nil
 }
 
 // prsPool is the one pool we have internally that is hard to expose an
@@ -2108,6 +2213,12 @@ func (p produceMetrics) hook(cfg *cfg, br *broker) {
 func (p *produceRequest) idempotent() bool { return p.producerID >= 0 }
 
 func (p *produceRequest) tryAddBatch(produceVersion int32, recBuf *recBuf, batch *recBatch) bool {
+	// A streaming batch is sealed the first time it is considered for a
+	// request: the compressor closes cleanly and the batch's wire size becomes
+	// exact (compressed), so the request-size accounting below packs by real
+	// bytes. Idempotent for batches reconsidered after a full request or on
+	// retry.
+	batch.sealStream(produceVersion)
 	batchWireLength, flexible, topicIDs := batch.wireLengthForProduceVersion(produceVersion)
 	batchWireLength += 4 // int32 partition prefix
 
@@ -2348,8 +2459,14 @@ func (b *recBatch) calculateRecordNumbers(r *Record) recordNumbers {
 		tsDelta = 0
 	}
 
-	offsetDelta := int32(len(b.records)) // since called before adding record, delta is the current end
+	// Since this is called before adding the record, the delta is the current end.
+	return recordNumbersOf(r, int32(len(b.records)), tsDelta)
+}
 
+// recordNumbersOf computes a record's wire numbers for an explicit position
+// (offsetDelta) and timestamp delta; the coalescer uses it to size records
+// against a merge target without mutating anything.
+func recordNumbersOf(r *Record, offsetDelta int32, tsDelta int64) recordNumbers {
 	l := 1 + // attributes, int8 unused
 		kbin.VarlongLen(tsDelta) +
 		kbin.VarintLen(offsetDelta) +
@@ -2424,7 +2541,11 @@ func (b *recBatch) tryBuffer(pr promisedRec, produceVersion, maxBatchBytes int32
 	batchWireLength, _, _ := b.wireLengthForProduceVersion(produceVersion)
 	newBatchLength := batchWireLength + nums.wireLength()
 
-	if b.frozen || newBatchLength > maxBatchBytes {
+	// A merged batch (stream != nil) has a finished compressed blob and an
+	// exact sealed wireLength; appending would grow the header fields past
+	// what the blob contains, corrupting the batch on the wire. Merged
+	// batches never accept appends.
+	if b.frozen || b.merging || b.stream != nil || newBatchLength > maxBatchBytes {
 		return false, false
 	}
 	if abortOnNewBatch {
@@ -2436,6 +2557,295 @@ func (b *recBatch) tryBuffer(pr promisedRec, produceVersion, maxBatchBytes int32
 		nums.tsDelta,
 	)
 	return true, false
+}
+
+// mergeBacklogs coalesces every partition's backlog of never-sent batches
+// into compressed-size-bound batches. Admission batches are bounded by
+// uncompressed size, so for compressible data each is ~1/ratio of the wire
+// limit; merging packs ~ratio-x more records per batch - and per request
+// round trip, since a request carries one batch per partition. Called at the
+// top of each drain iteration holding no locks: the compression itself runs
+// outside recBuf.mu, so admission is never stalled behind it.
+func (s *sink) mergeBacklogs() {
+	if !s.cl.cfg.streamCompression {
+		return
+	}
+	cc, ok := s.cl.cfg.compressor.(*compressor)
+	if !ok || cc == nil {
+		return
+	}
+	produceVersion := s.produceVersion.Load()
+	if produceVersion >= 0 && produceVersion < 3 {
+		return // message sets: no record-batch compression framing
+	}
+	codec := cc.pickCodec(produceVersion)
+	if !streamableCodec(codec) {
+		return
+	}
+	s.recBufsMu.Lock()
+	recBufs := append([]*recBuf(nil), s.recBufs...)
+	s.recBufsMu.Unlock()
+	for _, recBuf := range recBufs {
+		recBuf.mergeBacklog(cc, codec)
+	}
+}
+
+// mergeBacklog merges this partition's backlog via freeze-steal-merge:
+//
+//  1. STEAL (under recBuf.mu): claim the span of consecutive never-sent
+//     batches at the drain index by marking them merging, which blocks
+//     admission appends (tryBuffer) and drains (createReq skips merging
+//     batches) WITHOUT removing them from recBuf.batches - they must stay
+//     visible to failAllRecords/purge so a concurrent failure sweep still
+//     owns their promises.
+//  2. MERGE (no recBuf.mu): stream the span's records through the compressor
+//     into one batch bounded by compressed size, reading each source under
+//     its batch.mu (aborting if a failure sweep nil'd its records). Membership
+//     is decided record by record with a worst-case bound - bytes since the
+//     last flush plus the candidate are assumed incompressible; only when
+//     that would overflow do we flush to tighten and re-check, and a final
+//     overflow cuts BEFORE writing, so the bound is never exceeded and the
+//     compressor only ever holds accepted records. A cut mid-source moves the
+//     source's remaining records into a fresh tail batch - legal because the
+//     source was never sent and has no sequence (sequences are assigned at
+//     tryAddBatch).
+//  3. SPLICE (under recBuf.mu): revalidate that the span is exactly where it
+//     was left and untouched (no failure sweep, no drain-index movement, no
+//     cross-sink drain freeze), then replace the consumed sources with the
+//     merged batch (+ tail). On any interference the merge is discarded -
+//     the records' promises belong to whoever swept them.
+//
+// Only never-frozen batches are merged. A batch is frozen exactly when first
+// selected into a produce request, so frozen means possibly-sent: its content
+// and sequence must never change (idempotence), and on retries it is resent
+// verbatim.
+func (recBuf *recBuf) mergeBacklog(cc *compressor, codec CompressionCodecType) {
+	// PHASE 1: steal.
+	recBuf.mu.Lock()
+	if recBuf.purged || recBuf.failing || len(recBuf.batches)-recBuf.batchDrainIdx < 2 {
+		recBuf.mu.Unlock()
+		return
+	}
+	stealIdx := recBuf.batchDrainIdx
+	var span []*recBatch
+	for _, b := range recBuf.batches[stealIdx:] {
+		if b.frozen || b.merging || b.stream != nil {
+			break
+		}
+		span = append(span, b)
+	}
+	if len(span) < 2 {
+		recBuf.mu.Unlock()
+		return // nothing to merge with; draining stays byte-for-byte legacy
+	}
+	for _, b := range span {
+		b.merging = true
+	}
+	recBuf.mu.Unlock()
+
+	// PHASE 2: merge, holding only the current source's batch.mu.
+	limit := int(recBuf.maxRecordBatchBytes)
+	m := recBuf.newStreamBatch(cc, codec)
+	st := m.stream
+	var (
+		consumed int       // source batches consumed (the last may be split)
+		tail     *recBatch // remainder of a split source
+		aborted  = st == nil
+	)
+merge:
+	for _, src := range span {
+		if aborted {
+			break
+		}
+		src.mu.Lock()
+		if src.records == nil {
+			// A failure sweep took the recBuf mid-merge; it owns every
+			// record's promise. Discard the merge below.
+			src.mu.Unlock()
+			aborted = true
+			break
+		}
+		for ri, pr := range src.records {
+			nums := m.calculateRecordNumbers(pr.Record)
+			recWire := int(nums.wireLength())
+
+			var fits bool
+			switch {
+			case st != nil && st.uncompressed+recWire > streamMergeMaxUncompressed:
+				fits = false // cap uncompressed accumulation; see the const doc
+			case len(m.records) == 0:
+				fits = streamReserve+recWire <= limit
+			case st == nil:
+				// Demoted mid-merge: m is legacy; bound by uncompressed size.
+				fits = int(m.wireLength)+recWire <= limit
+			case streamReserve+st.checkpoint+st.sinceFlush+recWire <= limit:
+				fits = true
+			default:
+				if st.sc.flush() != nil {
+					// Effectively impossible for in-memory writes. Everything
+					// appended so far was admitted by worst case, so m is
+					// valid uncompressed; demote it to legacy and re-check.
+					m.releaseStream()
+					st = nil
+					fits = int(m.wireLength)+recWire <= limit
+				} else {
+					st.checkpoint = st.sc.len()
+					st.sinceFlush = 0
+					fits = streamReserve+st.checkpoint+recWire <= limit
+				}
+			}
+			if !fits {
+				// Cut before this record. Records ri.. of src move to a tail
+				// batch (recomputing their offset/timestamp deltas); the tail
+				// is unfrozen and seeds the next merge.
+				if ri > 0 {
+					tail = recBuf.newRecordBatch()
+					for _, tpr := range src.records[ri:] {
+						tnums := tail.calculateRecordNumbers(tpr.Record)
+						tail.appendRecord(tpr, tnums)
+						tpr.setLengthAndTimestampDelta(tnums.lengthField, tnums.tsDelta)
+					}
+					consumed++ // src is split across m and tail
+				}
+				src.mu.Unlock()
+				break merge
+			}
+
+			m.appendRecord(pr, nums)
+			pr.setLengthAndTimestampDelta(nums.lengthField, nums.tsDelta)
+			if st != nil {
+				st.scratch = pr.appendTo(st.scratch[:0], int32(len(m.records)-1))
+				if err := st.sc.write(st.scratch); err != nil {
+					m.releaseStream() // demote; m stays valid: admitted by worst case
+					st = nil
+				} else {
+					st.sinceFlush += len(st.scratch)
+					st.uncompressed += len(st.scratch)
+				}
+			}
+		}
+		src.mu.Unlock()
+		consumed++
+	}
+
+	// PHASE 3: splice. Validation is anchored on the CURRENT drain index
+	// rather than the steal-time one: a produce response completing during
+	// the merge pops finished front batches and shifts every index left,
+	// which moves the span without touching it - the span is still valid
+	// exactly when it sits, in order and unfrozen, at the head of what is
+	// left to drain. Only a failure sweep (batches replaced/nil'd) or a
+	// retry rewind (drain head now a frozen batch) invalidates the merge.
+	recBuf.mu.Lock()
+	defer recBuf.mu.Unlock()
+	for _, b := range span {
+		b.merging = false
+	}
+	spliceIdx := recBuf.batchDrainIdx
+	valid := !aborted && consumed > 0 &&
+		!recBuf.purged &&
+		len(recBuf.batches) >= spliceIdx+len(span)
+	if valid {
+		for i, b := range span {
+			if recBuf.batches[spliceIdx+i] != b || b.frozen {
+				valid = false
+				break
+			}
+		}
+	}
+	if !valid {
+		// Phase 2 re-stamped the span records' stored length/timestamp
+		// deltas to merge-relative values as it serialized them. The merge
+		// is being discarded, so the sources will drain as-is on the legacy
+		// path, which serializes from those stored stamps: restore them to
+		// source-relative values or the wire records would desync. (A sweep
+		// nil'd the records and owns their promises; restore no-ops there.)
+		for _, src := range span {
+			src.mu.Lock()
+			src.restoreRecordStamps()
+			src.mu.Unlock()
+		}
+		m.releaseStream()
+		recBuf.cl.prsPool.put(m.records)
+		if tail != nil {
+			recBuf.cl.prsPool.put(tail.records)
+		}
+		return
+	}
+	// The consumed sources' record slices were fully copied into m (and
+	// tail); with the span validated untouched, nothing else references them.
+	for _, b := range span[:consumed] {
+		recBuf.cl.prsPool.put(b.records)
+	}
+	keep := span[consumed:]
+	rest := recBuf.batches[spliceIdx+len(span):]
+	nb := make([]*recBatch, 0, spliceIdx+2+len(keep)+len(rest))
+	nb = append(nb, recBuf.batches[:spliceIdx]...)
+	nb = append(nb, m)
+	if tail != nil {
+		nb = append(nb, tail)
+	}
+	nb = append(nb, keep...)
+	recBuf.batches = append(nb, rest...)
+}
+
+// restoreRecordStamps recomputes and re-stores every record's length and
+// timestamp-delta stamps relative to THIS batch. A discarded merge leaves
+// records stamped relative to the abandoned merged batch; the stamps must
+// match this batch's layout again before its legacy serialization runs.
+// No-op for swept batches (records nil'd; the sweep owns their promises).
+func (b *recBatch) restoreRecordStamps() {
+	for i, pr := range b.records {
+		tsDelta := pr.Timestamp.UnixNano()/1e6 - b.firstTimestamp
+		if i == 0 {
+			tsDelta = 0
+		}
+		nums := recordNumbersOf(pr.Record, int32(i), tsDelta)
+		pr.setLengthAndTimestampDelta(nums.lengthField, nums.tsDelta)
+	}
+}
+
+// sealStream finalizes a streaming batch: the compressor emits its footer and
+// is returned to its pool, the compressed blob is recorded, and b.wireLength
+// becomes the batch's EXACT wire size, which every request-sizing path
+// (wireLengthForProduceVersion and friends) then reports exactly rather than
+// as an uncompressed overestimate.
+//
+// Idempotent. Called under recBuf.mu at drain time (tryAddBatch), where the
+// batch is at batchDrainIdx and therefore not inside any in-flight request's
+// AppendTo; batch.mu is still taken for the mutations because AppendTo reads
+// wireLength/stream under it.
+func (b *recBatch) sealStream(produceVersion int32) {
+	st := b.stream
+	if st == nil || st.sealed {
+		return
+	}
+	// Ancient-broker guard: the codec was chosen against the produce version
+	// at buffer time. If the KNOWN version is below record batches entirely
+	// (v3) or below the codec's floor (zstd: v7), demote; the kept records
+	// make the legacy path fully available. An unknown version (-1, possible
+	// here when everything buffered before the first response, e.g. manual
+	// flushing) stays optimistic: appendTo re-checks against the actually
+	// negotiated version at write time and demotes there if needed, and the
+	// v<3 message-set path never consults the blob at all.
+	if produceVersion >= 0 && (produceVersion < 3 || st.codec == CodecZstd && produceVersion < 7) {
+		b.releaseStream() // demote to the legacy path; records are kept
+		return
+	}
+	blob, err := st.sc.finish()
+	st.sc.release()
+	st.sc = nil
+	if err != nil || len(blob) >= st.uncompressed {
+		// Compression errored (effectively impossible) or did not shrink:
+		// take the legacy path, which decides compression per attempt and
+		// sends uncompressed when compression does not help.
+		b.stream = nil
+		return
+	}
+	b.mu.Lock()
+	st.blob = blob
+	st.sealed = true
+	b.wireLength = recordBatchOverhead + int32(len(blob))
+	b.mu.Unlock()
 }
 
 //////////////
@@ -2558,6 +2968,21 @@ func (b seqRecBatch) appendTo(
 	transactional bool,
 	compressor Compressor,
 ) (dst []byte, m ProduceBatchMetrics) { // named return so that our defer for flexible versions can modify it
+	if st := b.stream; st != nil && st.sealed {
+		if version >= 7 || st.codec != CodecZstd {
+			return b.appendSealedTo(in, version, producerID, producerEpoch, transactional)
+		}
+		// The negotiated version regressed below the sealed codec's floor
+		// between drain and write (ancient brokers only). Restore the
+		// uncompressed wire length and fall through to the legacy path, which
+		// re-serializes from the kept records and compresses per its own
+		// version-aware codec selection. Idempotent under AppendTo's
+		// re-invocation rule: the restore is a fixed value and subsequent
+		// calls take the legacy path directly. We hold batch.mu (the caller
+		// locks around appendTo), matching sealStream's mutation locking.
+		b.wireLength = recordBatchOverhead + int32(st.uncompressed)
+		b.stream = nil
+	}
 	flexible := version >= 9
 	dst = in
 	nullableBytesLen := b.wireLength - 4 // NULLABLE_BYTES leading length, minus itself
@@ -2669,6 +3094,76 @@ func (b seqRecBatch) appendTo(
 
 	kbin.AppendInt32(dst[:crcStart], int32(crc32.Checksum(dst[crcStart+4:], crc32c)))
 
+	return dst, m
+}
+
+// appendSealedTo writes a sealed streaming batch: the framing and 61-byte
+// header are written fresh (sequence, producer id/epoch, and the transactional
+// bit can differ per attempt) followed by the already-compressed records blob,
+// then the CRC over everything after the CRC field. Because the blob is
+// cached, retries do not re-serialize or recompress. The caller holds
+// batch.mu, serializing the blob read (and the b.attrs write) against
+// failAllRecords.
+//
+// All sizes are exact up front - sealStream set b.wireLength to
+// recordBatchOverhead+len(blob) - so, unlike the legacy path, the flexible
+// length prefix needs no post-compression shifting.
+func (b seqRecBatch) appendSealedTo(
+	in []byte,
+	version int16,
+	producerID int64,
+	producerEpoch int16,
+	transactional bool,
+) (dst []byte, m ProduceBatchMetrics) {
+	st := b.stream
+	flexible := version >= 9
+	dst = in
+
+	nullableBytesLen := b.wireLength - 4 // NULLABLE_BYTES leading length, minus itself
+	if flexible {
+		dst = kbin.AppendUvarint(dst, uvar32(nullableBytesLen)) // compact array non-null prefix
+	} else {
+		dst = kbin.AppendInt32(dst, nullableBytesLen)
+	}
+
+	dst = kbin.AppendInt64(dst, 0) // firstOffset, defined as zero for producing
+
+	batchLen := nullableBytesLen - 8 - 4 // length of what follows this field (so, minus what came before and ourself)
+	dst = kbin.AppendInt32(dst, batchLen)
+
+	dst = kbin.AppendInt32(dst, -1) // partitionLeaderEpoch, unused in clients
+	dst = kbin.AppendInt8(dst, 2)   // magic, defined as 2 for records v0.11.0+
+
+	crcStart := len(dst)           // fill at end
+	dst = kbin.AppendInt32(dst, 0) // reserved crc
+
+	attrs := int16(st.codec) // compression bits (attrs 0-2)
+	if transactional {
+		attrs |= 0x0010 // bit 5 is the "is transactional" bit
+	}
+	b.attrs = attrs // read at finishBatch under batch.mu; same value every attempt
+	dst = kbin.AppendInt16(dst, attrs)
+	dst = kbin.AppendInt32(dst, int32(len(b.records)-1)) // lastOffsetDelta
+	dst = kbin.AppendInt64(dst, b.firstTimestamp)
+	dst = kbin.AppendInt64(dst, b.firstTimestamp+b.maxTimestampDelta)
+
+	seq := b.seq
+	if producerID < 0 { // a negative producer ID means we are not using idempotence
+		seq = 0
+	}
+	dst = kbin.AppendInt64(dst, producerID)
+	dst = kbin.AppendInt16(dst, producerEpoch)
+	dst = kbin.AppendInt32(dst, seq)
+
+	dst = kbin.AppendArrayLen(dst, len(b.records))
+	dst = append(dst, st.blob...)
+
+	kbin.AppendInt32(dst[:crcStart], int32(crc32.Checksum(dst[crcStart+4:], crc32c)))
+
+	m.NumRecords = len(b.records)
+	m.UncompressedBytes = st.uncompressed
+	m.CompressedBytes = len(st.blob)
+	m.CompressionType = uint8(st.codec)
 	return dst, m
 }
 


### PR DESCRIPTION
Adds `kgo.StreamingCompression`, an opt-in producer option that merges a partition's backlog of unsent batches at drain time into batches bounded by their COMPRESSED size, for every codec the default compressor supports. Default off; no behavior change unless enabled.

Batches are bounded by `ProducerBatchMaxBytes` measured on uncompressed records, so with a compression ratio R, a backlog costs about R times more produce round trips than `max.message.bytes` allows. Sizing `ProducerBatchMaxBytes` against an assumed ratio instead risks MESSAGE_TOO_LARGE whenever the ratio dips.

How it works: before the drain goroutine waits on an inflight slot, it freezes each partition's unsent batches under the recBuf lock, streams their records through the codec outside the lock, and splices the merged batch back in. Membership is decided before each write: the compressed size at the last flush plus the codec's worst case for everything written since (raw size plus 1/1024 plus 64 bytes for gzip, lz4, and zstd; the format's per block bound for snappy); the codec is flushed only when that bound would overflow, and the batch is cut only if the record still does not fit. The finished blob is checked against the limit as well: if a codec ever exceeds its slack, the merge is discarded, merging is turned off for the client, and a warning asks for an issue, so the slack decides only how often we flush, never what we send. Snappy merged batches use the xerial framing the Java producer writes (one independent 32KB block at a time), which every reader accepts. A source's lock is held only while its records are copied out and is released while each 32KB chunk compresses, so a failure sweep (purge, close, abort, a batch out of retries) waits at most one chunk; the merge sees the swept source when it retakes the lock and discards itself. Merged batches keep their compressed blob, so retries do not recompress. Only never-frozen batches merge, so idempotent and transactional sequencing is unchanged. Merging starts once a sink knows its produce version, so the first request per broker is unmerged. A merged batch keeps the codec and format it was sealed with; if its partition later moves to a broker that cannot take it (below produce v3, or below v7 for zstd), createReq fails those records back to the application with an error rather than retrying a request the broker rejects, once nothing is inflight ahead of the batch. Merging itself waits for a sink's first produce response, so this only arises for a partition that moves after merging.

Thanks to @scunningham, whose #1421 split the original merge into the steal, merge, and splice steps and cleaned up the stream compressor; this revision keeps that shape.

Changes from the earlier revision of this PR: sources are frozen instead of carrying a per-batch merging flag (a per-partition flag makes createReq skip the partition), the splice finds the span by pointer instead of validating drain indexes, the codec is closed inside the merge so at most one is open per sink, the worst-case bound accounts for codec raw block overhead (the fixed 96 byte slack did not hold for gzip stored blocks past ~500KB of pending data), the blob buffer is pooled, and the merge runs before the inflight wait so compression overlaps requests in flight. kgo is about +400 lines instead of +710. Tests: direct merge tests in kgo over every codec and incompressible data, a discarded merge with and without a tail, a swept source, a sweep that must not wait past one chunk of compression, a head record too big to merge, an unsupported merged batch waiting for the inflight batch ahead of it, `renumber` against recomputation with timestamps spread over days, and v8 plus v9 encoding; in kfake, one table-driven end to end test (every codec, retry, live drain, purge, close) plus a random workload test that checks every batch written stays within the limit compressed; a partition moved between brokers mid merge (which hangs without the drain trigger the merge fires), a broker too old for the codec (no merges), a merged batch staged on a sink that has not yet seen a produce response, a transaction, and a 4KB batch limit; and `StreamingCompression` is on for the producers in TestGroupETL and TestTxnEtl, which the real broker CI jobs run.

Benchmarks, blackholed kfake, 512B ~5x compressible values, 4 partitions, medians of 7 interleaved passes:

| codec | legacy ns/rec | streaming ns/rec | rec/req legacy | rec/req streaming |
|---|---|---|---|---|
| gzip | 1417 | 1460 (+3.0%) | 7317 | 100000 (13.7x) |
| snappy | 479 | 461 | 3488 | 5660 (1.6x) |
| lz4 | 387 | 402 (+3.8%) | 4615 | 37500 (8.1x) |
| zstd | 388 | 485 (+25%) | 6000 | 50000 (8.3x) |
| none | 511 | 517 | 3896 | 4615 |

Snappy compresses too fast for a backlog to build against a blackholed broker, so its density gain there is small; the end to end test, with a real backlog, merges snappy 8x. The zstd delta is klauspost's streaming encoder against EncodeAll; a follow-up could write one zstd frame per chunk with EncodeAll (decoders accept concatenated frames) and skip the flushes entirely.

A final commit speeds up compression on both paths: gzip comes from klauspost/compress (same format, already a dependency; level for level 1.1 to 1.2x the stdlib encoder, and its default level 5 is 1.7x the stdlib default 6 with a slightly better ratio), zstd no longer writes its frame checksum (the batch CRC covers the bytes; 4% off encoding), and the merge path grows its merged record slice once to the span's size, pre-grows the blob buffer to the span's bytes, pools its serialization buffers, and adjusts stamped record lengths instead of recomputing them. Both paths run at zero allocations per record; before this commit the merge path churned about 200 bytes per record growing its record slice. Before and after, same setup, medians of 5:

| codec | legacy ns/rec | streaming ns/rec |
|---|---|---|
| gzip | 1398 to 687 | 1486 to 738 |
| zstd | 380 to 386 (noise) | 455 to 377 |
| lz4 | 370 to 374 (noise) | 404 to 373 |
| snappy | 464 to 457 (noise) | 460 to 441 |

Streaming zstd is now faster than legacy zstd. The gzip decoder moved with the import and is a wash (71us per batch either way, 2 B/op).

## Changelog

- kgo: add `StreamingCompression`, a producer option that merges a partition's backlog into batches bounded by their compressed size.
- kgo: gzip compression now uses klauspost/compress/gzip (same format): 2x faster at the default level, and `WithLevel` now selects klauspost's level of that number.
- kgo: zstd batches no longer carry a frame checksum; the record batch CRC already covers them.
