### PR TITLE
deps: replace golang.org/x/crypto/pbkdf2 with stdlib crypto/pbkdf2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1
-	golang.org/x/crypto v0.51.0
 )
 
 retract v1.11.4 // This version is actually a breaking change and requires a major version change.

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,3 @@ github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1 h1:fG5kItwysTk5UXqVwb64EpQEy3TydF3vYYK21nUQ+bI=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=

--- a/pkg/kadm/misc.go
+++ b/pkg/kadm/misc.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/crypto/pbkdf2"
+	"crypto/pbkdf2"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -762,13 +762,17 @@ func (cl *Client) AlterUserSCRAMs(ctx context.Context, del []DeleteSCRAM, upsert
 			if _, err := rand.Read(u.Salt); err != nil {
 				return nil, fmt.Errorf("user %s: unable to generate salt: %v", u.User, err)
 			}
+			var kdfErr error
 			switch u.Mechanism {
 			case ScramSha256:
-				u.SaltedPassword = pbkdf2.Key([]byte(u.Password), u.Salt, int(u.Iterations), sha256.Size, sha256.New)
+				u.SaltedPassword, kdfErr = pbkdf2.Key(sha256.New, u.Password, u.Salt, int(u.Iterations), sha256.Size)
 			case ScramSha512:
-				u.SaltedPassword = pbkdf2.Key([]byte(u.Password), u.Salt, int(u.Iterations), sha512.Size, sha512.New)
+				u.SaltedPassword, kdfErr = pbkdf2.Key(sha512.New, u.Password, u.Salt, int(u.Iterations), sha512.Size)
 			default:
 				return nil, fmt.Errorf("user %s: unknown mechanism, unable to generate password", u.User)
+			}
+			if kdfErr != nil {
+				return nil, fmt.Errorf("user %s: pbkdf2 err: %v", u.User, kdfErr)
 			}
 			upsert[i] = u
 		} else if len(u.Salt) == 0 || len(u.SaltedPassword) == 0 {

--- a/pkg/kfake/sasl.go
+++ b/pkg/kfake/sasl.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/crypto/pbkdf2"
+	"crypto/pbkdf2"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
@@ -95,12 +95,12 @@ func saslSplitPlain(auth []byte) (user, pass string, err error) {
 
 func newScramAuth(mechanism, pass string) scramAuth {
 	var saltedPass []byte
-	salt := randBytes(10)
+	salt := randBytes(16)
 	switch mechanism {
 	case saslScram256:
-		saltedPass = pbkdf2.Key([]byte(pass), salt, scramIterations, sha256.Size, sha256.New)
+		saltedPass, _ = pbkdf2.Key(sha256.New, pass, salt, scramIterations, sha256.Size) // cannot fail: salt ≥ 16 B, keyLen = 32 B
 	case saslScram512:
-		saltedPass = pbkdf2.Key([]byte(pass), salt, scramIterations, sha512.Size, sha512.New)
+		saltedPass, _ = pbkdf2.Key(sha512.New, pass, salt, scramIterations, sha512.Size) // cannot fail: salt ≥ 16 B, keyLen = 64 B
 	default:
 		panic("unreachable")
 	}

--- a/pkg/sasl/scram/scram.go
+++ b/pkg/sasl/scram/scram.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/crypto/pbkdf2"
+	"crypto/pbkdf2"
 
 	"github.com/twmb/franz-go/pkg/sasl"
 )
@@ -209,7 +209,10 @@ func (s *session) authenticateClient(serverFirstMsg []byte) ([]byte, error) {
 	//////////////////
 
 	h := s.newhash()
-	saltedPassword := pbkdf2.Key([]byte(s.auth.Pass), salt, iters, h.Size(), s.newhash) // SaltedPassword := Hi(Normalize(password), salt, i)
+	saltedPassword, err := pbkdf2.Key(s.newhash, s.auth.Pass, salt, iters, h.Size()) // SaltedPassword := Hi(Normalize(password), salt, i)
+	if err != nil {
+		return nil, fmt.Errorf("pbkdf2 err: %v", err)
+	}
 
 	mac := hmac.New(s.newhash, saltedPassword)
 	if _, err = mac.Write([]byte("Client Key")); err != nil {


### PR DESCRIPTION
Go 1.24 added `crypto/pbkdf2` to the standard library. This PR swaps the three call sites that used `golang.org/x/crypto/pbkdf2` over to the stdlib version, dropping `golang.org/x/crypto` from `go.mod` entirely.

The motivation is FIPS 140 compliance. Go's FIPS-validated crypto module (`GOFIPS140`) only covers stdlib primitives — anything from `golang.org/x/crypto` is outside that boundary, so the dependency had to go.

The stdlib API is slightly different: the hash constructor moves to the first argument, the password becomes a plain `string` instead of `[]byte`, and the function now returns `([]byte, error)`. The error path is FIPS-only mode (`GOFIPS140` enforced), which rejects salts shorter than 16 bytes. `kfake` was generating 10-byte salts, so its salt is bumped to 16 bytes as part of this change. With that fix all three call sites are provably error-free: salts are at least 16 bytes, key lengths are 32 or 64 bytes (well above the 14-byte minimum), and both SHA-256 and SHA-512 are approved hashes.