### PR TITLE
kadm: default filter patterns to LITERAL, error on unset operations

### DIFF
--- a/pkg/kadm/acls.go
+++ b/pkg/kadm/acls.go
@@ -2,6 +2,7 @@ package kadm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -1017,22 +1018,28 @@ func createDelDescACL(b *ACLBuilder) ([]kmsg.DeleteACLsRequestFilter, []*kmsg.De
 		return nil, nil, err
 	}
 
-	// The builder's unset-means-any philosophy applies to the pattern and
-	// the operations as well. An unset pattern was previously sent as
-	// UNKNOWN (the zero value), which conformant brokers reject when
-	// parsing the request -- every describe or delete from a builder that
-	// never called ResourcePatternType failed against a real broker
-	// (kfake historically did not validate the pattern, hiding this).
-	// Unset operations previously generated ZERO filters, silently doing
-	// nothing and returning no error.
+	// Per the ResourcePatternType docs, an unset pattern defaults to
+	// LITERAL. That default was never implemented: the zero value went out
+	// as UNKNOWN, which conformant brokers reject when parsing the request,
+	// so every describe or delete from a builder that never called
+	// ResourcePatternType failed against a real broker (kfake historically
+	// did not validate the pattern, hiding this). LITERAL is also the
+	// narrowest match, so a delete cannot silently cover prefixed or
+	// wildcard ACLs the caller did not ask for.
 	pattern := b.pattern
 	if pattern == ACLPatternUnknown {
-		pattern = ACLPatternAny
+		pattern = ACLPatternLiteral
+	}
+
+	// Unset operations generated ZERO filters, silently doing nothing and
+	// returning no error. We error rather than defaulting to OpAny:
+	// MaybeOperations documents that providing none must NOT match all
+	// operations, and a delete must never widen on its own. Operations()
+	// with no arguments remains the documented way to ask for any.
+	if len(b.ops) == 0 {
+		return nil, nil, errors.New("no operations set: call Operations with no arguments to filter on any operation")
 	}
 	ops := b.ops
-	if len(ops) == 0 {
-		ops = []ACLOperation{OpAny}
-	}
 
 	// As a special shortcut, if we have any allow and deny principals and
 	// hosts, we collapse these into one "any" group. The anyAny and

--- a/pkg/kadm/audit_test.go
+++ b/pkg/kadm/audit_test.go
@@ -16,7 +16,11 @@ import (
 // parse -- and generated ZERO filters for unset operations, silently doing
 // nothing.
 func TestACLBuilderFilterDefaults(t *testing.T) {
-	b := NewACLs().Topics("a").Allow().AllowHosts().Deny().DenyHosts()
+	if _, _, err := createDelDescACL(NewACLs().Topics("a").Allow().AllowHosts().Deny().DenyHosts()); err == nil {
+		t.Error("expected an error filtering with no operations")
+	}
+
+	b := NewACLs().Topics("a").Operations().Allow().AllowHosts().Deny().DenyHosts()
 	dels, descs, err := createDelDescACL(b)
 	if err != nil {
 		t.Fatal(err)
@@ -24,11 +28,11 @@ func TestACLBuilderFilterDefaults(t *testing.T) {
 	if len(dels) != 1 || len(descs) != 1 {
 		t.Fatalf("got %d deletions, %d describes, want 1 and 1", len(dels), len(descs))
 	}
-	if got := dels[0].ResourcePatternType; got != kmsg.ACLResourcePatternTypeAny {
-		t.Errorf("deletion pattern %v, want ANY", got)
+	if got := dels[0].ResourcePatternType; got != kmsg.ACLResourcePatternTypeLiteral {
+		t.Errorf("deletion pattern %v, want LITERAL", got)
 	}
-	if got := descs[0].ResourcePatternType; got != kmsg.ACLResourcePatternTypeAny {
-		t.Errorf("describe pattern %v, want ANY", got)
+	if got := descs[0].ResourcePatternType; got != kmsg.ACLResourcePatternTypeLiteral {
+		t.Errorf("describe pattern %v, want LITERAL", got)
 	}
 	if got := dels[0].Operation; got != kmsg.ACLOperationAny {
 		t.Errorf("deletion operation %v, want ANY", got)
@@ -42,7 +46,7 @@ func TestACLBuilderFilterDefaults(t *testing.T) {
 // a sticky any-flag that a later call with names did not clear, silently
 // broadening delete filters to ALL names of that resource type.
 func TestACLBuilderLastCallWins(t *testing.T) {
-	b := NewACLs().Topics().Topics("a").Allow().Allow("User:x").AllowHosts().Deny().DenyHosts()
+	b := NewACLs().Topics().Topics("a").Operations().Allow().Allow("User:x").AllowHosts().Deny().DenyHosts()
 	dels, _, err := createDelDescACL(b)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -4180,8 +4180,9 @@ func TestOnDataLossCallbackReentrancy(t *testing.T) {
 // filters -- rejected by real brokers at request parse (kfake now models
 // that) -- and creating without a pattern failed validation despite the
 // docs calling literal the default. Builders that never call Operations
-// generated zero filters, silently doing nothing. Now: create defaults to
-// literal, filters default to any-pattern and any-operation.
+// generated zero filters, silently doing nothing. Now: create and filters
+// both default to literal per the docs, and unset operations error rather
+// than silently matching nothing or widening to any.
 func TestKadmACLDefaultPatternRoundTrip(t *testing.T) {
 	t.Parallel()
 	const testTopic = "kadm-acl-defaults"
@@ -4217,8 +4218,14 @@ func TestKadmACLDefaultPatternRoundTrip(t *testing.T) {
 		}
 	}
 
-	// Describe with pattern AND operations unset: matches any.
-	db := kadm.NewACLs().Topics(testTopic).Allow().AllowHosts().Deny().DenyHosts()
+	// Operations unset is an error rather than a silent no-op or a widen.
+	nb := kadm.NewACLs().Topics(testTopic).Allow().AllowHosts().Deny().DenyHosts()
+	if _, err := adm.DescribeACLs(ctx, nb); err == nil {
+		t.Fatal("describe with no operations: expected an error")
+	}
+
+	// Describe with pattern unset: defaults to literal, matching the create.
+	db := kadm.NewACLs().Topics(testTopic).Operations().Allow().AllowHosts().Deny().DenyHosts()
 	described, err := adm.DescribeACLs(ctx, db)
 	if err != nil {
 		t.Fatalf("describe: %v", err)
@@ -4238,7 +4245,7 @@ func TestKadmACLDefaultPatternRoundTrip(t *testing.T) {
 		t.Fatalf("created ACL not described: %v", described)
 	}
 
-	// Delete with the same fully-default filter.
+	// Delete with the same default-pattern filter.
 	deleted, err := adm.DeleteACLs(ctx, db)
 	if err != nil {
 		t.Fatalf("delete: %v", err)


### PR DESCRIPTION
Adjusts two ACL builder defaults from the recent audit so they match docs that predate it.

### Pattern: ANY -> LITERAL

`ResourcePatternType`'s doc has said *"sets the pattern type to use when creating **or filtering** ACL resource names, overriding the default of LITERAL"* since d9054e0c (Oct 2021). The default was never implemented for filters -- the zero value went out as `UNKNOWN`, which conformant brokers reject while parsing, so every default-pattern describe or delete failed against real Kafka. kfake did not validate the pattern, so the tests were blind to it.

The audit fixed the `UNKNOWN` by defaulting to `ANY`. That contradicts the documented default and is the wrong direction for a delete: it silently covers prefixed and wildcard ACLs the caller never asked for. LITERAL is both documented and the narrowest match, so a filter can only ever under-match. Breadth is available explicitly via `ACLPatternAny`.

### Unset operations: OpAny -> error

`MaybeOperations` documents that providing no operations **must not** match all operations. The audit's `len(ops) == 0 -> OpAny` default breaks that contract outright, since `MaybeOperations()` with none provided leaves `ops` empty. A delete must never widen on its own, so this errors instead, naming the fix.

`Operations()` called with no arguments is unchanged -- it sets `OpAny` explicitly, is documented ("Passing no operations defaults to OpAny"), and predates the audit.

### Behavior vs. the currently released pkg/kadm/v1.18.0

| Builder usage | v1.18.0 | This PR |
|---|---|---|
| `ResourcePatternType` never called (filter) | sends UNKNOWN, broker rejects at parse | LITERAL |
| `ResourcePatternType` never called (create) | `ValidateCreate` errors | LITERAL |
| `Operations` never called | zero filters, silent no-op, nil error | error |
| `MaybeOperations()`, none provided | zero filters, silent no-op | error |
| `Operations()` with no args | OpAny | OpAny |

Nothing that worked in v1.18.0 changes meaning; every affected path either failed at the broker, failed in validation, or silently did nothing.

Existing `TestACLBuilderFilterDefaults` and `TestACLBuilderLastCallWins` were updated for the new contract -- they built filters without calling `Operations`, which now errors. `go build`, `go vet`, `gofmt`, `go test -race ./...` pass.