### PR TITLE
kgo: drop client-side software name/version validation

### DIFF
--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -284,20 +284,6 @@ func (cfg *cfg) validate() error {
 		}
 	}
 
-	// The broker validates the ApiVersions software name and version
-	// against [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])? and rejects the
-	// whole request with INVALID_REQUEST otherwise. ApiVersions is the
-	// first request on every connection, so an invalid value bricks the
-	// client with an opaque error; fail loudly here instead.
-	for _, sw := range []struct{ name, v string }{
-		{"software name", cfg.softwareName},
-		{"software version", cfg.softwareVersion},
-	} {
-		if !validSoftwareNameVersion(sw.v) {
-			return fmt.Errorf("invalid %s %q: brokers require a non-empty alphanumeric string that may contain '-' or '.' internally", sw.name, sw.v)
-		}
-	}
-
 	// Brokers reject an empty transactional id with INVALID_REQUEST at
 	// InitProducerID; catch it here where the error can say why.
 	if cfg.txnID != nil && *cfg.txnID == "" {
@@ -2302,21 +2288,3 @@ func AutoCommitCallback(fn func(*Client, *kmsg.OffsetCommitRequest, *kmsg.Offset
 //  	return groupOpt{func(cfg *cfg) { cfg.disableNextGenBalancer = true }}
 //  }
 //
-
-// validSoftwareNameVersion mirrors the broker's ApiVersions validation
-// pattern, [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])?: non-empty
-// alphanumeric ends with dashes and dots allowed internally.
-func validSoftwareNameVersion(s string) bool {
-	alnum := func(c byte) bool {
-		return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
-	}
-	if len(s) == 0 || !alnum(s[0]) || !alnum(s[len(s)-1]) {
-		return false
-	}
-	for i := 1; i < len(s)-1; i++ {
-		if c := s[i]; !alnum(c) && c != '-' && c != '.' {
-			return false
-		}
-	}
-	return true
-}

--- a/pkg/kgo/errors_classify_test.go
+++ b/pkg/kgo/errors_classify_test.go
@@ -28,28 +28,3 @@ func TestUnexpectedEOFRetriable(t *testing.T) {
 		t.Error("first-read io.EOF should stay non-retryable")
 	}
 }
-
-// The broker validates ApiVersions software name/version against
-// [a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])? and answers INVALID_REQUEST
-// otherwise; since ApiVersions is the first request on every connection, an
-// invalid value bricked the client with an opaque error. NewClient now
-// validates.
-func TestSoftwareNameVersionValidation(t *testing.T) {
-	t.Parallel()
-	for _, bad := range []string{"", "my app", "app_1", "-app", "app-", ".app", "app/1"} {
-		if _, err := NewClient(SeedBrokers("localhost:1"), SoftwareNameAndVersion(bad, "1.0.0")); err == nil {
-			t.Errorf("software name %q: expected NewClient error", bad)
-		}
-	}
-	for _, good := range []string{"kgo", "my-app", "app.1", "a", "A9"} {
-		cl, err := NewClient(SeedBrokers("localhost:1"), SoftwareNameAndVersion(good, "1.0.0"))
-		if err != nil {
-			t.Errorf("software name %q: unexpected error %v", good, err)
-			continue
-		}
-		cl.Close()
-	}
-	if _, err := NewClient(SeedBrokers("localhost:1"), TransactionalID("")); err == nil {
-		t.Error("empty transactional id: expected NewClient error")
-	}
-}


### PR DESCRIPTION
Reverts the `SoftwareNameAndVersion` validation added in 154335fe.

That commit validated the software name and version at `NewClient` against Kafka's ApiVersions pattern, `[a-zA-Z0-9](?:[a-zA-Z0-9\-.]*[a-zA-Z0-9])?`. Its stated premise was that an invalid value bricks the client with an opaque error on every connect, since ApiVersions is the first request on the wire.

582e0f21 has since removed that premise. The ApiVersions response error code is now checked, so a broker that rejects the value answers `INVALID_REQUEST` non-retryably instead of hanging up into a bare `io.EOF` retry loop.

What is left is a client-side reimplementation of a server-side rule that not every broker enforces. A proxy or a Kafka reimplementation that accepts an underscore works fine today; validating at `NewClient` turns that into a client that cannot be constructed at all, in exchange for saving a diagnosis step against the brokers that do enforce it. Breaking a working setup is the worse trade.

Kept from 154335fe:
- The empty `TransactionalID` rejection. No broker accepts one (there is nothing to fence on), so there is no working setup to break.
- kfake's ApiVersions validation (c06d6408) is untouched; it models a real broker, and it is what makes 582e0f21's error surfacing testable.

No changelog entry: 154335fe was never described in the v1.21.6 notes, so the release is net-neutral on this.