### PR TITLE
kgo: revoke everything when the group protocol downgrades from cooperative to eager

### DIFF
--- a/pkg/kfake/issue_1365_race_test.go
+++ b/pkg/kfake/issue_1365_race_test.go
@@ -1,0 +1,154 @@
+package kfake_test
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// Regression for #1365: a mid-life cooperative -> eager protocol downgrade
+// used to assign offsets over cursors that were still fetching. Member A
+// advertises [cooperative-sticky, sticky] and consumes hot; member B joins
+// advertising only [sticky], so the group's protocol vote is forced to
+// sticky. A's prior cooperative session revoked nothing at its end, and the
+// eager session's diffAssigned returns the entire assignment as newly added:
+// without the downgrade revoke, fetchOffsets issued list/epoch loads for
+// live cursors and the load's completion raced concurrent polls (data race
+// on the cursor offset, plus torn cursor state).
+//
+// Run with -race. Pre-fix this raced in most runs; post-fix it must be
+// clean, and all partitions must resume consuming after the downgrade.
+func TestIssue1365CooperativeDowngrade(t *testing.T) {
+	t.Parallel()
+	const (
+		topic      = "issue-1365-downgrade"
+		group      = "issue-1365-downgrade-g"
+		partitions = 6
+	)
+	c := newCluster(t, kfake.SeedTopics(partitions, topic))
+
+	// Keep epoch/list loads in flight longer: pre-fix, the race window is
+	// a load completing while records are buffered and being polled.
+	delay := func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		c.SleepControl(func() { time.Sleep(time.Duration(50+rand.Intn(200)) * time.Millisecond) })
+		return nil, nil, false
+	}
+	c.ControlKey(int16(kmsg.OffsetForLeaderEpoch), delay)
+	c.ControlKey(int16(kmsg.ListOffsets), delay)
+
+	producer := newPlainClient(t, c, kgo.DefaultProduceTopic(topic))
+	prodCtx, prodCancel := context.WithCancel(context.Background())
+	var prodWg sync.WaitGroup
+	prodWg.Add(1)
+	go func() {
+		defer prodWg.Done()
+		for i := 0; prodCtx.Err() == nil; i++ {
+			r := kgo.StringRecord("v" + strconv.Itoa(i))
+			r.Topic = topic
+			r.Key = []byte(strconv.Itoa(i)) // spread across partitions
+			producer.Produce(prodCtx, r, nil)
+			if i%50 == 49 {
+				producer.Flush(prodCtx)
+			}
+		}
+	}()
+	defer func() {
+		prodCancel()
+		prodWg.Wait()
+	}()
+
+	baseOpts := []kgo.Opt{
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumerGroup(group),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.FetchMaxWait(50 * time.Millisecond),
+		kgo.AutoCommitMarks(),
+		kgo.AutoCommitInterval(100 * time.Millisecond),
+		kgo.HeartbeatInterval(100 * time.Millisecond),
+	}
+
+	// A: prefers cooperative, also supports eager sticky (the standard
+	// migration config).
+	a := newPlainClient(t, c, append([]kgo.Opt{
+		kgo.Balancers(kgo.CooperativeStickyBalancer(), kgo.StickyBalancer()),
+	}, baseOpts...)...)
+
+	var mu sync.Mutex
+	seen := make(map[int32]int) // partition => records consumed by A
+	pollCtx, pollCancel := context.WithCancel(context.Background())
+	var pollWg sync.WaitGroup
+	pollWg.Add(1)
+	go func() {
+		defer pollWg.Done()
+		for pollCtx.Err() == nil {
+			fs := a.PollFetches(pollCtx)
+			fs.EachRecord(func(r *kgo.Record) {
+				a.MarkCommitRecords(r)
+				mu.Lock()
+				seen[r.Partition]++
+				mu.Unlock()
+			})
+		}
+	}()
+	defer func() {
+		pollCancel()
+		pollWg.Wait()
+	}()
+
+	// Let A consume and commit (marks) so partitions have committed
+	// offsets with leader epochs: the downgrade re-assign then issues
+	// OffsetForLeaderEpoch loads for every partition.
+	time.Sleep(750 * time.Millisecond)
+
+	// B joins eager-only: the group protocol downgrades to sticky while A
+	// has buffered fetches and is polling.
+	b := newPlainClient(t, c, append([]kgo.Opt{
+		kgo.Balancers(kgo.StickyBalancer()),
+	}, baseOpts...)...)
+	bctx, bcancel := context.WithTimeout(context.Background(), 3*time.Second)
+	for bctx.Err() == nil {
+		fs := b.PollFetches(bctx)
+		if fs.NumRecords() > 0 {
+			break
+		}
+	}
+	bcancel()
+
+	// Keep both consuming through the downgrade era, then B leaves.
+	time.Sleep(500 * time.Millisecond)
+	b.Close()
+
+	// Post-downgrade functional check: A owns everything again and every
+	// partition resumes consuming (the downgrade revoke must not strand
+	// partitions).
+	mu.Lock()
+	clear(seen)
+	mu.Unlock()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		mu.Lock()
+		n := len(seen)
+		mu.Unlock()
+		if n == partitions {
+			break
+		}
+		if time.Now().After(deadline) {
+			mu.Lock()
+			got := make(map[int32]int, len(seen))
+			for p, c := range seen {
+				got[p] = c
+			}
+			mu.Unlock()
+			t.Fatalf("after downgrade and member leave, only %d/%d partitions resumed consuming: %v", n, partitions, got)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1946,6 +1946,13 @@ func ShareAckCallback(fn func(*Client, ShareAckResults)) GroupOpt {
 // Note that if you opt into cooperative-sticky rebalancing, cooperative group
 // balancing is incompatible with eager (classical) rebalancing and requires a
 // careful rollout strategy (see KIP-429).
+//
+// If you use both cooperative and eager balancers, the group runs
+// cooperatively only if all members support cooperative balancing: an
+// eager-only member joining downgrades the whole group to eager. On
+// downgrade, the client revokes all partitions and re-consumes from
+// committed offsets, which can result in duplicates. It is not recommended
+// to downgrade once a group is cooperative.
 func Balancers(balancers ...GroupBalancer) GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.balancers = balancers }}
 }

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -65,6 +65,10 @@ type groupConsumer struct {
 	lastAssigned map[string][]int32
 	nowAssigned  amtps
 
+	// Set when a join downgrades the group from cooperative to eager;
+	// the next session revokes everything before consuming.
+	protocolDowngraded bool
+
 	// Fetching ensures we continue fetching offsets across cooperative
 	// rebalance if an offset fetch returns early due to an immediate
 	// rebalance. See the large comment on adjustCooperativeFetchOffsets
@@ -1031,6 +1035,33 @@ func (s *assignRevokeSession) revoke(g *groupConsumer, leaving bool) <-chan stru
 //   - fetching is complete
 //   - heartbeating is complete
 func (g *groupConsumer) setupAssignedAndHeartbeat(initialHb time.Duration, hbfn func() (time.Duration, error)) (string, error) {
+	if g.protocolDowngraded {
+		g.protocolDowngraded = false
+		// Our prior cooperative session ended without revoking
+		// anything, but diffAssigned below short-circuits for eager
+		// consumers and returns the entire assignment as newly added.
+		// fetchOffsets would then set offsets on cursors that are
+		// still actively fetching, and the offset load's completion
+		// races any concurrent poll's cursor update (#1365). Instead,
+		// first revoke everything, as an eager session would have
+		// before rejoining: stop fetching everything, let the user
+		// commit final work in onRevoked, and clear commit state
+		// before everything is re-fetched from committed offsets.
+		g.c.waitAndAddRebalance()
+		prior := g.lastAssigned
+		g.c.mu.Lock()
+		g.c.assignPartitions(nil, assignInvalidateAll, nil, "revoking all assignments; group protocol downgraded from cooperative to eager")
+		g.c.mu.Unlock()
+		if len(prior) > 0 {
+			g.cfg.onRevoked(g.cl.ctx, g.cl, prior)
+		}
+		g.mu.Lock()
+		g.uncommitted = nil
+		g.mu.Unlock()
+		g.fetching = nil
+		g.c.unaddRebalance()
+	}
+
 	type hbquit struct {
 		rejoinWhy string
 		err       error
@@ -1567,7 +1598,14 @@ func (g *groupConsumer) handleJoinResp(resp *kmsg.JoinGroupResponse) (restart bo
 		if protocol == balancer.ProtocolName() {
 			cooperative := balancer.IsCooperative()
 			if !cooperative && g.cooperative.Load() {
-				g.cfg.logger.Log(LogLevelWarn, "downgrading from cooperative group to eager group, this is not supported per KIP-429!")
+				g.cfg.logger.Log(LogLevelInfo, "group protocol downgraded from cooperative to eager; all partitions will be revoked before consuming resumes from committed offsets")
+				g.protocolDowngraded = true
+			} else if cooperative {
+				// A join can restart (e.g. MemberIDRequired) or an
+				// earlier downgrade join's sync can fail; if the
+				// group is (back) on cooperative by the time a join
+				// succeeds, no downgrade materialized.
+				g.protocolDowngraded = false
 			}
 			g.cooperative.Store(cooperative)
 			break


### PR DESCRIPTION
Fixes the data race in #1365 between `PollFetches` (`takeBuffered` -> `finishUsingAllWithSet` -> `cursor.setOffset`) and `handleListOrEpochResults`' `cursor.setOffset`.

## Root cause

A group whose members carry both cooperative and eager balancers (the standard migration config, e.g. `Balancers(CooperativeStickyBalancer(), RangeBalancer())`) runs cooperatively until a member supporting only an eager protocol joins; the group's protocol vote is then forced to eager. The client followed the flip with only a warning:

1. The prior cooperative session revoked nothing at its end (correct for cooperative).
2. `handleJoinResp` flipped `g.cooperative` to false.
3. `diffAssigned` short-circuits for eager consumers and returned the entire assignment as newly added, and prerevoke (gated on cooperative) invalidated nothing.
4. `fetchOffsets` -> `assignPartitions(assignWithoutInvalidating)` issued list/epoch loads (and direct offset sets) for partitions whose cursors were still fetching: two owners per cursor, and the load's completion raced concurrent polls' cursor updates.

The Java client pins each member's rebalance protocol at construction from its own assignor list (a mixed-list Java member revokes everything on every rejoin, forever), so a live member there can never flip. franz-go follows the group-selected protocol per generation - cooperative rebalancing whenever the whole group supports it - so it uniquely owns this transition.

## Fix

On a downgrade join, enter the eager era the way an eager session would have left the prior one, before offsets are fetched: invalidate all assignments, call `onRevoked` with the prior assignment (so final work can commit), and clear commit state. The old "not supported per KIP-429" warning was wrong per the KIP's downgrade section and is replaced with an INFO describing the revoke.

A final autocommit between the downgrade sync and the revoke can land after another member fetched offsets; that window yields duplicates only (at-least-once holds) and cannot be closed client-side, since the selected protocol is only learned from the join response.

## Verification

- New kfake regression test (`TestIssue1365CooperativeDowngrade`): one member advertises `[cooperative-sticky, sticky]` and consumes hot while a second joins with only `[sticky]`. Pre-fix it reproduced the exact reported race pair in 3 of 5 `-race` runs; post-fix, 27/27 clean, and every partition resumes consuming after the downgrade revoke.
- kfake suite `-race -skip ETL`: pass, zero races.
- 85 varied `-race` runs of pure cooperative-sticky churn confirm the invariant holds without a downgrade (the flip is the only feeder found; two independent full traces of the load/fetch ownership machinery agreed).

#1271 and the "partition fetched while offsets concurrently fetched" oddity in #1222 share this signature and were both mixed-config-capable groups; this plausibly retires those as well.

Closes #1365