### PR TITLE
kgo: fix double close of a connection's deadCh on acks=0 produce

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -712,11 +712,11 @@ doConnect:
 		// version possible (as should be allowed). On the third try,
 		// we downgrade to v0 (see requestAPIVersions).
 		if er := (*errApiVersionsReset)(nil); errors.As(err, &er) && tries < 3 {
-			cxn.closeConn()
+			cxn.die()
 			goto doConnect
 		}
 		b.cl.cfg.logger.Log(LogLevelDebug, "connection initialization failed", "addr", b.addr, "broker", logID(b.meta.NodeID), "err", err)
-		cxn.closeConn()
+		cxn.die()
 		return nil, err
 	}
 	b.cl.cfg.logger.Log(LogLevelDebug, "connection initialized successfully", "addr", b.addr, "broker", logID(b.meta.NodeID))
@@ -740,11 +740,16 @@ doConnect:
 	// connection-per-broker ordering guarantee that Kafka requires
 	// for idempotent produce.
 	//
-	// closeConn runs the user's OnBrokerDisconnect hook, so it runs
-	// after the unlock (see stopForever for why).
+	// die runs the user's OnBrokerDisconnect hook, so it runs after the
+	// unlock (see stopForever for why). We die rather than just close the
+	// conn even though the connection was never stored: for an acks=0
+	// produce connection, init above already spawned the discard goroutine,
+	// which owns all reads. Closing the conn wakes its read with an error,
+	// and it dies the connection as it exits -- die's dead swap is what
+	// keeps the two teardowns from both closing deadCh (see #1377).
 	if b.dead.Load() {
 		b.reapMu.Unlock()
-		cxn.closeConn()
+		cxn.die()
 		return nil, errChosenBrokerDead
 	}
 
@@ -876,7 +881,7 @@ type brokerCxn struct {
 	resps ring[promisedResp]
 	// dead is an atomic so that a backed up resps cannot block cxn death.
 	dead atomic.Bool
-	// closed in closeConn; allows throttle waiting to quit
+	// closed in die; allows throttle waiting to quit
 	deadCh chan struct{}
 	// hasDiscard is set during init (before the connection is shared) if
 	// this is an acks=0 produce connection running the discard goroutine.
@@ -1598,12 +1603,17 @@ func (cxn *brokerCxn) readResponse(
 	return buf[4:], nil
 }
 
-// closeConn is the one place we close broker connections. It is reached via
-// die (callable from anywhere once the connection is live: read/write errors,
-// reaping, broker stoppage) or directly when the connection was never shared:
-// init failure, the ApiVersions-reset retry, and loadConnection's dead-broker
-// arm.
-func (cxn *brokerCxn) closeConn() {
+// die is the one place we close broker connections, and it replies to all
+// requests awaiting responses appropriately, including requests parked for a
+// pending reauthentication. It is callable from anywhere and at any point in a
+// connection's life: read/write errors, reaping, broker stoppage, init failure,
+// and loadConnection's ApiVersions-reset retry and dead-broker arm. The dead
+// swap is what makes every one of those safe -- deadCh can only be closed once,
+// no matter how many goroutines race to tear the connection down.
+func (cxn *brokerCxn) die() {
+	if cxn == nil || cxn.dead.Swap(true) {
+		return
+	}
 	cxn.cl.cfg.hooks.each(func(h Hook) {
 		if h, ok := h.(HookBrokerDisconnect); ok {
 			h.OnBrokerDisconnect(cxn.b.meta, cxn.conn)
@@ -1611,16 +1621,6 @@ func (cxn *brokerCxn) closeConn() {
 	})
 	cxn.conn.Close()
 	close(cxn.deadCh)
-}
-
-// die kills a broker connection (which could be dead already) and replies to
-// all requests awaiting responses appropriately, including requests parked
-// for a pending reauthentication.
-func (cxn *brokerCxn) die() {
-	if cxn == nil || cxn.dead.Swap(true) {
-		return
-	}
-	cxn.closeConn()
 	cxn.resps.die()
 	cxn.failParked()
 }

--- a/pkg/kgo/broker_test.go
+++ b/pkg/kgo/broker_test.go
@@ -366,3 +366,127 @@ func (h brokerConnDisconnHook) OnBrokerConnect(_ BrokerMetadata, _ time.Duration
 func (h brokerConnDisconnHook) OnBrokerDisconnect(BrokerMetadata, net.Conn) {
 	h.disconnects.Add(1)
 }
+
+// discardExitHook signals every time the acks=0 discard goroutine reaches its
+// exit path. discard reports its read with key 0 (it does not know what version
+// it produced) immediately before returning, and no produce request is ever
+// written in the test below, so a key 0 read error is only ever discard giving
+// up. The send never blocks: a hook must not stall a client goroutine.
+type discardExitHook chan struct{}
+
+func (h discardExitHook) OnBrokerRead(_ BrokerMetadata, key int16, _ int, _, _ time.Duration, err error) {
+	if key == 0 && err != nil {
+		select {
+		case h <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// serveApiVersions replies to one ApiVersions request, running retire
+// immediately before the reply, and then reads and drops anything else the
+// client sends (an acks=0 broker never replies to produce). Because the
+// client's ApiVersions read cannot return until we write, everything retire
+// does is guaranteed to be in place for the rest of the client's connection
+// setup.
+func serveApiVersions(conn net.Conn, retire func()) {
+	defer conn.Close()
+	version, corr, err := readReq(conn)
+	if err != nil {
+		return
+	}
+	retire()
+
+	resp := kmsg.NewPtrApiVersionsResponse()
+	resp.Version = version
+	for _, keyMax := range [][2]int16{{0, 11}, {18, 4}} { // produce, api versions
+		k := kmsg.NewApiVersionsResponseApiKey()
+		k.ApiKey = keyMax[0]
+		k.MaxVersion = keyMax[1]
+		resp.ApiKeys = append(resp.ApiKeys, k)
+	}
+	if err := writeResp(conn, corr, resp); err != nil {
+		return
+	}
+	io.Copy(io.Discard, conn)
+}
+
+// An acks=0 produce connection has a discard goroutine, spawned by init before
+// loadConnection decides whether the connection is worth keeping. If the broker
+// was retired while we were connecting, loadConnection throws the connection
+// away -- and it used to do that with a raw close that left cxn.dead false. The
+// discard goroutine's read then woke with the conn-closed error and died the
+// connection as it exited, and because dead was still false, nothing stopped it
+// from closing deadCh a second time: "panic: close of closed channel", in a
+// library goroutine, taking the process down.
+//
+// Both teardowns now run through die, whose dead swap picks exactly one closer.
+// The interleaving here is deterministic rather than sampled: the fake broker
+// retires the broker object before it answers ApiVersions, so init always
+// finishes -- spawning discard -- into an already-dead broker.
+func TestIssue1377(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var connects, disconnects atomic.Int32
+	discardExited := make(discardExitHook, 8)
+
+	cl, err := NewClient(
+		SeedBrokers(ln.Addr().String()),
+		RequiredAcks(NoAck()),
+		DisableIdempotentWrite(),
+		DisableClientMetrics(), // the produce connection must be the only traffic
+		WithHooks(brokerConnDisconnHook{&connects, &disconnects}, discardExited),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cl.Close()
+
+	// Accepting starts only now: retiring the broker needs the broker.
+	b := cl.loadSeeds()[0]
+	var conns atomic.Int32
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conns.Add(1)
+			go serveApiVersions(conn, b.stopForever)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Produce (key 0) is what makes this the produce connection, and acks=0
+	// is what makes init spawn discard on it.
+	if _, err := b.waitResp(ctx, kmsg.NewPtrProduceRequest()); !errors.Is(err, errChosenBrokerDead) {
+		t.Fatalf("produce on a retired broker: error = %v, want %v", err, errChosenBrokerDead)
+	}
+
+	// handleReq retries a retryable connection error once, so both attempts
+	// connect, spawn discard, and then hit the dead-broker arm. Every discard
+	// goroutine must reach its exit path -- that is where the second deadCh
+	// close panicked.
+	want := int(conns.Load())
+	if want == 0 {
+		t.Fatal("no connection was established")
+	}
+	for i := range want {
+		select {
+		case <-discardExited:
+		case <-ctx.Done():
+			t.Fatalf("%d of %d discard goroutines exited", i, want)
+		}
+	}
+	if c, d := int(connects.Load()), int(disconnects.Load()); c != want || d != want {
+		t.Errorf("got %d connects and %d disconnects, want %d of each (one per connection)", c, d, want)
+	}
+}


### PR DESCRIPTION
`closeConn` closed `deadCh` unguarded, and `loadConnection` called it directly on
connections it treated as private to the connecting goroutine. That premise is
false for exactly one config: with `acks=0`, `init` spawns `go cxn.discard()` --
a goroutine that owns all reads on the connection -- and *then* returns to
`loadConnection`, which re-checks whether `stopForever` retired the broker while
we were connecting. On that arm the connection was thrown away with a raw
`closeConn`, leaving `cxn.dead == false`. The discard goroutine's blocked read
woke with the conn-closed error, exited, and its deferred `die()` won the `dead`
swap it should have lost -- closing `deadCh` a second time. Unrecovered panic in
a library goroutine, process down.

The reverse ordering panics too (client close wakes discard first, then
`loadConnection` reaches the dead arm), so this is not only the sequence in the
report.

`closeConn` is now folded into `die`, and all three former direct callers go
through it. `deadCh` is closed behind the `dead` swap by construction -- there is
no unguarded close path left to call -- and "connection closed => `cxn.dead` is
true" now holds everywhere. The two init-failure sites are behaviorally
unchanged: `resps`/`parked` are empty during init (`requestAPIVersions` and
`sasl` read synchronously, not through the ring), so the added
`resps.die()`/`failParked()` are no-ops there. `OnBrokerDisconnect` and
`conn.Close()` still fire exactly once per connection.

`TestIssue1377` drives the interleaving deterministically rather than sampling
for it: a fake listener calls `stopForever` on the broker *before* it answers
ApiVersions, so `init` always completes -- spawning discard -- into an
already-dead broker. Verified both directions: passes under `-race`, and with the
dead-broker arm temporarily reverted to a raw close it panics with the reported
stack trace (`discard` -> `die` -> close of closed channel, goroutine created by
`init`).

Closes #1377