### PR TITLE
kgo: guard the per-partition metadata debug logs

### DIFF
--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -781,6 +781,12 @@ func (cl *Client) mergeTopicPartitions(
 ) {
 	isProduce := kind == partitionKindProduce
 	isShare := kind == partitionKindShare
+	// The logger is an interface, so the variadic slice and the interface
+	// boxes for every argument are built at the call site even when the
+	// logger drops the line. The logs below fire once per partition per
+	// metadata refresh, so for a client with many partitions that is
+	// continuous garbage forever; we only pay it if debug is on.
+	debug := cl.cfg.logger.Level() >= LogLevelDebug
 	lv := *l.load() // copy so our field writes do not collide with reads
 
 	r := mt.newPartitions(cl, kind)
@@ -996,12 +1002,14 @@ func (cl *Client) mergeTopicPartitions(
 		// If the tp data equals the old, then the sink / source is the
 		// same, because the sink/source is from the tp leader.
 		if newTP.topicPartitionData == oldTP.topicPartitionData {
-			cl.cfg.logger.Log(LogLevelDebug, "metadata refresh has identical topic partition data",
-				"topic", topic,
-				"partition", part,
-				"leader", newTP.leader,
-				"leader_epoch", newTP.leaderEpoch,
-			)
+			if debug {
+				cl.cfg.logger.Log(LogLevelDebug, "metadata refresh has identical topic partition data",
+					"topic", topic,
+					"partition", part,
+					"leader", newTP.leader,
+					"leader_epoch", newTP.leaderEpoch,
+				)
+			}
 			switch kind {
 			case partitionKindProduce:
 				newTP.records = oldTP.records
@@ -1012,14 +1020,16 @@ func (cl *Client) mergeTopicPartitions(
 				newTP.cursor = oldTP.cursor // unlike records, there is no failing state for a cursor
 			}
 		} else {
-			cl.cfg.logger.Log(LogLevelDebug, "metadata refresh topic partition data changed",
-				"topic", topic,
-				"partition", part,
-				"new_leader", newTP.leader,
-				"new_leader_epoch", newTP.leaderEpoch,
-				"old_leader", oldTP.leader,
-				"old_leader_epoch", oldTP.leaderEpoch,
-			)
+			if debug {
+				cl.cfg.logger.Log(LogLevelDebug, "metadata refresh topic partition data changed",
+					"topic", topic,
+					"partition", part,
+					"new_leader", newTP.leader,
+					"new_leader_epoch", newTP.leaderEpoch,
+					"old_leader", oldTP.leader,
+					"old_leader_epoch", oldTP.leaderEpoch,
+				)
+			}
 			switch kind {
 			case partitionKindProduce:
 				oldTP.migrateProductionTo(newTP) // migration clears failing state
@@ -1055,32 +1065,38 @@ func (cl *Client) mergeTopicPartitions(
 		case partitionKindProduce:
 			if newTP.records.recBufsIdx == -1 {
 				newTP.records.sink.addRecBuf(newTP.records)
-				cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new produce partition",
-					"topic", topic,
-					"partition", newTP.partition(),
-					"leader", newTP.leader,
-					"leader_epoch", newTP.leaderEpoch,
-				)
+				if debug {
+					cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new produce partition",
+						"topic", topic,
+						"partition", newTP.partition(),
+						"leader", newTP.leader,
+						"leader_epoch", newTP.leaderEpoch,
+					)
+				}
 			}
 		case partitionKindShare:
 			if newTP.shareCursor.cursorsIdx == -1 {
 				newTP.shareCursor.source.Load().addShareCursor(newTP.shareCursor)
-				cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new share consume partition",
-					"topic", topic,
-					"partition", newTP.partition(),
-					"leader", newTP.leader,
-					"leader_epoch", newTP.leaderEpoch,
-				)
+				if debug {
+					cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new share consume partition",
+						"topic", topic,
+						"partition", newTP.partition(),
+						"leader", newTP.leader,
+						"leader_epoch", newTP.leaderEpoch,
+					)
+				}
 			}
 		default:
 			if newTP.cursor.cursorsIdx == -1 {
 				newTP.cursor.source.addCursor(newTP.cursor)
-				cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new consume partition",
-					"topic", topic,
-					"partition", newTP.partition(),
-					"leader", newTP.leader,
-					"leader_epoch", newTP.leaderEpoch,
-				)
+				if debug {
+					cl.cfg.logger.Log(LogLevelDebug, "metadata refresh new consume partition",
+						"topic", topic,
+						"partition", newTP.partition(),
+						"leader", newTP.leader,
+						"leader_epoch", newTP.leaderEpoch,
+					)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

`mergeTopicPartitions` in `pkg/kgo/metadata.go` has ~15 `logger.Log(LogLevelDebug, ...)` calls and zero level guards, while `source.go` and `sink.go` already hoist `debug := s.cl.cfg.logger.Level() >= LogLevelDebug`.

**The default `nopLogger` does not avoid the cost.** `cfg.logger` is an interface, so the variadic `[]any` slice and the interface boxes for every argument are constructed at the call site before the call is made. The no-op `Log` body only avoids printing; the garbage is already allocated.

The one that matters is `"metadata refresh has identical topic partition data"`: it fires **once per partition on every metadata refresh, even when nothing changed**. A previous profiling run measured these lines as roughly half of all allocations in the merge. At 10k partitions with the default 5 minute `MetadataMaxAge`, that is continuous garbage forever, for a client that has logging turned off.

## Fix

Hoist `debug := cl.cfg.logger.Level() >= LogLevelDebug` at the top of `mergeTopicPartitions` and guard the five logs that fire per partition (the identical/changed pair in the migrate loop, and the three "new partition" lines). Logs that fire once per refresh or once per topic are left alone -- they are not worth the noise.

## Measured

Throwaway benchmark of one such call site through a `Logger` interface variable holding a `nopLogger` (Apple M1, Go tip, `-benchmem -count 3`):

```
BenchmarkScratchUnguarded-8   13894543    80.30 ns/op    152 B/op    2 allocs/op
BenchmarkScratchUnguarded-8   15389218    79.15 ns/op    152 B/op    2 allocs/op
BenchmarkScratchUnguarded-8   15139814    80.42 ns/op    152 B/op    2 allocs/op
BenchmarkScratchGuarded-8    352885086     3.398 ns/op     0 B/op    0 allocs/op
BenchmarkScratchGuarded-8    352556259     3.404 ns/op     0 B/op    0 allocs/op
BenchmarkScratchGuarded-8    349473889     4.076 ns/op     0 B/op    0 allocs/op
```

The two allocations are the `[]any` backing array and the boxed partition index. The benchmark itself is not committed.

## Verification

`gofmt -l`, `go vet ./...`, `go build ./...` clean; `go test -race ./pkg/kgo/internal/...` passes. `go test ./pkg/kgo/` requires a broker on :9092 and was not run. No behavior change -- debug output is byte-for-byte identical when debug logging is enabled.