### PR TITLE
Randomize initial seed broker selection

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -597,6 +597,7 @@ func NewClient(opts ...Opt) (*Client, error) {
 		b := cl.newBroker(unknownSeedID(i), seed.host, seed.port, nil)
 		seedBrokers = append(seedBrokers, b)
 	}
+	cl.anySeedIdx = cl.randomSeedIdx(len(seedBrokers))
 	cl.seeds.Store(seedBrokers)
 	go cl.updateMetadataLoop()
 	go cl.reapConnectionsLoop()
@@ -623,6 +624,17 @@ func (cl *Client) Context() context.Context {
 
 func (cl *Client) loadSeeds() []*broker {
 	return cl.seeds.Load().([]*broker)
+}
+
+func (cl *Client) randomSeedIdx(n int) int32 {
+	if n <= 1 {
+		return 0
+	}
+	var idx int32
+	cl.rng(func(r *rand.Rand) {
+		idx = int32(r.Intn(n))
+	})
+	return idx
 }
 
 // Ping returns whether any broker is reachable and that the client can
@@ -2602,6 +2614,7 @@ func (cl *Client) UpdateSeedBrokers(addrs ...string) error {
 	// the lock for what this usually guards.
 	cl.brokersMu.Lock()
 	old := cl.loadSeeds()
+	cl.anySeedIdx = cl.randomSeedIdx(len(seedBrokers))
 	cl.seeds.Store(seedBrokers)
 	cl.brokersMu.Unlock()
 

--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -2610,8 +2610,7 @@ func (cl *Client) UpdateSeedBrokers(addrs ...string) error {
 		seedBrokers = append(seedBrokers, b)
 	}
 
-	// We lock to guard against concurrently updating seeds; we do not need
-	// the lock for what this usually guards.
+	// We lock to guard against concurrently updating seeds.
 	cl.brokersMu.Lock()
 	old := cl.loadSeeds()
 	cl.anySeedIdx = cl.randomSeedIdx(len(seedBrokers))

--- a/pkg/kgo/client_sweep_test.go
+++ b/pkg/kgo/client_sweep_test.go
@@ -1,6 +1,7 @@
 package kgo
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -35,6 +36,63 @@ func TestStoreCachedMetaTopicIDChange(t *testing.T) {
 	}
 	if ct := cl.metaCache.topics["foo"]; ct.id != ([16]byte{2}) {
 		t.Errorf("cached topic id = %v, want the new ID", ct.id)
+	}
+}
+
+// New clients with many seeds used to always try seed_0 first because
+// anySeedIdx's zero value directly selected loadSeeds()[0]. A fleet restarting
+// at once could therefore stampede the first bootstrap broker. The starting
+// cursor is now randomized per client, distributing first bootstrap attempts
+// across the configured brokers while preserving their configured order.
+func TestSeedBrokersStartDistributedAcrossClients(t *testing.T) {
+	t.Parallel()
+
+	seeds := []hostport{
+		{host: "seed-0", port: 9092},
+		{host: "seed-1", port: 9092},
+		{host: "seed-2", port: 9092},
+		{host: "seed-3", port: 9092},
+	}
+
+	rng := rand.New(rand.NewSource(1))
+	const clients = 1000
+	counts := make([]int, len(seeds))
+	for range clients {
+		cl := &Client{
+			rng: func(fn func(*rand.Rand)) { fn(rng) },
+		}
+
+		seedBrokers := make([]*broker, 0, len(seeds))
+		for i, hp := range seeds {
+			seedBrokers = append(seedBrokers, cl.newBroker(unknownSeedID(i), hp.host, hp.port, nil))
+		}
+		cl.anySeedIdx = cl.randomSeedIdx(len(seedBrokers))
+		cl.seeds.Store(seedBrokers)
+
+		got := cl.broker().meta.NodeID
+		found := false
+		for i := range seeds {
+			if got == unknownSeedID(i) {
+				counts[i]++
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("first selected seed broker = %s, want one of the configured seeds", NodeName(got))
+		}
+	}
+
+	want := clients / len(seeds)
+	// With 1000 clients and 4 seeds, each seed should be picked about 250
+	// times. 75 allows range of accepted values while still catching the old
+	// behavior, where seed_0 would be picked 1000 times.
+	const maxSkew = 75
+	for i, got := range counts {
+		if got < want-maxSkew || got > want+maxSkew {
+			t.Fatalf("seed %s was selected first %d times out of %d clients, want roughly %d; counts=%v",
+				NodeName(unknownSeedID(i)), got, clients, want, counts)
+		}
 	}
 }
 

--- a/pkg/kgo/client_sweep_test.go
+++ b/pkg/kgo/client_sweep_test.go
@@ -1,7 +1,6 @@
 package kgo
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -36,63 +35,6 @@ func TestStoreCachedMetaTopicIDChange(t *testing.T) {
 	}
 	if ct := cl.metaCache.topics["foo"]; ct.id != ([16]byte{2}) {
 		t.Errorf("cached topic id = %v, want the new ID", ct.id)
-	}
-}
-
-// New clients with many seeds used to always try seed_0 first because
-// anySeedIdx's zero value directly selected loadSeeds()[0]. A fleet restarting
-// at once could therefore stampede the first bootstrap broker. The starting
-// cursor is now randomized per client, distributing first bootstrap attempts
-// across the configured brokers while preserving their configured order.
-func TestSeedBrokersStartDistributedAcrossClients(t *testing.T) {
-	t.Parallel()
-
-	seeds := []hostport{
-		{host: "seed-0", port: 9092},
-		{host: "seed-1", port: 9092},
-		{host: "seed-2", port: 9092},
-		{host: "seed-3", port: 9092},
-	}
-
-	rng := rand.New(rand.NewSource(1))
-	const clients = 1000
-	counts := make([]int, len(seeds))
-	for range clients {
-		cl := &Client{
-			rng: func(fn func(*rand.Rand)) { fn(rng) },
-		}
-
-		seedBrokers := make([]*broker, 0, len(seeds))
-		for i, hp := range seeds {
-			seedBrokers = append(seedBrokers, cl.newBroker(unknownSeedID(i), hp.host, hp.port, nil))
-		}
-		cl.anySeedIdx = cl.randomSeedIdx(len(seedBrokers))
-		cl.seeds.Store(seedBrokers)
-
-		got := cl.broker().meta.NodeID
-		found := false
-		for i := range seeds {
-			if got == unknownSeedID(i) {
-				counts[i]++
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("first selected seed broker = %s, want one of the configured seeds", NodeName(got))
-		}
-	}
-
-	want := clients / len(seeds)
-	// With 1000 clients and 4 seeds, each seed should be picked about 250
-	// times. 75 allows range of accepted values while still catching the old
-	// behavior, where seed_0 would be picked 1000 times.
-	const maxSkew = 75
-	for i, got := range counts {
-		if got < want-maxSkew || got > want+maxSkew {
-			t.Fatalf("seed %s was selected first %d times out of %d clients, want roughly %d; counts=%v",
-				NodeName(unknownSeedID(i)), got, clients, want, counts)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Randomize the starting seed broker index for each client.

Before this change, every new client started `anySeedIdx` at `0`, so clients with the same `SeedBrokers(...)` list all sent their first seed-broker request to the first configured broker. In large fleets restarting at roughly the same time, this can create a TCP connection spike on that first bootstrap broker.

I’m currently seeing this issue through the OpenTelemetry Collector Kafka exporter, which uses franz-go underneath. When many collectors restart around the same time with the same Kafka bootstrap broker list, the first configured broker receives a spike of TCP connections.

This keeps the configured seed broker order unchanged, but starts the private seed cursor at a random index per client. After that first pick, the existing round-robin behavior over seed brokers is unchanged.

## Test

Added a deterministic test that simulates 1000 clients using the same 4 seed brokers, and verifies the first selected seed is spread roughly evenly instead of always selecting `seed_0`.
```bash
go test ./pkg/kgo -run TestSeedBrokersStartDistributedAcrossClients