### PR TITLE
kgo: surface error codes in ApiVersions responses

### DIFF
--- a/pkg/kgo/broker.go
+++ b/pkg/kgo/broker.go
@@ -1039,7 +1039,9 @@ start:
 	//
 	// Pre Kafka 2.4, we have to retry the request with version 0.
 	// Post, Kafka replies with the version we should retry with (KIP-511).
+	var sawUnsupportedVersion bool
 	if rawResp[1] == 35 {
+		sawUnsupportedVersion = true
 		if maxVersion == 0 {
 			return errors.New("broker replied with UNSUPPORTED_VERSION to an ApiVersions request of version 0")
 		}
@@ -1068,7 +1070,7 @@ start:
 			}
 			return fmt.Errorf("broker replied with UNSUPPORTED_VERSION to our v%d ApiVersions request but advertised non-downgrade version %d", maxVersion, resp.ApiKeys[0].MaxVersion)
 		default:
-			// Should not hit this case, but we hope the broker replied with all keys
+			// The broker replied with all keys; nothing to downgrade to, we use them.
 		}
 		resp = req.ResponseKind().(*kmsg.ApiVersionsResponse)
 		resp.Version = 0
@@ -1076,6 +1078,12 @@ start:
 
 	if err = resp.ReadFrom(rawResp); err != nil {
 		return fmt.Errorf("unable to read ApiVersions response: %w", err)
+	}
+	// Checked before ApiKeys below: an error can come with an empty key table.
+	if !sawUnsupportedVersion {
+		if err := kerr.ErrorForCode(resp.ErrorCode); err != nil {
+			return err
+		}
 	}
 	if len(resp.ApiKeys) == 0 {
 		return errors.New("ApiVersions response invalidly contained no ApiKeys")


### PR DESCRIPTION
`requestAPIVersions` never read `ApiVersionsResponse.ErrorCode`. It validated the response by *shape* -- `len(resp.ApiKeys) == 0` -- rather than by *status*, so a broker that rejected the connection at ApiVersions was recorded as a clean success as long as it replied with a non-empty key table. We stored its versions and continued into SASL.

Anything that rejects ApiVersions hangs up right after replying, so the next request wrote into a dead socket and the user saw only a bare `io.EOF`:

- the reason for the rejection was lost at every log level;
- a **non**-retryable rejection presented as a retry loop ending in a timeout, since `io.EOF` is retryable and `kerr` errors are not;
- with no SASL configured, the EOF was attributed to the `is SASL missing?` hint -- pointing at the wrong problem entirely.

### Why now

Masked until v1.21.0. We previously issued ApiVersions only when we had no cached versions for a broker, so on a reconnect `SASLHandshake` was the first request on the wire and *its* error code was checked. Now that we issue ApiVersions on every connection (KIP-714 client-metrics software-name advertising, #1296) it is always first, and always swallowed the error. Same broker error, two outcomes:

| First request on the connection | Client saw |
| --- | --- |
| SASLHandshake (<= v1.20 reconnect) | the actual error |
| ApiVersions (v1.21+, always) | `EOF` |

### The guard is required

The check is skipped when we came through the `UNSUPPORTED_VERSION` branch. A broker may reply `35` alongside its **complete** key table rather than the lone key 18 that KIP-511 specifies, and that response is perfectly usable -- there is nothing to downgrade to and nothing to retry. Checking the error code unconditionally would turn every such connection into a hard failure, which is a worse bug than the one being fixed. That branch's `Should not hit this case` comment was wrong and is corrected.

### Second case fixed

Ordering the check before the `ApiKeys` check matters: a broker sends an *empty* key table alongside an error (Kafka does this for `INVALID_REQUEST`), which previously reported the misleading `ApiVersions response invalidly contained no ApiKeys`. An empty table is only invalid when no error explains it.

### Testing

`TestApiVersionsErrorCode` covers all three shapes. Verified failing before / passing after:

```
--- FAIL: TestApiVersionsErrorCode/error_alongside_a_key_table_surfaces
    Ping: got error broker closed the connection immediately after a request
    was issued, which often happens when SASL is required but not provided:
    is SASL missing?, want INVALID_REQUEST: ...
--- FAIL: TestApiVersionsErrorCode/error_with_no_key_table_surfaces_the_error,_not_the_empty_table
    Ping: got error ApiVersions response invalidly contained no ApiKeys,
    want INVALID_REQUEST: ...
```

The third case -- `unsupported version alongside a complete key table stays usable` -- passes both before and after; it exists to keep a future simplification from removing the guard.

`readReq` in the test file now also returns the request key, so a fake broker can dispatch on it.

Full `pkg/kgo` suite run with `-race`: the only failure is `TestPauseIssueOct2023`, which fails identically on unmodified master here (it needs a broker on :9092).

🤖 Generated with [Claude Code](https://claude.com/claude-code)