### PR TITLE
kgo: drop the topic partition lock before buffering a record

### DIFF
--- a/pkg/kgo/producer.go
+++ b/pkg/kgo/producer.go
@@ -887,8 +887,13 @@ func (cl *Client) doPartition(parts *topicPartitions, partsData *topicPartitions
 		return
 	}
 
+	// partsMu exists only to serialize access to the topic's partitioner
+	// (and the least-backup input we feed it): it guards nothing that
+	// bufferRecord touches, and bufferRecord takes the target recBuf's own
+	// mutex. Every exit below therefore unlocks as soon as the partitioner
+	// is done being used -- see the comment above the buffering below for
+	// why the KIP-480 path is the one exception.
 	parts.partsMu.Lock()
-	defer parts.partsMu.Unlock()
 	if parts.partitioner == nil {
 		parts.partitioner = cl.cfg.partitioner.ForTopic(pr.Topic)
 	}
@@ -910,6 +915,7 @@ func (cl *Client) doPartition(parts *topicPartitions, partsData *topicPartitions
 		mapping = partsData.partitions
 	}
 	if len(mapping) == 0 {
+		parts.partsMu.Unlock()
 		cl.producer.promiseRecord(pr, errors.New("unable to partition record due to no usable partitions"))
 		return
 	}
@@ -926,16 +932,35 @@ func (cl *Client) doPartition(parts *topicPartitions, partsData *topicPartitions
 		pick = parts.partitioner.Partition(pr.Record, len(mapping))
 	}
 	if pick < 0 || pick >= len(mapping) {
+		parts.partsMu.Unlock()
 		cl.producer.promiseRecord(pr, fmt.Errorf("invalid record partitioning choice of %d from %d available", pick, len(mapping)))
 		return
 	}
 
 	partition := mapping[pick]
 
+	// A KIP-480 partitioner needs the lock held across the buffering: if
+	// the record would start a new batch, bufferRecord aborts and we must
+	// call OnNewBatch and re-pick. That trio (pick, abort, re-pick) has to
+	// be atomic against the partitioner's state -- OnNewBatch un-pins the
+	// sticky partition, so a concurrent produce landing between our abort
+	// and our re-pick would either be handed the partition we are about to
+	// abandon or would itself re-pin, and our OnNewBatch would then clobber
+	// its fresh pin.
+	//
+	// Without OnNewBatch there is no abort and nothing to keep atomic, so
+	// we are done with the partitioner the moment we have our pick. Holding
+	// the lock across bufferRecord would serialize every produce to a topic
+	// on one mutex no matter how many partitions the topic has.
 	onNewBatch, _ := parts.partitioner.(TopicPartitionerOnNewBatch)
-	abortOnNewBatch := onNewBatch != nil
-	processed := partition.records.bufferRecord(pr, abortOnNewBatch) // KIP-480
-	if !processed {
+	if onNewBatch == nil {
+		parts.partsMu.Unlock()
+		partition.records.bufferRecord(pr, false)
+		return
+	}
+	defer parts.partsMu.Unlock()
+
+	if !partition.records.bufferRecord(pr, true) { // KIP-480
 		onNewBatch.OnNewBatch()
 
 		if tlp != nil {

--- a/pkg/kgo/producer_partition_test.go
+++ b/pkg/kgo/producer_partition_test.go
@@ -1,0 +1,248 @@
+package kgo
+
+import (
+	"context"
+	"math"
+	"net"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const benchProducePartitions = 64
+
+// newSeededProduceClient returns a client with `topics` topics of `partitions`
+// partitions each, seeded directly into the producer's topic map so that no
+// broker is needed. batchMaxBytes overrides the per-recBuf batch cap directly,
+// bypassing the config minimum: a tiny cap rolls batches constantly (and so
+// runs the KIP-480 abort-and-repick constantly), while an unreachable cap
+// keeps every recBuf at exactly one batch, which is what the benchmarks want
+// so that nothing ever drains toward the nonexistent broker.
+func newSeededProduceClient(tb testing.TB, topics, partitions int, partitioner Partitioner, batchMaxBytes int32) *Client {
+	tb.Helper()
+
+	// A guaranteed-refused seed plus an unreachable metadata age means
+	// nothing in these tests ever talks to a broker.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	deadAddr := ln.Addr().String()
+	ln.Close()
+
+	opts := []Opt{
+		SeedBrokers(deadAddr),
+		ManualFlushing(),
+		MaxBufferedRecords(math.MaxInt32),
+		ProducerLinger(time.Minute),
+		MetadataMaxAge(time.Hour),
+		MetadataMinAge(time.Hour),
+	}
+	if partitioner != nil {
+		opts = append(opts, RecordPartitioner(partitioner))
+	}
+	cl, err := NewClient(opts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	sink := cl.newSink(0)
+	data := make(topicsPartitionsData, topics)
+	for t := range topics {
+		topic := produceTestTopic(t)
+		tps := newTopicPartitions()
+		tpd := &topicPartitionsData{topic: topic}
+		for p := range partitions {
+			mp := metadataPartition{
+				topic:     topic,
+				partition: int32(p),
+				sns:       sinkAndSource{sink: sink},
+			}
+			tp := mp.newPartition(cl, partitionKindProduce)
+			tp.records.maxRecordBatchBytes = batchMaxBytes
+			tpd.partitions = append(tpd.partitions, tp)
+			tpd.writablePartitions = append(tpd.writablePartitions, tp)
+		}
+		tps.v.Store(tpd)
+		data[topic] = tps
+	}
+	cl.producer.topics.storeData(data)
+
+	return cl
+}
+
+func produceTestTopic(n int) string { return "bench-" + strconv.Itoa(n) }
+
+// doPartition holds parts.partsMu across the buffering only for partitioners
+// implementing TopicPartitionerOnNewBatch, whose abort-and-repick has to be
+// atomic against the partitioner's state; for every other partitioner it drops
+// the lock as soon as it has its pick. This produces concurrently through every
+// shipped partitioner, with a batch cap small enough that batches roll (and so
+// OnNewBatch fires) constantly, and asserts each record is promised exactly
+// once with a partition in range.
+//
+// Under -race this is the guard on that narrowed scope: any partitioner state
+// read or written outside partsMu surfaces here.
+func TestConcurrentProducePartitioning(t *testing.T) {
+	t.Parallel()
+
+	const (
+		partitions   = 8
+		goroutines   = 8
+		perGoroutine = 250
+		total        = goroutines * perGoroutine
+	)
+
+	for _, test := range []struct {
+		name        string
+		partitioner Partitioner
+		keys        bool
+	}{
+		// The default partitioner, both of its paths: keyed records
+		// hash consistently, keyless records take the sticky byte path.
+		{"default", nil, false},
+		{"default-keyed", nil, true},
+
+		// TopicPartitionerOnNewBatch implementors: the lock must still
+		// span the buffering for these.
+		{"sticky", StickyPartitioner(), false},
+		{"sticky-key", StickyKeyPartitioner(nil), false},
+		{"sticky-key-keyed", StickyKeyPartitioner(nil), true},
+		{"least-backup", LeastBackupPartitioner(), false},
+
+		{"round-robin", RoundRobinPartitioner(), false},
+		{"uniform-bytes-nonadaptive", UniformBytesPartitioner(512, false, true, nil), true},
+		{"basic-consistent", BasicConsistentPartitioner(func(string) func(*Record, int) int {
+			return func(_ *Record, n int) int { return n - 1 }
+		}), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cl := newSeededProduceClient(t, 1, partitions, test.partitioner, 512)
+
+			var (
+				wg        sync.WaitGroup
+				promised  atomic.Int64
+				badPart   atomic.Int64
+				topic     = produceTestTopic(0)
+				ctx       = context.Background()
+				value     = make([]byte, 64)
+				produceWG sync.WaitGroup
+			)
+			wg.Add(total)
+			promise := func(r *Record, _ error) {
+				if r.Partition < 0 || r.Partition >= partitions {
+					badPart.Add(1)
+				}
+				promised.Add(1)
+				wg.Done()
+			}
+
+			produceWG.Add(goroutines)
+			for g := range goroutines {
+				go func() {
+					defer produceWG.Done()
+					for i := range perGoroutine {
+						r := &Record{Topic: topic, Value: value}
+						if test.keys {
+							r.Key = []byte("key-" + strconv.Itoa(g*perGoroutine+i))
+						}
+						cl.TryProduce(ctx, r, promise)
+					}
+				}()
+			}
+			produceWG.Wait()
+
+			// Close fails everything still buffered, so every record's
+			// promise is guaranteed to run.
+			cl.Close()
+
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(30 * time.Second):
+				t.Fatalf("timed out with %d/%d records promised", promised.Load(), total)
+			}
+
+			if got := promised.Load(); got != total {
+				t.Errorf("promised %d records, want %d", got, total)
+			}
+			if got := badPart.Load(); got != 0 {
+				t.Errorf("%d records were promised with an out-of-range partition", got)
+			}
+		})
+	}
+}
+
+// benchProduce produces b.N records in parallel, giving each goroutine a topic
+// round robin. Every goroutine cycles a fixed set of records rather than
+// building one per iteration: we are measuring the produce path's locking, not
+// allocation.
+//
+// These benchmarks are sensitive to anything that lets a record reach the
+// (nonexistent) broker or that carries memory pressure between runs. Measure
+// one benchmark at one -cpu per process; a -count above 1, or several -cpu
+// values in one process, has each run inherit the previous run's buffered
+// records and reports garbage.
+func benchProduce(b *testing.B, topics int, keyed bool) {
+	cl := newSeededProduceClient(b, topics, benchProducePartitions, nil, math.MaxInt32)
+	defer cl.Close()
+
+	value := make([]byte, 128)
+	ctx := context.Background()
+
+	var goroutine atomic.Int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		topic := produceTestTopic(int(goroutine.Add(1)-1) % topics)
+		// Keyed records hash across every partition, so the records a
+		// goroutine produces land in many different recBufs while still
+		// sharing the topic's one partsMu. Keyless records take the
+		// default partitioner's sticky path, which pins one partition
+		// (and so one recBuf) at a time.
+		rs := make([]*Record, benchProducePartitions)
+		for i := range rs {
+			rs[i] = &Record{Topic: topic, Value: value}
+			if keyed {
+				rs[i].Key = []byte("key-" + strconv.Itoa(i))
+			}
+		}
+		var i int
+		for pb.Next() {
+			cl.TryProduce(ctx, rs[i], nil)
+			i++
+			if i == len(rs) {
+				i = 0
+			}
+		}
+	})
+	b.StopTimer()
+
+	// Every record must have buffered. If any failed - a drain reaching the
+	// dead broker and erroring records, say - the numbers above measured
+	// the wrong thing.
+	cl.producer.mu.Lock()
+	buffered := cl.producer.bufferedRecords
+	cl.producer.mu.Unlock()
+	if buffered != int64(b.N) {
+		b.Fatalf("buffered %d records, expected all %d to buffer", buffered, b.N)
+	}
+}
+
+// All goroutines share one topic and so share that topic's partsMu. Keyed
+// records spread over every partition, so partsMu is the only thing every
+// goroutine must pass through.
+func BenchmarkProduceParallelSharedTopicKeyed(b *testing.B) { benchProduce(b, 1, true) }
+
+// As above, but keyless: the default partitioner is sticky, so every goroutine
+// also converges on one partition's recBuf.
+func BenchmarkProduceParallelSharedTopic(b *testing.B) { benchProduce(b, 1, false) }
+
+// Each goroutine gets its own topic and so its own partsMu, with the same
+// partition count as the shared-topic benchmarks. This is the uncontended
+// reference point.
+func BenchmarkProduceParallelTopicPerGoroutine(b *testing.B) { benchProduce(b, 8, true) }


### PR DESCRIPTION
`doPartition` held `parts.partsMu` across both the partitioner call **and**
`bufferRecord`. There is one `partsMu` per topic, so every produce to a topic
serialized on one mutex no matter how many partitions the topic had — producing
to a single topic scaled *negatively* with cores.

A mutex profile of 8 goroutines producing keyed records to one 64-partition
topic put **97% of all mutex delay in `doPartition`** (the global `producer.mu`
was ~2%).

### Why the lock can be dropped

`partsMu` guards exactly two things: `parts.partitioner` (lazy init plus the
partitioner's own mutable state) and `parts.lb`, the `leastBackupInput` fed to
`TopicBackupPartitioner`. It guards nothing `bufferRecord` touches, and
`bufferRecord` takes the target `recBuf`'s own mutex (`sink.go`, `recBuf.mu`).
Once the partitioner has handed back a pick, the lock has no further work.

`mapping` is not protected by it either: `partsData` is an immutable snapshot
loaded *before* `partsMu` is taken, so a metadata refresh can already swap it
under the lock today. Buffering into a `recBuf` from a stale snapshot is the
existing design — `migrateProductionTo` reuses the same `recBuf` pointer in the
new `topicPartition` under `recBuf.mu`.

### Why the KIP-480 path keeps the old scope

For a partitioner implementing `TopicPartitionerOnNewBatch`, a buffer that would
start a new batch aborts, and the recovery calls `OnNewBatch` and re-picks. That
trio (pick, abort, re-pick) must be atomic against the partitioner's state:
`OnNewBatch` un-pins the sticky partition, so a concurrent produce landing in
between would either be handed the partition we are abandoning, or would re-pin
one that our `OnNewBatch` then clobbers. Those partitioners keep the lock across
the buffering.

Shipped partitioners that implement it — `StickyPartitioner`,
`StickyKeyPartitioner` (embeds `stickyTopicPartitioner`), `LeastBackupPartitioner`.
Ones that do not, and so take the narrowed scope — the **default**
`UniformBytesPartitioner`, `RoundRobinPartitioner`, `BasicConsistentPartitioner`,
`ManualPartitioner`.

### Benchmarks

One topic, 64 partitions, 128-byte values, `ManualFlushing`, `b.RunParallel`,
`benchstat` over 12 runs per point (each run in its own process — see the
benchmark comment for why).

| GOMAXPROCS | keyed, spread over partitions | keyless, default sticky partitioner | topic per goroutine (control) |
|---|---|---|---|
| 1 | 327n -> 262n | 239n -> 233n (~) | ~ |
| 2 | 369n -> 276n (-25%) | 334n -> 292n (~) | ~ |
| 4 | 561n -> 347n (-38%) | 431n -> 400n (-7%) | ~ |
| 8 | 732n -> 504n (-31%) | 569n -> 542n (-5%) | ~ |

A second full run on a busier machine reproduced -11% / -23% / -34% at 2/4/8 for
the keyed shape and -6.5% at 8 for the keyless shape. A focused 20-sample
`GOMAXPROCS=1` rerun showed **no** significant difference (p=0.165), which is the
expected result with no contention — the apparent gain in the table's first row
did not survive resampling.

The keyless case gains less because the default partitioner is sticky: it pins
one partition at a time, so the goroutines converge on one `recBuf` and the
contention only moves from `partsMu` to `recBuf.mu`. Total mutex delay for that
shape still drops ~25% (582ms -> 438ms) because the two locks now pipeline.

Aggregate mutex delay for the contended shape drops correspondingly; the control
benchmark (one topic per goroutine, no shared `partsMu`) is unchanged, which is
the point.

### Testing

`TestConcurrentProducePartitioning` produces concurrently through every shipped
partitioner with a batch cap small enough that batches roll — and so
`OnNewBatch` fires — constantly, asserting each record is promised exactly once
with an in-range partition. It needs no broker.

It is a real guard, not a formality: reverting just the KIP-480 exception (so
the lock is dropped for `OnNewBatch` partitioners too) makes it fail with 69
data races, all on `stickyTopicPartitioner.OnNewBatch`.

- `gofmt -l`, `go vet ./...`, `go build ./...`, `golangci-lint run ./...` — clean
- `go test -race ./pkg/kgo/internal/...` — pass
- `go test -race -count=4` over the new test and the partitioner tests — pass
- The broker-backed `pkg/kgo` suite was **not** run (no broker on :9092 available here)

### Checked against #1347

#1347 (KIP-1123 rack-aware partitioning) also edits `doPartition`, but only the
`mapping` selection *before* the pick — it does not touch the lock scope,
`bufferRecord`, or the `OnNewBatch` interaction, and nothing in its diff or its
review discussion states an invariant requiring `partsMu` to span the buffering.
The two merge cleanly (verified with a trial merge: no conflicts, builds, both
test sets pass), and the composition is correct — the rack filter narrows
`mapping` while still under `partsMu`, well before any unlock point.
