### PR TITLE
kgo: add NewRecordAttrs constructor

### DIFF
--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -67,6 +67,33 @@ func (a RecordAttrs) IsControl() bool {
 	return a.attrs&0b0010_0000 != 0
 }
 
+// NewRecordAttrs returns a RecordAttrs built from its components. It exists so
+// code outside this package can populate Record.Attrs to match what the client
+// sets: the attrs bits are otherwise unexported and only readable via the
+// accessors below.
+//
+// The arguments mirror those accessors and round-trip through them:
+// compressionType uses the CompressionType codes (0 none, 1 gzip, 2 snappy,
+// 3 lz4, 4 zstd) and timestampType uses the TimestampType convention (0 for
+// client-side CreateTime, 1 for broker-side LogAppendTime, -1 for no timestamp
+// as on v0 message sets). Both are masked to their documented bit ranges.
+func NewRecordAttrs(compressionType uint8, timestampType int8, isTransactional, isControl bool) RecordAttrs {
+	attrs := compressionType & 0b0000_0111
+	switch {
+	case timestampType < 0:
+		attrs |= 0b1000_0000 // no timestamp type
+	case timestampType > 0:
+		attrs |= 0b0000_1000 // LogAppendTime
+	}
+	if isTransactional {
+		attrs |= 0b0001_0000
+	}
+	if isControl {
+		attrs |= 0b0010_0000
+	}
+	return RecordAttrs{attrs}
+}
+
 // Record is a record to write to Kafka.
 type Record struct {
 	// Key is an optional field that can be used for partition assignment.

--- a/pkg/kgo/record_and_fetch.go
+++ b/pkg/kgo/record_and_fetch.go
@@ -67,28 +67,44 @@ func (a RecordAttrs) IsControl() bool {
 	return a.attrs&0b0010_0000 != 0
 }
 
-// NewRecordAttrs returns a RecordAttrs built from its components. It exists so
-// code outside this package can populate Record.Attrs to match what the client
-// sets: the attrs bits are otherwise unexported and only readable via the
-// accessors below.
-//
-// The arguments mirror those accessors and round-trip through them:
-// compressionType uses the CompressionType codes (0 none, 1 gzip, 2 snappy,
-// 3 lz4, 4 zstd) and timestampType uses the TimestampType convention (0 for
-// client-side CreateTime, 1 for broker-side LogAppendTime, -1 for no timestamp
-// as on v0 message sets). Both are masked to their documented bit ranges.
-func NewRecordAttrs(compressionType uint8, timestampType int8, isTransactional, isControl bool) RecordAttrs {
-	attrs := compressionType & 0b0000_0111
+// RecordAttrsOpts contains the fields of a [RecordAttrs]. The zero value is an
+// uncompressed, non-transactional, non-control record with a client-generated
+// timestamp.
+type RecordAttrsOpts struct {
+	// Codec is the codec the record was compressed with, overriding the
+	// default of no compression. The codec is stored in three bits; a
+	// codec that does not fit is ignored.
+	Codec CompressionCodecType
+
+	// TimestampType is how the record's timestamp was determined; see
+	// [RecordAttrs.TimestampType] for what the values mean.
+	TimestampType int8
+
+	// Transactional sets the record as a part of a transaction.
+	Transactional bool
+
+	// Control sets the record as a control record (ABORT or COMMIT).
+	Control bool
+}
+
+// NewRecordAttrs returns the attrs corresponding to opts. This exists so you
+// can populate [Record.Attrs] yourself; the client sets that field for you
+// when producing and consuming.
+func NewRecordAttrs(opts RecordAttrsOpts) RecordAttrs {
+	var attrs uint8
+	if c := uint8(opts.Codec); c <= 0b0000_0111 {
+		attrs |= c
+	}
 	switch {
-	case timestampType < 0:
+	case opts.TimestampType < 0:
 		attrs |= 0b1000_0000 // no timestamp type
-	case timestampType > 0:
+	case opts.TimestampType > 0:
 		attrs |= 0b0000_1000 // LogAppendTime
 	}
-	if isTransactional {
+	if opts.Transactional {
 		attrs |= 0b0001_0000
 	}
-	if isControl {
+	if opts.Control {
 		attrs |= 0b0010_0000
 	}
 	return RecordAttrs{attrs}

--- a/pkg/kgo/record_and_fetch_test.go
+++ b/pkg/kgo/record_and_fetch_test.go
@@ -88,3 +88,40 @@ func TestEachTopicPreservesTopicID(t *testing.T) {
 		}
 	})
 }
+
+// TestNewRecordAttrs verifies NewRecordAttrs round-trips through the accessors.
+func TestNewRecordAttrs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		compressionType uint8
+		timestampType   int8
+		isTransactional bool
+		isControl       bool
+	}{
+		{"zero", 0, 0, false, false},
+		{"snappy create-time", 2, 0, false, false},
+		{"zstd log-append-time", 4, 1, false, false},
+		{"no-timestamp", 0, -1, false, false},
+		{"transactional", 1, 0, true, false},
+		{"control", 0, 0, false, true},
+		{"all set", 3, 1, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewRecordAttrs(tc.compressionType, tc.timestampType, tc.isTransactional, tc.isControl)
+			if got := a.CompressionType(); got != tc.compressionType {
+				t.Errorf("CompressionType: got %d, want %d", got, tc.compressionType)
+			}
+			if got := a.TimestampType(); got != tc.timestampType {
+				t.Errorf("TimestampType: got %d, want %d", got, tc.timestampType)
+			}
+			if got := a.IsTransactional(); got != tc.isTransactional {
+				t.Errorf("IsTransactional: got %t, want %t", got, tc.isTransactional)
+			}
+			if got := a.IsControl(); got != tc.isControl {
+				t.Errorf("IsControl: got %t, want %t", got, tc.isControl)
+			}
+		})
+	}
+}

--- a/pkg/kgo/record_and_fetch_test.go
+++ b/pkg/kgo/record_and_fetch_test.go
@@ -94,33 +94,30 @@ func TestNewRecordAttrs(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name            string
-		compressionType uint8
-		timestampType   int8
-		isTransactional bool
-		isControl       bool
+		name string
+		opts RecordAttrsOpts
 	}{
-		{"zero", 0, 0, false, false},
-		{"snappy create-time", 2, 0, false, false},
-		{"zstd log-append-time", 4, 1, false, false},
-		{"no-timestamp", 0, -1, false, false},
-		{"transactional", 1, 0, true, false},
-		{"control", 0, 0, false, true},
-		{"all set", 3, 1, true, true},
+		{"zero", RecordAttrsOpts{}},
+		{"snappy create-time", RecordAttrsOpts{Codec: CodecSnappy}},
+		{"zstd log-append-time", RecordAttrsOpts{Codec: CodecZstd, TimestampType: 1}},
+		{"no-timestamp", RecordAttrsOpts{TimestampType: -1}},
+		{"transactional", RecordAttrsOpts{Codec: CodecGzip, Transactional: true}},
+		{"control", RecordAttrsOpts{Control: true}},
+		{"all set", RecordAttrsOpts{Codec: CodecLz4, TimestampType: 1, Transactional: true, Control: true}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			a := NewRecordAttrs(tc.compressionType, tc.timestampType, tc.isTransactional, tc.isControl)
-			if got := a.CompressionType(); got != tc.compressionType {
-				t.Errorf("CompressionType: got %d, want %d", got, tc.compressionType)
+			a := NewRecordAttrs(tc.opts)
+			if got := a.CompressionType(); got != uint8(tc.opts.Codec) {
+				t.Errorf("CompressionType: got %d, want %d", got, uint8(tc.opts.Codec))
 			}
-			if got := a.TimestampType(); got != tc.timestampType {
-				t.Errorf("TimestampType: got %d, want %d", got, tc.timestampType)
+			if got := a.TimestampType(); got != tc.opts.TimestampType {
+				t.Errorf("TimestampType: got %d, want %d", got, tc.opts.TimestampType)
 			}
-			if got := a.IsTransactional(); got != tc.isTransactional {
-				t.Errorf("IsTransactional: got %t, want %t", got, tc.isTransactional)
+			if got := a.IsTransactional(); got != tc.opts.Transactional {
+				t.Errorf("IsTransactional: got %t, want %t", got, tc.opts.Transactional)
 			}
-			if got := a.IsControl(); got != tc.isControl {
-				t.Errorf("IsControl: got %t, want %t", got, tc.isControl)
+			if got := a.IsControl(); got != tc.opts.Control {
+				t.Errorf("IsControl: got %t, want %t", got, tc.opts.Control)
 			}
 		})
 	}


### PR DESCRIPTION
### What

Adds an exported `NewRecordAttrs` constructor to `kgo`, mirroring the existing
`CompressionType` / `TimestampType` / `IsTransactional` / `IsControl` accessors:

```go
func NewRecordAttrs(compressionType uint8, timestampType int8, isTransactional, isControl bool) RecordAttrs
```

The `attrs` bits stay unexported; the constructor round-trips through the
accessors. Includes a unit test. No existing behaviour changes.

### Why

We're building [warpstream-go](https://github.com/grafana/warpstream-go) — a
produce-only Kafka client for WarpStream's stateless-agent architecture — on top
of franz-go, and we'd like it to be a drop-in for `kgo` on the produce path. When
a produce completes we populate the returned `*kgo.Record` with the same metadata
franz-go sets in `finishPromises`, including `Record.Attrs` (the batch's
compression codec + timestamp type).

That one field can't be set from outside `kgo` today: `RecordAttrs`'s only field
is unexported and there's no constructor, so external code can *read* attrs (via
the accessors) but never *build* one. It's the last produce-result field we can't
match.

So we're gently asking for this small, additive constructor to close the gap. The
name and signature are of course open to whatever you prefer — happy to adjust.
