### PR TITLE
kgo: classify retired broker reads as broker dead

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -1571,6 +1571,14 @@ func (cxn *brokerCxn) readResponse(
 	}
 
 	if readErr != nil {
+		// A metadata update can retire this broker while a response read is
+		// blocked. stopForever calls die, which marks the connection dead
+		// before closing it; the read then wakes with a platform-specific
+		// socket error. Return the same retryable error as requests queued
+		// behind this read, unless the client or request itself was canceled.
+		if cxn.dead.Load() && cxn.cl.ctx.Err() == nil && !isContextErr(readErr) {
+			return nil, errChosenBrokerDead
+		}
 		return nil, readErr
 	}
 	if len(buf) < 4 {
@@ -1850,22 +1858,24 @@ func (cxn *brokerCxn) handleResp(pr promisedResp) {
 		pr.readEnqueue,
 	)
 	if err != nil {
-		if !errors.Is(err, ErrClientClosed) && !errors.Is(err, context.Canceled) {
-			if cxn.successes > 0 || len(cxn.b.cl.cfg.sasls) > 0 {
-				cxn.b.cl.cfg.logger.Log(LogLevelDebug, "read from broker errored, killing connection", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "successful_reads", cxn.successes, "err", err)
-			} else {
-				cxn.b.cl.cfg.logger.Log(LogLevelWarn, "read from broker errored, killing connection after 0 successful responses (is SASL missing?)", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
-				if err == io.EOF || err == io.ErrUnexpectedEOF { // specifically avoid checking errors.Is to ensure this is not already wrapped
-					// ErrUnexpectedEOF gets the same first-read
-					// pessimism: now that it is retryable in
-					// isRetryableBrokerErr, a mid-frame close on
-					// the very first read (bad SASL cutting us off
-					// mid-response) must not retry forever either.
-					err = &ErrFirstReadEOF{kind: firstReadSASL, err: err, retry: cxn.b.cl.cfg.alwaysRetryEOF}
+		if !errors.Is(err, errChosenBrokerDead) {
+			if !errors.Is(err, ErrClientClosed) && !errors.Is(err, context.Canceled) {
+				if cxn.successes > 0 || len(cxn.b.cl.cfg.sasls) > 0 {
+					cxn.b.cl.cfg.logger.Log(LogLevelDebug, "read from broker errored, killing connection", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "successful_reads", cxn.successes, "err", err)
+				} else {
+					cxn.b.cl.cfg.logger.Log(LogLevelWarn, "read from broker errored, killing connection after 0 successful responses (is SASL missing?)", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
+					if err == io.EOF || err == io.ErrUnexpectedEOF { // specifically avoid checking errors.Is to ensure this is not already wrapped
+						// ErrUnexpectedEOF gets the same first-read
+						// pessimism: now that it is retryable in
+						// isRetryableBrokerErr, a mid-frame close on
+						// the very first read (bad SASL cutting us off
+						// mid-response) must not retry forever either.
+						err = &ErrFirstReadEOF{kind: firstReadSASL, err: err, retry: cxn.b.cl.cfg.alwaysRetryEOF}
+					}
 				}
+			} else {
+				cxn.b.cl.cfg.logger.Log(LogLevelDebug, "read from broker canceled, closing connection and killing any other in-flight requests on this connection", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
 			}
-		} else {
-			cxn.b.cl.cfg.logger.Log(LogLevelDebug, "read from broker canceled, closing connection and killing any other in-flight requests on this connection", "req", kmsg.Key(pr.resp.Key()).Name(), "addr", cxn.b.addr, "broker", logID(cxn.b.meta.NodeID), "err", err)
 		}
 		pr.promise(nil, err)
 		cxn.die()

--- a/pkg/kgo/broker_test.go
+++ b/pkg/kgo/broker_test.go
@@ -3,6 +3,7 @@ package kgo
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"sync"
@@ -12,6 +13,182 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
+
+type readSignalConn struct {
+	net.Conn
+	readStarted chan struct{}
+	once        sync.Once
+}
+
+type brokerReadHook func()
+
+func (h brokerReadHook) OnBrokerRead(BrokerMetadata, int16, int, time.Duration, time.Duration, error) {
+	h()
+}
+
+func (c *readSignalConn) Read(p []byte) (int, error) {
+	c.once.Do(func() { close(c.readStarted) })
+	return c.Conn.Read(p)
+}
+
+func TestRetiredBrokerConnectionClassifiedAsDead(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { serverConn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	logger := newRingLogger(new(nopLogger), 10)
+	cfg := defaultCfg()
+	cfg.logger = logger
+	cl := &Client{cfg: cfg, ctx: ctx}
+	b := cl.newBroker(1, "127.0.0.1", 9092, nil)
+	cxn := &brokerCxn{
+		conn: &readSignalConn{
+			Conn:        clientConn,
+			readStarted: make(chan struct{}),
+		},
+		cl:     cl,
+		b:      b,
+		addr:   b.addr,
+		deadCh: make(chan struct{}),
+	}
+	b.cxnFetch = cxn
+
+	errCh := make(chan error, 1)
+	go cxn.handleResp(promisedResp{
+		ctx:         ctx,
+		resp:        kmsg.NewPtrFetchResponse(),
+		readEnqueue: time.Now(),
+		promise: func(_ kmsg.Response, err error) {
+			errCh <- err
+		},
+	})
+
+	<-cxn.conn.(*readSignalConn).readStarted
+	b.stopForever()
+
+	if err := <-errCh; !errors.Is(err, errChosenBrokerDead) {
+		t.Fatalf("retired broker request error = %v, want %v", err, errChosenBrokerDead)
+	}
+	for _, entry := range logger.buf {
+		if entry.level == LogLevelWarn {
+			t.Fatalf("retired broker logged warning %q", entry.msg)
+		}
+		if entry.msg == "read from broker canceled, closing connection and killing any other in-flight requests on this connection" {
+			t.Fatalf("retired broker logged misleading cancellation message")
+		}
+	}
+}
+
+func TestRetiredBrokerDoesNotMaskResponseError(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { serverConn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cfg := defaultCfg()
+	cl := &Client{cfg: cfg, ctx: ctx}
+	b := cl.newBroker(1, "127.0.0.1", 9092, nil)
+	cxn := &brokerCxn{
+		conn:   clientConn,
+		cl:     cl,
+		b:      b,
+		addr:   b.addr,
+		deadCh: make(chan struct{}),
+	}
+	cl.cfg.hooks = hooks{brokerReadHook(cxn.die)}
+
+	writeErrCh := make(chan error, 1)
+	go func() {
+		response := make([]byte, 8)
+		binary.BigEndian.PutUint32(response, 4)
+		binary.BigEndian.PutUint32(response[4:], 2)
+		_, err := serverConn.Write(response)
+		writeErrCh <- err
+	}()
+
+	var (
+		promiseErr    error
+		deadAtPromise bool
+	)
+	cxn.handleResp(promisedResp{
+		ctx:         ctx,
+		resp:        kmsg.NewPtrMetadataResponse(),
+		corrID:      1,
+		readEnqueue: time.Now(),
+		promise: func(_ kmsg.Response, err error) {
+			promiseErr = err
+			deadAtPromise = cxn.dead.Load()
+		},
+	})
+
+	if writeErr := <-writeErrCh; writeErr != nil {
+		t.Fatalf("write response: %v", writeErr)
+	}
+	if !deadAtPromise {
+		t.Fatal("broker read hook did not retire connection")
+	}
+	if !errors.Is(promiseErr, errCorrelationIDMismatch) {
+		t.Fatalf("retired broker response error = %v, want %v", promiseErr, errCorrelationIDMismatch)
+	}
+}
+
+func TestUnexpectedFirstReadStillWarns(t *testing.T) {
+	t.Parallel()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { serverConn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	logger := newRingLogger(new(nopLogger), 10)
+	cfg := defaultCfg()
+	cfg.logger = logger
+	cl := &Client{cfg: cfg, ctx: ctx}
+	b := cl.newBroker(1, "127.0.0.1", 9092, nil)
+	cxn := &brokerCxn{
+		conn: &readSignalConn{
+			Conn:        clientConn,
+			readStarted: make(chan struct{}),
+		},
+		cl:     cl,
+		b:      b,
+		addr:   b.addr,
+		deadCh: make(chan struct{}),
+	}
+
+	errCh := make(chan error, 1)
+	go cxn.handleResp(promisedResp{
+		ctx:         ctx,
+		resp:        kmsg.NewPtrFetchResponse(),
+		readEnqueue: time.Now(),
+		promise: func(_ kmsg.Response, err error) {
+			errCh <- err
+		},
+	})
+
+	<-cxn.conn.(*readSignalConn).readStarted
+	serverConn.Close()
+
+	err := <-errCh
+	var firstReadErr *ErrFirstReadEOF
+	if !errors.As(err, &firstReadErr) {
+		t.Fatalf("unexpected first read error = %v, want *ErrFirstReadEOF", err)
+	}
+	for _, entry := range logger.buf {
+		if entry.level == LogLevelWarn && entry.msg == "read from broker errored, killing connection after 0 successful responses (is SASL missing?)" {
+			return
+		}
+	}
+	t.Fatal("unexpected first read did not log the SASL warning")
+}
 
 // resetThenServeListener implements just enough of the wire protocol to
 // exercise loadConnection's ApiVersions-reset retry: it RSTs (SO_LINGER 0)


### PR DESCRIPTION
## Problem

The broker list in a metadata response is authoritative. When a broker is removed or replaced, `updateBrokers` retires it through `stopForever`, which marks each connection dead and closes its socket.

If a request is waiting for its first response at that point, the blocked read wakes with the platform's local socket-close error. `handleResp` currently treats that as an unexpected first-read failure, emits the `is SASL missing?` warning, and returns the raw network error. Requests queued behind the active read already receive `errChosenBrokerDead`, and `updateBrokers` documents that in-flight requests should receive the same retryable result.

This is especially visible with deployments whose advertised broker endpoints change frequently, but the lifecycle mismatch is generic to kgo.

## Change

- Return `errChosenBrokerDead` for a non-context socket-read failure when another goroutine has already marked the connection dead and the client remains open.
- Perform the normalization after raw read hooks and per-request debug logging, preserving the actual I/O error for low-level observability.
- Avoid both the misleading first-read SASL warning and the cancellation debug message for an intentional retirement.
- Preserve response-header and correlation errors even if the connection is retired concurrently.
- Preserve the existing warning and `ErrFirstReadEOF` behavior for unexpected first-read disconnects.

## Validation

- The retirement regression failed before the fix with the local socket-close error and SASL warning.
- The protocol-error regression failed before the refinement because `errChosenBrokerDead` masked `errCorrelationIDMismatch`.
- The logging regression failed before the refinement because retirement emitted the cancellation debug message.
- `go test -race ./pkg/kgo -run '^(TestRetiredBrokerConnectionClassifiedAsDead|TestRetiredBrokerDoesNotMaskResponseError|TestUnexpectedFirstReadStillWarns)$' -count=100`
- `go test -race ./pkg/kgo -run '^(TestRetiredBrokerConnectionClassifiedAsDead|TestRetiredBrokerDoesNotMaskResponseError|TestUnexpectedFirstReadStillWarns|TestAuditApiVersionsResetRetryClosesConns)$' -count=1`
- `go build ./pkg/kgo`
- `go vet ./pkg/kgo`
- `gofmt` and `git diff --check`

The full integration suite was not run locally because it requires a broker; the repository's PR workflow covers Kafka, kfake, and Redpanda.
