### PR TITLE
kgo: skip metadata refresh work that nothing changed

### DIFF
--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
+	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 type metawait struct {
@@ -90,6 +91,69 @@ func (cl *Client) id2tMap() map[[16]byte]string {
 		return noid2t
 	}
 	return m
+}
+
+// mergeTopicIDs merges the topic ID mappings in a metadata response into the
+// existing id2t map. We clone rather than rebuild so that topics missing from
+// this particular metadata response (transient broker omission, non-all
+// request) retain their ID mapping from prior responses.
+//
+// If a topic was deleted and recreated, the broker returns a new ID for the
+// same name. We do NOT add the new ID if the old ID is still present - the old
+// mapping is preserved until the user explicitly purges via
+// PurgeTopicsFromClient. This avoids having two IDs for the same topic name.
+func (cl *Client) mergeTopicIDs(latest map[string]*metadataTopic) {
+	old := cl.id2tMap()
+
+	// Steady state is that every ID in the response is already mapped to
+	// the same name: IDs only change when a topic is created, deleted, or
+	// recreated. Cloning the map and building the reverse name set costs
+	// two allocations sized by the number of topics, on every refresh, so
+	// we first walk the response to see if there is anything to do. If
+	// every ID maps to the name we already have, the merge below cannot
+	// change anything: the name is necessarily in knownNames (it is a
+	// value in the map we would clone) and the map already holds the
+	// entry the merge would write.
+	var changed bool
+	for _, mt := range latest {
+		if mt.id == ([16]byte{}) {
+			continue
+		}
+		if name, ok := old[mt.id]; !ok || name != mt.topic {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return
+	}
+
+	merged := make(map[[16]byte]string, len(old)+len(latest))
+	maps.Copy(merged, old)
+
+	// Build the set of topic names that already have an ID.
+	knownNames := make(map[string]struct{}, len(merged))
+	for _, name := range merged {
+		knownNames[name] = struct{}{}
+	}
+
+	for _, mt := range latest {
+		if mt.id == ([16]byte{}) {
+			continue
+		}
+		if _, exists := knownNames[mt.topic]; exists {
+			// This name already has an ID in the map. Only update
+			// if it's the same ID (normal case), skip if it's a
+			// different ID (recreated topic).
+			if _, sameID := merged[mt.id]; sameID {
+				merged[mt.id] = mt.topic
+			}
+			continue
+		}
+		merged[mt.id] = mt.topic
+		knownNames[mt.topic] = struct{}{}
+	}
+	cl.id2t.Store(merged)
 }
 
 // waitmeta returns immediately if metadata was updated within the last second,
@@ -404,46 +468,7 @@ func (cl *Client) updateMetadata() (retryWhy multiUpdateWhy, err error) {
 		}
 	}
 
-	// Merge topic ID mappings into the existing id2t map. We clone
-	// rather than rebuild so that topics missing from this particular
-	// metadata response (transient broker omission, non-all request)
-	// retain their ID mapping from prior responses.
-	//
-	// If a topic was deleted and recreated, the broker returns a new
-	// ID for the same name. We do NOT add the new ID if the old ID
-	// is still present - the old mapping is preserved until the user
-	// explicitly purges via PurgeTopicsFromClient. This avoids having
-	// two IDs for the same topic name.
-	{
-		old := cl.id2tMap()
-		merged := make(map[[16]byte]string, len(old)+len(latest))
-		maps.Copy(merged, old)
-
-		// Build the set of topic names that already have an ID.
-		knownNames := make(map[string]struct{}, len(merged))
-		for _, name := range merged {
-			knownNames[name] = struct{}{}
-		}
-
-		for _, mt := range latest {
-			if mt.id == ([16]byte{}) {
-				continue
-			}
-			if _, exists := knownNames[mt.topic]; exists {
-				// This name already has an ID in the map.
-				// Only update if it's the same ID (normal
-				// case), skip if it's a different ID
-				// (recreated topic).
-				if _, sameID := merged[mt.id]; sameID {
-					merged[mt.id] = mt.topic
-				}
-				continue
-			}
-			merged[mt.id] = mt.topic
-			knownNames[mt.topic] = struct{}{}
-		}
-		cl.id2t.Store(merged)
-	}
+	cl.mergeTopicIDs(latest)
 
 	// If we are consuming with regex and fetched all topics, the metadata
 	// may have returned topics the consumer is not yet tracking. We ensure
@@ -633,7 +658,6 @@ func (mp metadataPartition) newPartition(cl *Client, kind partitionKind) *topicP
 			topicPartitionData:  td,
 			lastAckedOffset:     -1,
 		}
-		r.lingerFn = r.unlingerAndManuallyDrain
 		p.records = r
 	case partitionKindShare:
 		p.shareCursor = &shareCursor{
@@ -659,6 +683,36 @@ func (mp metadataPartition) newPartition(cl *Client, kind partitionKind) *topicP
 		}
 	}
 	return p
+}
+
+// firstUnordered returns the index of the first partition that is not at its
+// own index, or -1 if the partitions are exactly 0..n-1.
+func firstUnordered(ps []kmsg.MetadataResponseTopicPartition) int {
+	for i := range ps {
+		if ps[i].Partition != int32(i) {
+			return i
+		}
+	}
+	return -1
+}
+
+// ensurePartitionsOrdered requires that a metadata response contains every
+// partition of a topic exactly once, and orders the response so that partition
+// N is at index N. Kafka partitions are strictly increasing from 0; if any
+// partition is missing, the caller considers the topic a load failure.
+//
+// A response where every partition already sits at its own index is by
+// definition sorted, so the completeness check doubles as the sortedness check
+// and we only pay for a sort when a broker replies out of order.
+func ensurePartitionsOrdered(ps []kmsg.MetadataResponseTopicPartition) error {
+	if firstUnordered(ps) < 0 {
+		return nil
+	}
+	sort.Slice(ps, func(i, j int) bool { return ps[i].Partition < ps[j].Partition })
+	if i := firstUnordered(ps); i >= 0 {
+		return fmt.Errorf("kafka did not reply with a comprehensive set of partitions for a topic; we expected partition %d but saw %d", i, ps[i].Partition)
+	}
+	return nil
 }
 
 // fetchTopicMetadata fetches metadata for all reqTopics and returns new
@@ -704,20 +758,8 @@ func (cl *Client) fetchTopicMetadata(all bool, reqTopics []string) (map[string]*
 			continue
 		}
 
-		// Kafka partitions are strictly increasing from 0. We enforce
-		// that here; if any partition is missing, we consider this
-		// topic a load failure.
-		sort.Slice(topicMeta.Partitions, func(i, j int) bool {
-			return topicMeta.Partitions[i].Partition < topicMeta.Partitions[j].Partition
-		})
-		for i := range topicMeta.Partitions {
-			if got := topicMeta.Partitions[i].Partition; got != int32(i) {
-				mt.loadErr = fmt.Errorf("kafka did not reply with a comprehensive set of partitions for a topic; we expected partition %d but saw %d", i, got)
-				break
-			}
-		}
-
-		if mt.loadErr != nil {
+		if err := ensurePartitionsOrdered(topicMeta.Partitions); err != nil {
+			mt.loadErr = err
 			continue
 		}
 

--- a/pkg/kgo/metadata_test.go
+++ b/pkg/kgo/metadata_test.go
@@ -1,0 +1,262 @@
+package kgo
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+func benchTopicID(n int) [16]byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(n)+1) // +1: never the zero ID
+	return id
+}
+
+func benchLatestTopics(n int) map[string]*metadataTopic {
+	latest := make(map[string]*metadataTopic, n)
+	for i := range n {
+		topic := fmt.Sprintf("benchmark_topic_%06d", i)
+		latest[topic] = &metadataTopic{
+			topic: topic,
+			id:    benchTopicID(i),
+		}
+	}
+	return latest
+}
+
+func benchPartitions(n int) []kmsg.MetadataResponseTopicPartition {
+	ps := make([]kmsg.MetadataResponseTopicPartition, n)
+	for i := range ps {
+		ps[i].Partition = int32(i)
+		ps[i].Leader = int32(i % 3)
+		ps[i].LeaderEpoch = 1
+		ps[i].Replicas = []int32{int32(i % 3)}
+		ps[i].ISR = []int32{int32(i % 3)}
+	}
+	return ps
+}
+
+func TestMergeTopicIDs(t *testing.T) {
+	t.Parallel()
+
+	cl := new(Client)
+	ta, tb := benchTopicID(0), benchTopicID(1)
+
+	// An ID-less topic (an old broker, or a topic that failed to load) is
+	// never mapped.
+	cl.mergeTopicIDs(map[string]*metadataTopic{
+		"a": {topic: "a", id: ta},
+		"b": {topic: "b", id: tb},
+		"c": {topic: "c"},
+	})
+	want := map[[16]byte]string{ta: "a", tb: "b"}
+	if got := cl.id2tMap(); !reflect.DeepEqual(got, want) {
+		t.Errorf("after first merge: got %v != want %v", got, want)
+	}
+
+	// Re-merging the same response must not rebuild the map. The rebuild
+	// always stores a fresh map, so an unchanged stored map proves we
+	// skipped it.
+	same := map[string]*metadataTopic{
+		"b": {topic: "b", id: tb},
+		"a": {topic: "a", id: ta},
+		"c": {topic: "c"},
+	}
+	prior := reflect.ValueOf(cl.id2tMap()).Pointer()
+	cl.mergeTopicIDs(same)
+	if got := reflect.ValueOf(cl.id2tMap()).Pointer(); got != prior {
+		t.Error("merging an unchanged response replaced the id2t map")
+	}
+	if got := cl.id2tMap(); !reflect.DeepEqual(got, want) {
+		t.Errorf("after unchanged merge: got %v != want %v", got, want)
+	}
+
+	// A recreated topic (same name, new ID) keeps the old mapping until
+	// the user purges; a new name is added.
+	tc, trecreate := benchTopicID(2), benchTopicID(3)
+	cl.mergeTopicIDs(map[string]*metadataTopic{
+		"a": {topic: "a", id: trecreate},
+		"c": {topic: "c", id: tc},
+	})
+	want = map[[16]byte]string{ta: "a", tb: "b", tc: "c"}
+	if got := cl.id2tMap(); !reflect.DeepEqual(got, want) {
+		t.Errorf("after recreate merge: got %v != want %v", got, want)
+	}
+}
+
+func TestEnsurePartitionsOrdered(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ordered", func(t *testing.T) {
+		t.Parallel()
+		ps := benchPartitions(64)
+		if err := ensurePartitionsOrdered(ps); err != nil {
+			t.Fatal(err)
+		}
+		if i := firstUnordered(ps); i >= 0 {
+			t.Errorf("partition at index %d is %d", i, ps[i].Partition)
+		}
+	})
+
+	t.Run("shuffled", func(t *testing.T) {
+		t.Parallel()
+		ps := benchPartitions(64)
+		rand.Shuffle(len(ps), func(i, j int) { ps[i], ps[j] = ps[j], ps[i] })
+		if err := ensurePartitionsOrdered(ps); err != nil {
+			t.Fatal(err)
+		}
+		for i := range ps {
+			if ps[i].Partition != int32(i) {
+				t.Fatalf("partition at index %d is %d", i, ps[i].Partition)
+			}
+			// Sorting must move the whole partition, not just the
+			// number.
+			if want := int32(i % 3); ps[i].Leader != want {
+				t.Fatalf("partition %d has leader %d != %d", i, ps[i].Leader, want)
+			}
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		if err := ensurePartitionsOrdered(nil); err != nil {
+			t.Error(err)
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		ps   []int32
+	}{
+		{"missing", []int32{0, 1, 3}},
+		{"duplicate", []int32{0, 1, 1}},
+		{"not_from_zero", []int32{1, 2, 3}},
+		{"negative", []int32{-1, 0, 1}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ps := make([]kmsg.MetadataResponseTopicPartition, len(test.ps))
+			for i, p := range test.ps {
+				ps[i].Partition = p
+			}
+			if err := ensurePartitionsOrdered(ps); err == nil {
+				t.Errorf("got nil error for partitions %v", test.ps)
+			}
+		})
+	}
+}
+
+// BenchmarkMergeTopicIDs measures merging a metadata response's topic IDs into
+// the client's ID to name map. Every metadata refresh merges every topic in the
+// response; "unchanged" is the steady state where the broker returns the same
+// IDs it returned last time.
+func BenchmarkMergeTopicIDs(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		latest := benchLatestTopics(n)
+
+		b.Run(fmt.Sprintf("unchanged/%d", n), func(b *testing.B) {
+			cl := new(Client)
+			cl.mergeTopicIDs(latest)
+			b.ReportAllocs()
+			for b.Loop() {
+				cl.mergeTopicIDs(latest)
+			}
+		})
+
+		// One recreated topic (same name, new ID) is enough to force
+		// the full clone-and-merge on every iteration.
+		recreated := make(map[string]*metadataTopic, n)
+		for topic, mt := range latest {
+			recreated[topic] = mt
+		}
+		for topic := range recreated {
+			recreated[topic] = &metadataTopic{topic: topic, id: benchTopicID(n)}
+			break
+		}
+		b.Run(fmt.Sprintf("changed/%d", n), func(b *testing.B) {
+			cl := new(Client)
+			cl.mergeTopicIDs(latest)
+			b.ReportAllocs()
+			for b.Loop() {
+				cl.mergeTopicIDs(recreated)
+			}
+		})
+	}
+}
+
+// BenchmarkEnsurePartitionsOrdered measures the per-topic partition ordering
+// check that runs on every metadata refresh. "ordered" is what a broker
+// actually returns; "shuffled" forces the sort.
+func BenchmarkEnsurePartitionsOrdered(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("ordered/%d", n), func(b *testing.B) {
+			ps := benchPartitions(n)
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := ensurePartitionsOrdered(ps); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("shuffled/%d", n), func(b *testing.B) {
+			shuffled := benchPartitions(n)
+			rand.Shuffle(n, func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+			ps := make([]kmsg.MetadataResponseTopicPartition, n)
+			b.ReportAllocs()
+			for b.Loop() {
+				b.StopTimer()
+				copy(ps, shuffled)
+				b.StartTimer()
+				if err := ensurePartitionsOrdered(ps); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkNewPartitions measures building the topicPartitionsData for one
+// topic, which a metadata refresh does for every topic the client knows about
+// -- including topics that did not change.
+func BenchmarkNewPartitions(b *testing.B) {
+	cl, err := NewClient(SeedBrokers("127.0.0.1:1")) // metadata never loads; we drive the path directly
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cl.Close()
+
+	for _, n := range []int{100, 1000, 10000} {
+		mt := &metadataTopic{
+			topic:      "benchmark_topic",
+			id:         benchTopicID(0),
+			partitions: make([]metadataPartition, n),
+		}
+		for i := range mt.partitions {
+			mt.partitions[i] = metadataPartition{
+				topic:     mt.topic,
+				topicID:   mt.id,
+				partition: int32(i),
+				leader:    int32(i % 3),
+			}
+		}
+		for _, kind := range []struct {
+			name string
+			kind partitionKind
+		}{
+			{"produce", partitionKindProduce},
+			{"consume", partitionKindConsume},
+		} {
+			b.Run(fmt.Sprintf("%s/%d", kind.name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					mt.newPartitions(cl, kind.kind)
+				}
+			})
+		}
+	}
+}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1581,9 +1581,13 @@ type recBuf struct {
 	// interactions of triggering the sink to loop or not. Ideally, with
 	// the sticky partition hashers, we will only have a few partitions
 	// lingering and that this is on a RecBuf should not matter.
-	lingering   *time.Timer
-	lingerFn    func() // stored once to avoid method value closure alloc per linger cycle
-	isLingering bool   // whether the linger timer is active; lingering may be non-nil but stopped
+	lingering *time.Timer
+	// lingerFn is stored to avoid a method value alloc per linger cycle,
+	// but is set on the first linger rather than at recBuf creation: a
+	// metadata refresh builds a recBuf for every partition it sees, and
+	// few of those ever linger.
+	lingerFn    func()
+	isLingering bool // whether the linger timer is active; lingering may be non-nil but stopped
 
 	// failing is set when we encounter a temporary partition error during
 	// producing, such as UnknownTopicOrPartition (signifying the partition
@@ -1709,6 +1713,9 @@ func (recBuf *recBuf) lockedMaybeLinger() bool {
 	if !recBuf.isLingering {
 		recBuf.isLingering = true
 		if recBuf.lingering == nil {
+			if recBuf.lingerFn == nil {
+				recBuf.lingerFn = recBuf.unlingerAndManuallyDrain
+			}
 			recBuf.lingering = time.AfterFunc(recBuf.cl.cfg.linger, recBuf.lingerFn)
 		} else {
 			recBuf.lingering.Reset(recBuf.cl.cfg.linger)

--- a/pkg/kgo/sink_resweep_test.go
+++ b/pkg/kgo/sink_resweep_test.go
@@ -56,7 +56,6 @@ func TestAuditTxnRecheckRewindUnmarksAddedToTxn(t *testing.T) {
 			lastAckedOffset:     -1,
 			sink:                s,
 		}
-		r.lingerFn = r.unlingerAndManuallyDrain // mirror metadata.go recBuf creation
 		s.addRecBuf(r)
 		r.bufferRecord(promisedRec{
 			ctx:     context.Background(),


### PR DESCRIPTION
Three independent optimizations to the periodic metadata refresh. Each removes
work a refresh did unconditionally but that only matters when the cluster
actually changed. Behavior is unchanged in every case; the slow paths still run
exactly as before.

Based on `master`. This does not touch the per-partition debug logs in
`mergeTopicPartitions` that #1373 guards, so the two should not conflict.

### 1. Rebuild the topic ID map only when a topic ID changed

`updateMetadata` cloned `id2t` and built a throwaway reverse name set on every
refresh. Topic IDs only move when a topic is created, deleted, or recreated, so
the extracted `mergeTopicIDs` first walks the response: if every non-zero ID
already maps to that same name, the merge below provably cannot change anything
(the name is necessarily in `knownNames`, since it is a value in the map we
would clone, and the map already holds the exact entry the merge would write),
so we skip the rebuild and leave the stored map in place. The walk short
circuits on the first difference, so a response that does change something pays
at most one extra map lookup per topic before it finds one.

### 2. Sort partitions only when the response is out of order

`fetchTopicMetadata` sorted every topic's partitions and then verified they are
exactly `0..n-1`. That verification proves sortedness when it passes -- partition
`i` sitting at index `i` is sorted by definition -- so `ensurePartitionsOrdered`
runs the check first and only sorts when it fails, then re-checks. An
out-of-order or incomplete response takes the identical old path (sort, verify,
same error text). A passing check also rules out duplicate partitions, so there
is no input where the old unstable sort and the new skip could produce different
orders.

### 3. Set the recBuf linger callback on first linger

`newPartition` stored `r.lingerFn = r.unlingerAndManuallyDrain` on every recBuf
it built. A method value is an allocation, and a refresh builds a recBuf for
every partition it sees only to discard the ones that already existed, while few
partitions ever linger. It is now set in `lockedMaybeLinger`, next to the
`time.AfterFunc` that consumes it.

`lingerFn` has exactly one reader (that `AfterFunc` call), which is where the
lazy set lives, and both call sites that reach it hold `recBuf.mu`, so the write
is under the same mutex as the read. The only other `&recBuf{}` in the package
(`topics_and_partitions.go`, `modifyP`) is a field-carrying template whose
`sink` is copied into the live recBuf before it is discarded -- it never
lingers, and it did not set `lingerFn` before this change either.

## Benchmarks

New in `pkg/kgo/metadata_test.go`; they need no broker. The baseline is `master`
with the two extracted functions lifted verbatim out of `updateMetadata` /
`fetchTopicMetadata` into a (throwaway, uncommitted) test file, so the same
benchmarks run against the old algorithms. Apple M1, `-count 5` for
allocations, interleaved base/new rounds for time (`-count 6`, `-count 10` for
`NewPartitions`).

Allocation counts are deterministic and are the primary result:

| benchmark | before | after |
| --- | --- | --- |
| `MergeTopicIDs/unchanged/100` | 12.75 KiB, 7 allocs | 0 B, 0 allocs |
| `MergeTopicIDs/unchanged/1000` | 213.5 KiB, 15 allocs | 0 B, 0 allocs |
| `MergeTopicIDs/unchanged/10000` | 1.668 MiB, 99 allocs | 0 B, 0 allocs |
| `MergeTopicIDs/changed/10000` | 1.668 MiB, 99 allocs | 1.668 MiB, 99 allocs |
| `EnsurePartitionsOrdered/ordered/100` | 168 B, 3 allocs | 0 B, 0 allocs |
| `EnsurePartitionsOrdered/ordered/1000` | 168 B, 3 allocs | 0 B, 0 allocs |
| `EnsurePartitionsOrdered/ordered/10000` | 168 B, 3 allocs | 0 B, 0 allocs |
| `EnsurePartitionsOrdered/shuffled/10000` | 168 B, 3 allocs | 168 B, 3 allocs |
| `NewPartitions/produce/100` | 29.98 KiB, 303 allocs | 28.42 KiB, 203 allocs |
| `NewPartitions/produce/1000` | 297.4 KiB, 3003 allocs | 281.7 KiB, 2003 allocs |
| `NewPartitions/produce/10000` | 2.903 MiB, 30003 allocs | 2.750 MiB, 20003 allocs |
| `NewPartitions/consume/10000` (control) | 2.140 MiB, 20003 allocs | 2.140 MiB, 20003 allocs |

`NewPartitions/produce` drops exactly one allocation per partition; the consume
path, which this PR does not touch, is identical on both sides.

Time, medians:

| benchmark | before | after | delta |
| --- | --- | --- | --- |
| `MergeTopicIDs/unchanged/100` | 16.02 us | 3.96 us | -75% (p=0.002) |
| `MergeTopicIDs/unchanged/1000` | 336.4 us | 40.0 us | -88% (p=0.002) |
| `MergeTopicIDs/unchanged/10000` | 3.800 ms | 466.6 us | -88% (p=0.002) |
| `MergeTopicIDs/changed/10000` | 3.750 ms | 3.574 ms | ~ (p=0.937) |
| `EnsurePartitionsOrdered/ordered/100` | 868 ns | 157 ns | -82% (p=0.002) |
| `EnsurePartitionsOrdered/ordered/1000` | 6.25 us | 1.51 us | -76% (p=0.002) |
| `EnsurePartitionsOrdered/ordered/10000` | 67.9 us | 17.9 us | -74% (p=0.002) |
| `EnsurePartitionsOrdered/shuffled/10000` | 2.540 ms | 2.871 ms | ~ (p=0.394) |
| `NewPartitions/produce/100` | 14.50 us | 12.45 us | -14% (p=0.001) |
| `NewPartitions/produce/1000` | 171.5 us | 148.6 us | ~ (p=0.143) |
| `NewPartitions/produce/10000` | 2.233 ms | 1.740 ms | ~ (p=0.218) |
| `NewPartitions/consume/100` (control) | 11.01 us | 11.18 us | ~ (p=0.912) |

Caveat on the timing column: another process was running benchmarks on the same
machine throughout, so the confidence intervals are wide (frequently +/-50%) and
benchstat calls several plausible improvements insignificant. The untouched
`NewPartitions/consume` control drifts by up to ~15% between runs, which is the
noise floor here; read anything smaller as noise, and treat the allocation table
above as the reliable measurement.

## Testing

Ran: `gofmt -l` (clean over `pkg/`; `examples/bench/main.go` is already
unformatted on `master` and is untouched here), `go vet ./...`,
`go build ./...`, `go test -race ./pkg/kgo/internal/...`, and `go test -race` on
the new `TestMergeTopicIDs` / `TestEnsurePartitionsOrdered` plus
`TestAuditTxnRecheckRewindUnmarksAddedToTxn` -- the one existing test in a file
this PR touches, since it mirrored the recBuf construction that change 3
removes.

**Not run: `go test ./pkg/kgo/`.** That suite needs a Kafka broker on :9092,
which was not available in this environment. The full refresh path
(`updateMetadata` / `fetchTopicMetadata` end to end against a live broker) is
therefore unverified here; the new unit tests cover the two extracted functions
directly, including the recreated-topic case and the missing / duplicate /
out-of-order / negative partition cases.
