### PR TITLE
kgo: flatten topic/partition maps in group rebalance logs

### DIFF
--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -399,9 +399,9 @@ func (c *consumer) initGroup() {
 			default:
 			}
 			if ctxExpired {
-				cl.cfg.logger.Log(LogLevelDebug, "entering "+name, "with", m, "context_expired", ctxExpired)
+				cl.cfg.logger.Log(LogLevelDebug, "entering "+name, "with", mtps(m), "context_expired", ctxExpired)
 			} else {
-				cl.cfg.logger.Log(LogLevelDebug, "entering "+name, "with", m)
+				cl.cfg.logger.Log(LogLevelDebug, "entering "+name, "with", mtps(m))
 			}
 			if user != nil {
 				dup := make(map[string][]int32)
@@ -747,9 +747,9 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 		g.c.mu.Unlock()
 
 		if !g.cooperative.Load() {
-			g.cfg.logger.Log(LogLevelInfo, "eager consumer revoking prior assigned partitions", "group", g.cfg.group, "revoking", g.nowAssigned.read())
+			g.cfg.logger.Log(LogLevelInfo, "eager consumer revoking prior assigned partitions", "group", g.cfg.group, "revoking", mtps(g.nowAssigned.read()))
 		} else {
-			g.cfg.logger.Log(LogLevelInfo, "cooperative consumer revoking prior assigned partitions because leaving group", "group", g.cfg.group, "revoking", g.nowAssigned.read())
+			g.cfg.logger.Log(LogLevelInfo, "cooperative consumer revoking prior assigned partitions because leaving group", "group", g.cfg.group, "revoking", mtps(g.nowAssigned.read()))
 		}
 		g.cfg.onRevoked(g.cl.ctx, g.cl, g.nowAssigned.read())
 		g.nowAssigned.store(nil)
@@ -843,7 +843,7 @@ func (g *groupConsumer) revoke(stage revokeStage, lost map[string][]int32, leavi
 		if len(lost) == 0 {
 			g.cfg.logger.Log(LogLevelInfo, "consumer calling onRevoke at the end of a session; consumer did not change any client-side subscription", "group", g.cfg.group)
 		} else {
-			g.cfg.logger.Log(LogLevelInfo, "calling onRevoke at the end of a session", "group", g.cfg.group, "lost", lost, "stage", stage)
+			g.cfg.logger.Log(LogLevelInfo, "calling onRevoke at the end of a session", "group", g.cfg.group, "lost", mtps(lost), "stage", stage)
 		}
 		g.cfg.onRevoked(g.cl.ctx, g.cl, lost)
 	}


### PR DESCRIPTION
On rebalance, `kgo` logs affected partitions as a raw `map[string][]int32` keyed by topic. A structured (JSON) logger turns each map key into its own field, so with high-cardinality topics (for example one topic per tenant) the field count grows without bound on the log backend.

`kgo` is inconsistent about this. It already wraps the same data in the `mtps` stringer on "new group session begun" and "synced":

- https://github.com/twmb/franz-go/blob/dd56926b16a14d119f6c4c0212051b79c9f9aed8/pkg/kgo/consumer_group.go#L1045
- https://github.com/twmb/franz-go/blob/dd56926b16a14d119f6c4c0212051b79c9f9aed8/pkg/kgo/consumer_group.go#L1774

But it passes the raw map on "calling onRevoke at the end of a session" (`lost`), both "revoking prior assigned partitions" lines (`revoking`), and the debug "entering <callback>" lines (`with`):

- https://github.com/twmb/franz-go/blob/dd56926b16a14d119f6c4c0212051b79c9f9aed8/pkg/kgo/consumer_group.go#L846
- https://github.com/twmb/franz-go/blob/dd56926b16a14d119f6c4c0212051b79c9f9aed8/pkg/kgo/consumer_group.go#L749-L753
- https://github.com/twmb/franz-go/blob/dd56926b16a14d119f6c4c0212051b79c9f9aed8/pkg/kgo/consumer_group.go#L401-L405

A `map[string][]int32` has no `String()`, so it reflects into nested keys. [`mtps`](https://github.com/twmb/franz-go/blob/dd56926b16a14d119f6c4c0212051b79c9f9aed8/pkg/kgo/topics_and_partitions.go#L97-L118) implements `fmt.Stringer`, so wrapping the value emits a single string. This change wraps those values in `mtps`; only log formatting changes, the same information is preserved.

Example now:

```json
"lost": {
  "events.tenant-a1": [0],
  "metrics.tenant-a1": [0]
}
```

Example after this change:

```json
"lost": "events.tenant-a1[0], metrics.tenant-a1[0]"
```