### PR TITLE
deps: bump pkg/kadm dependencies

### DIFF
--- a/pkg/kadm/go.mod
+++ b/pkg/kadm/go.mod
@@ -3,12 +3,11 @@ module github.com/twmb/franz-go/pkg/kadm
 go 1.25.0
 
 require (
-	github.com/twmb/franz-go v1.21.1
+	github.com/twmb/franz-go v1.21.6
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1
-	golang.org/x/crypto v0.51.0
 )
 
 require (
-	github.com/klauspost/compress v1.18.6 // indirect
-	github.com/pierrec/lz4/v4 v4.1.26 // indirect
+	github.com/klauspost/compress v1.19.2 // indirect
+	github.com/pierrec/lz4/v4 v4.1.28 // indirect
 )

--- a/pkg/kadm/go.sum
+++ b/pkg/kadm/go.sum
@@ -1,10 +1,8 @@
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
-github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
-github.com/twmb/franz-go v1.21.1 h1:sp17bMRLz6OB/w+7vHtBadHGIQVymzQHwvRbEKe5c4I=
-github.com/twmb/franz-go v1.21.1/go.mod h1:1o+jj5oRbItsIMoE+DGpfJIcPcPtDdtkcNFPj4bWNwU=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/pierrec/lz4/v4 v4.1.28 h1:pPEPwRJ4kybBTfGt28q7lQsRJQHhC08axprdLD5Ppio=
+github.com/pierrec/lz4/v4 v4.1.28/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/twmb/franz-go v1.21.6 h1:+v0dQJVIIuw9uPmPWmPrkoUHs1pPeV8MSwA4eU/Y2kY=
+github.com/twmb/franz-go v1.21.6/go.mod h1:wMepkgCatAdV9vCsuwM+wr+C1fl7KV/41+uHGAjt/wc=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1 h1:fG5kItwysTk5UXqVwb64EpQEy3TydF3vYYK21nUQ+bI=
 github.com/twmb/franz-go/pkg/kmsg v1.13.1/go.mod h1:+DPt4NC8RmI6hqb8G09+3giKObE6uD2Eya6CfqBpeJY=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=


### PR DESCRIPTION
Prep for the kadm patch release.

`go get -u ./...` plus `go mod tidy` in `pkg/kadm`:

- `github.com/twmb/franz-go` v1.21.1 => v1.21.6
- `github.com/klauspost/compress` v1.18.6 => v1.19.2 (indirect)
- `github.com/pierrec/lz4/v4` v4.1.26 => v4.1.28 (indirect)
- `golang.org/x/crypto` **removed** -- kadm no longer references it at all. Its only use was pbkdf2, which moved to the standard library `crypto/pbkdf2` in 18f9a10f, so tidy drops it from the module rather than demoting it to indirect.

`go build`, `go vet`, `gofmt`, and `go test -race ./...` all pass.