### PR TITLE
kgo: reduce allocations in the fetch-decode and produce-encode paths

### DIFF
--- a/pkg/kgo/consumer_test.go
+++ b/pkg/kgo/consumer_test.go
@@ -766,6 +766,8 @@ type testPooling struct {
 	putDecompress bool
 	putKRecs      bool
 	putRecs       bool
+
+	keptKRecHeaders bool
 }
 
 func (p *testPooling) GetDecompressBytes([]byte, CompressionCodecType) []byte {
@@ -792,6 +794,22 @@ func (p *testPooling) PutKRecords(put []kmsg.Record) {
 		p.t.Error("PutKRecords != given!")
 	}
 	p.putKRecs = true
+
+	// A put record keeps its Headers slice so that the decoder refills
+	// that capacity on the next get rather than allocating; the elements
+	// are what must be cleared, since they point into the fetch buffer.
+	for i := range put {
+		hs := put[i].Headers
+		if len(hs) == 0 {
+			continue
+		}
+		p.keptKRecHeaders = true
+		for _, h := range hs {
+			if h.Key != "" || h.Value != nil {
+				p.t.Error("PutKRecords header not cleared!")
+			}
+		}
+	}
 }
 
 func (p *testPooling) GetRecords(int) []Record {
@@ -835,7 +853,12 @@ func TestPooling(t *testing.T) {
 	var wg sync.WaitGroup
 	for range nrecs {
 		wg.Add(1)
-		cl.Produce(context.Background(), StringRecord("foobarfoobarfoobarfoobar"), func(_ *Record, err error) {
+		r := StringRecord("foobarfoobarfoobarfoobar")
+		r.Headers = []RecordHeader{
+			{Key: "h1", Value: []byte("v1")},
+			{Key: "h2", Value: []byte("v2")},
+		}
+		cl.Produce(context.Background(), r, func(_ *Record, err error) {
 			defer wg.Done()
 			if err != nil {
 				t.Fatal(err)
@@ -850,6 +873,11 @@ func TestPooling(t *testing.T) {
 		fs := cl.PollFetches(context.Background())
 		consumed += fs.NumRecords()
 		fs.EachRecord(func(r *Record) {
+			// Each record's headers are a window into one per-batch
+			// slab; a short window must not see its neighbor's.
+			if len(r.Headers) != 2 || r.Headers[0].Key != "h1" || r.Headers[1].Key != "h2" {
+				t.Errorf("got headers %v != [h1 h2]", r.Headers)
+			}
 			r.Recycle()
 		})
 	}
@@ -862,6 +890,9 @@ func TestPooling(t *testing.T) {
 	}
 	if !pool.putRecs {
 		t.Error("did not put recs!")
+	}
+	if !pool.keptKRecHeaders {
+		t.Error("krecs were put back without their header slices!")
 	}
 }
 

--- a/pkg/kgo/pools.go
+++ b/pkg/kgo/pools.go
@@ -71,7 +71,9 @@ type PoolDecompressBytes interface {
 type PoolKRecords interface {
 	// GetKRecords returns a slice with capacity n.
 	GetKRecords(n int) []kmsg.Record
-	// PutKRecords puts a slice back into the pool.
+	// PutKRecords puts a slice back into the pool. Every record is
+	// zeroed, save for its Headers slice: the decoder reuses that
+	// slice's capacity on the next get.
 	PutKRecords([]kmsg.Record)
 }
 

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -2451,7 +2451,10 @@ func (p *produceRequest) IsFlexible() bool   { return p.version >= 9 }
 func (p *produceRequest) AppendTo(dst []byte) []byte {
 	flexible := p.IsFlexible()
 
-	p.metrics = make(map[string]map[int32]ProduceBatchMetrics)
+	// The metrics maps are rebuilt on every AppendTo and take one entry
+	// per topic and one per partition we actually write, so size them up
+	// front rather than growing our way there.
+	p.metrics = make(map[string]map[int32]ProduceBatchMetrics, len(p.batches.bs))
 
 	if p.version >= 3 {
 		if flexible {
@@ -2482,7 +2485,7 @@ func (p *produceRequest) AppendTo(dst []byte) []byte {
 			dst = kbin.AppendArrayLen(dst, len(partitions))
 		}
 
-		tmetrics := make(map[int32]ProduceBatchMetrics)
+		tmetrics := make(map[int32]ProduceBatchMetrics, len(partitions))
 		p.metrics[topic] = tmetrics
 
 		for partition, batch := range partitions {

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1799,22 +1799,24 @@ func (a aborter) trackAbortedPID(producerID int64) {
 // processing records to fetch part //
 //////////////////////////////////////
 
-// readRawRecordsInto reads records from in and returns them, returning early
-// if there were partial records.
-func readRawRecordsInto(rs []kmsg.Record, in []byte) []kmsg.Record {
+// readRawRecordsInto reads records from in and returns them and the total
+// number of headers they hold, returning early if there were partial records.
+func readRawRecordsInto(rs []kmsg.Record, in []byte) ([]kmsg.Record, int) {
+	var nheaders int
 	for i := range rs {
 		length, used := kbin.Varint(in)
 		total := used + int(length)
 		if used == 0 || length < 0 || len(in) < total {
-			return rs[:i]
+			return rs[:i], nheaders
 		}
 		if err := (&rs[i]).ReadFrom(in[:total]); err != nil {
 			rs[i] = kmsg.Record{} // clear any invalid partial data
-			return rs[:i]
+			return rs[:i], nheaders
 		}
+		nheaders += len(rs[i].Headers)
 		in = in[total:]
 	}
-	return rs
+	return rs, nheaders
 }
 
 func (o *ProcessFetchPartitionOpts) processRecordBatch(
@@ -1896,6 +1898,12 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 		}
 		numRecords = len(rawRecords)
 	}
+
+	// Presize for the first batch; later batches grow the slice normally.
+	if cap(fp.Records) == 0 {
+		fp.Records = make([]*Record, 0, numRecords)
+	}
+
 	var krecords []kmsg.Record
 	var krecordsPool PoolKRecords
 	pools(o.Pools).each(func(p Pool) bool {
@@ -1913,7 +1921,7 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 		}()
 	}
 	krecords = ensureLen(krecords, numRecords)
-	krecords = readRawRecordsInto(krecords, rawRecords)
+	krecords, nheaders := readRawRecordsInto(krecords, rawRecords)
 
 	// KAFKA-5443: compacted topics preserve the last offset in a batch,
 	// even if the last record is removed, meaning that using offsets from
@@ -1943,6 +1951,8 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 		return false
 	})
 	rrecords = ensureLen(rrecords, numRecords)
+
+	hslab := make([]RecordHeader, nheaders) // headers are dropped together, same as records, with the same slab tradeoffs above
 
 	var p *recordPools
 	var poolsCtx context.Context
@@ -2002,9 +2012,15 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 			batch,
 			&krecords[i],
 			record,
+			&hslab,
 		)
-		record.Context = recordCtx  //nolint:fatcontext // not a nested context
-		krecords[i] = kmsg.Record{} // prevent the kmsg.Record from hanging onto anything
+		record.Context = recordCtx //nolint:fatcontext // not a nested context
+
+		// Prevent the kmsg.Record from hanging onto anything. The
+		// header slice is kept: the decoder reuses its capacity.
+		clear(krecords[i].Headers)
+		krecords[i] = kmsg.Record{Headers: krecords[i].Headers}
+
 		if kept := o.maybeKeepRecord(fp, record, abortBatch); kept {
 			nkept++
 		}
@@ -2305,10 +2321,11 @@ func recordToRecord(
 	batch *kmsg.RecordBatch,
 	krecord *kmsg.Record,
 	r *Record,
+	hslab *[]RecordHeader,
 ) {
 	var h []RecordHeader
-	if len(krecord.Headers) > 0 {
-		h = make([]RecordHeader, len(krecord.Headers))
+	if n := len(krecord.Headers); n > 0 {
+		h, *hslab = (*hslab)[:n:n], (*hslab)[n:]
 		for i, kv := range krecord.Headers {
 			h[i] = RecordHeader{
 				Key:   kv.Key,


### PR DESCRIPTION
Four allocation reductions in the record path, plus the benchmarks that measure them.

## Changes

1. **Benchmarks** (`source_test.go`, `sink_test.go`, new). `BenchmarkProcessFetchPartition[Pooled]` decodes a fetch response partition at 10/100/1000 records with 0 and 2 headers per record, pooled and unpooled; `BenchmarkProduceRequestAppendTo` encodes a produce request across topic/partition counts. Both run without a broker.

2. **Per-batch header slab.** `recordToRecord` allocated a `[]RecordHeader` per record, so a 1000-record batch carrying two headers each cost 1000 allocations that a header-free batch does not pay at all. Records now slice out of a single per-batch slab, sized from a header count that `readRawRecordsInto` accumulates while it is already walking each record.

3. **Presize `fp.Records`.** `maybeKeepRecord` appends kept records one at a time into a nil slice, so a partition response holding N records walked log2(N) growslice doublings, recopying every pointer kept so far at each one. The batch's record count is already validated at the top of `processRecordBatch`.

4. **Presize the produce metrics maps.** `produceRequest.AppendTo` rebuilds `p.metrics` and a per-topic map on every call -- once per produce request and again on every retry -- with no size hint, though the topic and partition counts are in hand.

5. **Keep the header slice when clearing a decoded `kmsg.Record`.** Processing a record zeroed the whole `kmsg.Record` to drop its references into the (possibly pooled) fetch buffer. `kmsg.Record.readFrom` reuses the capacity of whatever `Headers` slice it is handed, so zeroing the struct wholesale is exactly what stopped a `PoolKRecords` user from ever reusing a header backing array. The header *elements* are cleared instead -- that is what releases the buffer references -- and the emptied slice is kept.

## Tradeoff

The header slab inherits the tradeoff `rrecords` already accepts a few lines above it: one record held past the poll pins the whole batch's header slab, not just its own headers. That is the same shape as a kept record pinning the batch's `[]Record` slab today.

The slab slices are clipped (`[:n:n]`) so that a user appending to one record's `Headers` grows a copy instead of overwriting the next record's. `TestProcessFetchPartitionHeaderSlab` pins that; without the clip it fails.

`PutKRecords` now hands back records that are cleared except for an emptied `Headers` slice. That is documented on the interface. Nothing is retained: the elements are cleared, and the decoder zeroes whatever it extends into on the next batch, so a shorter batch cannot surface a longer one's headers (`TestProcessFetchPartitionPooledHeaderReuse` covers shrinking, growing, and dropping to zero headers).

## Measurement conditions

Measured on an M1 laptop **on battery and under concurrent load from sibling agents** (load average reaching ~7). Apple Silicon throttles sustained clocks on battery, so **absolute ns/op figures from this session are indicative only and should not be treated as merge-quality timing data**. Allocation counts and B/op are deterministic and unaffected by power state or machine load; those are exact.

Before/after were produced from two separately compiled test binaries run **interleaved** (base, after, base, after, ...) and compared with benchstat, rather than all of one then all of the other.

## Allocations (exact)

Fetch decode, no pools:

| benchmark | allocs/op | B/op |
|---|---|---|
| records=10/headers=0 | 9 -> 5 (-44%) | 3.219Ki -> 3.055Ki |
| records=10/headers=2 | 49 -> 36 (-27%) | 5.094Ki -> 5.023Ki |
| records=100/headers=0 | 12 -> 5 (-58%) | 28.84Ki -> 27.60Ki |
| records=100/headers=2 | 412 -> 306 (-26%) | 47.59Ki -> 46.54Ki |
| records=1000/headers=0 | 15 -> 5 (-67%) | 281.2Ki -> 272.1Ki |
| records=1000/headers=2 | 4015 -> 3006 (-25%) | 468.7Ki -> 461.5Ki |

Fetch decode, `PoolKRecords` + `PoolRecords`, every record recycled:

| benchmark | allocs/op | B/op |
|---|---|---|
| records=10/headers=0 | 9 -> 5 (-44%) | 480B -> 312B |
| records=10/headers=2 | 49 -> 26 (-47%) | 2.344Ki -> 1.492Ki |
| records=100/headers=0 | 12 -> 5 (-58%) | 2.344Ki -> 1.102Ki |
| records=100/headers=2 | 412 -> 206 (-50%) | 21.09Ki -> 12.23Ki |
| records=1000/headers=0 | 15 -> 5 (-67%) | 17.39Ki -> 8.273Ki |
| records=1000/headers=2 | 4015 -> 2006 (-50%) | 205.0Ki -> 119.6Ki |

Produce request encode:

| benchmark | allocs/op | B/op |
|---|---|---|
| topics=1/partitions=1 | 4 -> 4 | 656B -> 656B |
| topics=1/partitions=64 | 13 -> 6 (-54%) | 10.71Ki -> 5.586Ki |
| topics=8/partitions=16 | 58 -> 34 (-41%) | 20.44Ki -> 11.94Ki |
| topics=32/partitions=64 | 361 -> 132 (-63%) | 343.0Ki -> 178.4Ki |

Of the remaining 2 allocations per record with 2 headers, both are the header keys: `kbin.VarintString` copies each one. That is a `kmsg` decode question, untouched here.

The single-partition produce case is unchanged, as expected: a map of one entry allocates the same either way. The win starts past eight entries, which is where an unsized map begins growing.

## Timings (indicative only, see conditions above)

Interleaved, benchstat, n=6-10. Fetch decode geomean -8%; the pooled 2-header cases, where the allocation delta is largest, moved -20% to -23%; the produce multi-partition cases moved -8% to -9%.

One case moved the other way: pooled `records=100/headers=0` at +2.3% (p=0.002, tight variance). That is the header-free pooled path paying for the per-record `Headers` load and `clear` that change 5 buys, with no headers to save anything on. I left it: a ~2% cost on header-free decoding in exchange for halving the allocations of header-carrying decoding is the right side of that trade, and the number is from a throttled machine anyway.

## Verification

- `gofmt -l`, `go vet ./...`, `go build ./...` clean.
- `go test -race ./pkg/kgo/internal/...` passes.
- Targeted `-race` runs of the fetch-decode and produce-encode tests pass, including the two new ones.
- **`go test ./pkg/kgo/` was not run: it requires a broker on :9092, which was not available in this environment.**
