### PR TITLE
comments: ASCII arrows and colons instead of unicode

### DIFF
--- a/generate/validate_test.go
+++ b/generate/validate_test.go
@@ -336,7 +336,7 @@ func TestValidateDSLAgainstKafkaJSON(t *testing.T) {
 
 	initDSL(t)
 
-	// Build a map from apiKey → DSL request and response structs.
+	// Build a map from apiKey -> DSL request and response structs.
 	type dslPair struct {
 		request  *Struct
 		response *Struct
@@ -503,7 +503,7 @@ func compareFieldsAtVersion(t *testing.T, msgName string, version, flexibleAt in
 	}
 
 	// Filter DSL fields active at this version.
-	// Tags never have version ranges — they are valid across all flexible
+	// Tags never have version ranges: they are valid across all flexible
 	// versions once introduced and can never be reused.
 	var dslNonTagged []StructField
 	dslTagged := make(map[int]StructField)
@@ -644,7 +644,7 @@ func TestValidateMiscDSLAgainstKafkaJSON(t *testing.T) {
 
 	initDSL(t)
 
-	// Build a map from name → DSL struct for non-top-level types.
+	// Build a map from name -> DSL struct for non-top-level types.
 	dslByName := make(map[string]*Struct)
 	for i := range newStructs {
 		s := &newStructs[i]
@@ -653,7 +653,7 @@ func TestValidateMiscDSLAgainstKafkaJSON(t *testing.T) {
 		}
 	}
 
-	// Misc type mappings: Kafka JSON path (relative to KAFKA_DIR) → DSL name.
+	// Misc type mappings: Kafka JSON path (relative to KAFKA_DIR) -> DSL name.
 	type miscMapping struct {
 		jsonPath string
 		dslName  string

--- a/pkg/kfake/cover_test.go
+++ b/pkg/kfake/cover_test.go
@@ -410,7 +410,7 @@ func TestAlterPartitionAssignments(t *testing.T) {
 	rp.Replicas = []int32{0}
 	rt.Partitions = append(rt.Partitions, rp)
 
-	// Cancel reassignment (nil replicas) — kfake has none in progress.
+	// Cancel reassignment (nil replicas): kfake has none in progress.
 	rpCancel := kmsg.NewAlterPartitionAssignmentsRequestTopicPartition()
 	rpCancel.Partition = 1
 	rpCancel.Replicas = nil
@@ -467,7 +467,7 @@ func TestAddRemoveNodeUpdatesCluster(t *testing.T) {
 		t.Fatalf("expected 2 brokers, got %d", len(c.ListenAddrs()))
 	}
 
-	// Verify we can produce — the new broker should appear in metadata.
+	// Verify we can produce: the new broker should appear in metadata.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	cl := newCoverClient(t, c)
@@ -550,7 +550,7 @@ func TestMoveTopicPartitionChangesLeader(t *testing.T) {
 }
 
 // TestSCRAMCredentialLifecycle verifies the full SCRAM credential lifecycle:
-// create → describe → update → describe → delete → describe (not found).
+// create -> describe -> update -> describe -> delete -> describe (not found).
 func TestSCRAMCredentialLifecycle(t *testing.T) {
 	t.Parallel()
 	c := newCoverCluster(t, NumBrokers(1))
@@ -596,7 +596,7 @@ func TestSCRAMCredentialLifecycle(t *testing.T) {
 	upsert("alice", 1, 4096) // SCRAM-SHA-256
 	upsert("bob", 2, 8192)   // SCRAM-SHA-512
 
-	// Describe both — verify mechanism and iterations.
+	// Describe both and verify the mechanism and iterations.
 	resp := describe("alice", "bob")
 	for _, r := range resp.Results {
 		if r.ErrorCode != 0 {
@@ -618,7 +618,7 @@ func TestSCRAMCredentialLifecycle(t *testing.T) {
 		}
 	}
 
-	// Describe all (nil users) — should find both.
+	// Describe all (nil users): this should find both.
 	respAll := describe()
 	if len(respAll.Results) < 2 {
 		t.Errorf("describe-all: expected >=2 results, got %d", len(respAll.Results))
@@ -645,7 +645,7 @@ func TestSCRAMCredentialLifecycle(t *testing.T) {
 		t.Fatal(kerr.ErrorForCode(delResp.Results[0].ErrorCode))
 	}
 
-	// Describe alice after delete → ResourceNotFound.
+	// Describe alice after delete -> ResourceNotFound.
 	resp3 := describe("alice")
 	if resp3.Results[0].ErrorCode != kerr.ResourceNotFound.Code {
 		t.Errorf("alice after delete: expected ResourceNotFound, got %v",
@@ -866,7 +866,7 @@ func TestAlterConfigsAppliesAndReadsBack(t *testing.T) {
 		t.Error("retention.ms=86400000 not found after AlterConfigs on topic")
 	}
 
-	// Unknown topic → error.
+	// Unknown topic -> error.
 	req3 := kmsg.NewAlterConfigsRequest()
 	rr3 := kmsg.NewAlterConfigsRequestResource()
 	rr3.ResourceType = kmsg.ConfigResourceTypeTopic
@@ -1201,7 +1201,7 @@ func TestCreateTopicsEdgeCases(t *testing.T) {
 		t.Fatal(kerr.ErrorForCode(resp5.Topics[0].ErrorCode))
 	}
 
-	// ReplicaAssignment with NumPartitions != -1 → InvalidRequest.
+	// ReplicaAssignment with NumPartitions != -1 -> InvalidRequest.
 	req6 := kmsg.NewCreateTopicsRequest()
 	rt6 := kmsg.NewCreateTopicsRequestTopic()
 	rt6.Topic = "bad-assign"
@@ -1220,7 +1220,7 @@ func TestCreateTopicsEdgeCases(t *testing.T) {
 		t.Errorf("expected InvalidRequest, got %v", kerr.ErrorForCode(resp6.Topics[0].ErrorCode))
 	}
 
-	// ValidateOnly — topic should not be created.
+	// ValidateOnly: the topic should not be created.
 	req7 := kmsg.NewCreateTopicsRequest()
 	req7.ValidateOnly = true
 	rt7 := kmsg.NewCreateTopicsRequestTopic()
@@ -1344,7 +1344,7 @@ func TestDescribeProducersShowsActiveTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Describe — should see active producer.
+	// Describe: we should see the active producer.
 	cl := newCoverClient(t, c)
 	req := kmsg.NewDescribeProducersRequest()
 	rt := kmsg.NewDescribeProducersRequestTopic()
@@ -1371,7 +1371,7 @@ func TestDescribeProducersShowsActiveTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Describe again — no active producers.
+	// Describe again: no active producers.
 	resp2, err := req.RequestWith(ctx, cl)
 	if err != nil {
 		t.Fatal(err)
@@ -1634,7 +1634,7 @@ func TestOffsetForLeaderEpochEmptyPartition(t *testing.T) {
 
 	// Move partition to bump epoch, but don't produce. This tests the
 	// "no batches" path (lines 97-105 in the handler).
-	c.MoveTopicPartition(topic, 0, 0) // epoch 0 → 1
+	c.MoveTopicPartition(topic, 0, 0) // epoch 0 -> 1
 	adm := kadm.NewClient(newCoverClient(t, c))
 	var req kadm.OffsetForLeaderEpochRequest
 	req.Add(topic, 0, 0) // query for old epoch 0
@@ -1857,7 +1857,7 @@ func TestTxnAbortDiscardsOffsets(t *testing.T) {
 		t.Fatal(kerr.ErrorForCode(addResp.ErrorCode))
 	}
 
-	// TxnOffsetCommit — stage offset 5 for the group.
+	// TxnOffsetCommit: stage offset 5 for the group.
 	commitReq := kmsg.NewTxnOffsetCommitRequest()
 	commitReq.TransactionalID = txnID
 	commitReq.Group = group
@@ -1895,7 +1895,7 @@ func TestTxnAbortDiscardsOffsets(t *testing.T) {
 	}
 
 	// Verify offsets were NOT committed to the group.
-	// GROUP_ID_NOT_FOUND is expected — the group was never created because
+	// GROUP_ID_NOT_FOUND is expected: the group was never created because
 	// the abort discarded the staged offsets.
 	adm := kadm.NewClient(cl)
 	offsets, err := adm.FetchOffsets(ctx, group)

--- a/pkg/kfake/persist_test.go
+++ b/pkg/kfake/persist_test.go
@@ -2024,7 +2024,7 @@ func TestPersistTxnAutoAbortExpiredOnRestart(t *testing.T) {
 // LastHeartbeat, each restart would reset the member's timeout to "just
 // now", preventing eviction indefinitely.
 //
-// The three-phase design is critical. A single close→sleep→restart would
+// The three-phase design is critical. A single close->sleep->restart would
 // pass even without the fix because enough wall time elapses. Phase 2's
 // intermediate restart advances shutdownAt: without the fix, phase 3
 // falls back to shutdownAt (recent), thinks the member is alive, and
@@ -2134,8 +2134,8 @@ func TestPersistGroupPhantomMemberExpiry(t *testing.T) {
 	time.Sleep(600 * time.Millisecond)
 
 	// Phase 3: restart again. With the fix, LastHeartbeat is from
-	// phase 1 (~1.1s ago) → expired. Without the fix, fallback to
-	// shutdownAt from phase 2 (~600ms ago) → alive (bug).
+	// phase 1 (~1.1s ago) -> expired. Without the fix, fallback to
+	// shutdownAt from phase 2 (~600ms ago) -> alive (bug).
 	{
 		c, err := NewCluster(
 			mfs.opt(),
@@ -2293,8 +2293,8 @@ func TestPersistGroupPhantomMemberExpiry848(t *testing.T) {
 	time.Sleep(600 * time.Millisecond)
 
 	// Phase 3: restart. With the fix, LastHeartbeat from phase 1
-	// (~1.1s ago) → expired. Without the fix, fallback to shutdownAt
-	// from phase 2 (~600ms ago) → alive (bug).
+	// (~1.1s ago) -> expired. Without the fix, fallback to shutdownAt
+	// from phase 2 (~600ms ago) -> alive (bug).
 	{
 		c, err := NewCluster(
 			mfs.opt(),

--- a/pkg/kfake/share_groups.go
+++ b/pkg/kfake/share_groups.go
@@ -116,7 +116,7 @@ type (
 	// (incremental), the request's Topics are ADDED to the session and
 	// ForgottenTopicsData are REMOVED (matching Kafka's ShareSession.update).
 	//
-	// partitions maps topicID → partition → requiresUpdate. The bool is
+	// partitions maps topicID -> partition -> requiresUpdate. The bool is
 	// true when the partition must appear in the next incremental response
 	// even if it has no data (new partition, or previous response had an
 	// error). Matching Java's CachedSharePartition.requiresUpdateInResponse.
@@ -674,7 +674,7 @@ func (g *shareGroup) recomputeAssignments() {
 
 	memberIDs := slices.Sorted(maps.Keys(g.members))
 
-	// Build topic→subscribers index.
+	// Build topic->subscribers index.
 	topicSubs := make(map[string][]string)
 	for _, id := range memberIDs {
 		for _, topic := range g.members[id].subscribedTopics {
@@ -682,7 +682,7 @@ func (g *shareGroup) recomputeAssignments() {
 		}
 	}
 
-	// Reverse lookup: topicID → topicName.
+	// Reverse lookup: topicID -> topicName.
 	topicForID := make(map[uuid]string)
 	for topic, si := range snap {
 		topicForID[si.id] = topic

--- a/pkg/kgo/consumer_group_848.go
+++ b/pkg/kgo/consumer_group_848.go
@@ -41,14 +41,14 @@ func (g *groupConsumer) should848() bool {
 // manage848 drives the KIP-848 heartbeat session: it restarts the session on
 // transient errors and re-fetches outstanding partitions via g.fetching.
 //
-// Constraints any change to coordinator/leader-churn recovery (here, in
-// heartbeat, and in fetchOffsets) must preserve — established by the
-// rebalance-churn audit:
+// The rebalance-churn audit established constraints that any change to
+// coordinator/leader-churn recovery (here, in heartbeat, and in fetchOffsets)
+// must preserve:
 //
 //  1. Heartbeat-originated transport and coordinator errors retry in place
 //     (the stale-connection cycle 90bcc2bb fixed is real). Fetch errors do
-//     NOT take that arm — they propagate here so the session restarts and
-//     re-fetches; do not collapse the two error sources back together.
+//     NOT take that arm; they propagate here so the session restarts and
+//     re-fetches. Do not collapse the two error sources back together.
 //  2. Session restart is the designed heal for fetch failures: the g.fetching
 //     carryover exists precisely so a torn-down session re-fetches. Route
 //     fixes through it rather than inventing a second retry inside fetchOffsets.
@@ -56,7 +56,7 @@ func (g *groupConsumer) should848() bool {
 //     for UnknownMemberID, the SAME UUID for epoch problems (FENCED and STALE
 //     both keep it). Anything stronger strands server-side state for a full
 //     session timeout.
-//  4. Leaves (MemberEpoch -1/-2) are idempotent and stateless — safe to retry
+//  4. Leaves (MemberEpoch -1/-2) are idempotent and stateless, safe to retry
 //     anywhere. The CGHB no-retry rule applies only to reconciliation-carrying
 //     heartbeats, never to leaves.
 func (g *groupConsumer) manage848() {

--- a/pkg/kgo/internal/xsync/synctest_mutex.go
+++ b/pkg/kgo/internal/xsync/synctest_mutex.go
@@ -52,7 +52,7 @@ func (m *Mutex) Unlock() {
 // immediately return it (passing through the gate). Writers
 // take the token and hold it, which blocks all new readers
 // until the writer unlocks. This provides writer priority
-// naturally — the moment a writer calls Lock, new RLock
+// naturally: the moment a writer calls Lock, new RLock
 // calls block on the gate.
 //
 // A separate writerSignal channel (buffered 1) is used by

--- a/pkg/kgo/txn.go
+++ b/pkg/kgo/txn.go
@@ -1073,29 +1073,29 @@ func (cl *Client) maybeRecoverProducerID(ctx context.Context) (necessary, did bo
 // Kafka may still be finalizing its commit / abort and will return a
 // concurrent transactions error. We handle that by retrying for a bit.
 //
-// Constraints any change to EOS-under-coordinator-churn (here and in
-// maybeRecoverProducerID / EndTransaction) must preserve — established by the
-// txn-churn audit:
+// The txn-churn audit established constraints that any change to
+// EOS-under-coordinator-churn (here and in maybeRecoverProducerID /
+// EndTransaction) must preserve:
 //
 //  1. This wrapper / coordinator-retry division stays: the coordinator
 //     wrapper retries only coordinator-move codes; CONCURRENT_TRANSACTIONS
 //     loops belong to callers, ctx-bounded, because CT can legitimately last
 //     as long as a marker drain. Route CT recovery through this loop, not a
 //     second one.
-//  2. anyAdded gating stays for TV1 — EndTxn on an EMPTY TV1 transaction is
+//  2. anyAdded gating stays for TV1: EndTxn on an empty TV1 transaction is
 //     INVALID_TXN_STATE. The TV2 forced-abort-when-every-produce-failed path
-//     must stay TV2-only and attempted-only; idle Begin/End cycles stay
-//     wireless.
+//     must stay TV2-only and attempted-only; idle Begin/End cycles issue no
+//     requests.
 //  3. Producer-fenced means dead: no fix may add recovery for PRODUCER_FENCED
 //     from coordinator paths. Only the timeout-abort IPE-on-produce path is
 //     recoverable, and only under TV1 semantics.
 //
-// Two design-sized items remain deliberately NOT taken (would need their own
-// round; until then docs + AbortingFirstErrPromise carry them): (a)
-// commit-after-failed-produce — kgo commits whatever succeeded if the caller
+// Two design-sized items remain deliberately NOT taken; they would need their
+// own round, and until then docs + AbortingFirstErrPromise carry them. (a)
+// Commit-after-failed-produce: kgo commits whatever succeeded if the caller
 // asks, unlike Java's abortable-state block, so changing it means tracking
-// per-txn batch failures and changing End's contract; (b) TV2 feature
-// downgrade mid-session (transaction.version 2=>1 while a client lives) —
+// per-txn batch failures and changing End's contract. (b) TV2 feature
+// downgrade mid-session (transaction.version 2=>1 while a client lives):
 // Java's per-EndTxn re-check is the reference shape if it ever bites.
 func (cl *Client) doWithConcurrentTransactions(ctx context.Context, name string, fn func() error) error {
 	start := time.Now()

--- a/pkg/sr/srfake/handlers.go
+++ b/pkg/sr/srfake/handlers.go
@@ -858,7 +858,7 @@ func (r *Registry) handleDeleteSubjectMode(w http.ResponseWriter, req *http.Requ
 }
 
 /* -------------------------------------------------------------------------
-   Handlers – Contexts
+   Handlers - Contexts
    ------------------------------------------------------------------------- */
 
 // handleGetContexts emulates GET /contexts.

--- a/pkg/sr/srfake/registry.go
+++ b/pkg/sr/srfake/registry.go
@@ -726,7 +726,7 @@ func (r *Registry) detectCycle(schema sr.Schema, subject string, version int, vi
 func subjectContext(subject string) string {
 	if strings.HasPrefix(subject, ":.") {
 		if idx := strings.Index(subject[2:], ":"); idx >= 0 {
-			return subject[1 : idx+2] // e.g. ":.myctx:topic" → ".myctx"
+			return subject[1 : idx+2] // e.g. ":.myctx:topic" -> ".myctx"
 		}
 	}
 	return "."

--- a/pkg/sr/srfake/registry_test.go
+++ b/pkg/sr/srfake/registry_test.go
@@ -2121,7 +2121,7 @@ func TestContextHandlers(t *testing.T) {
 				})
 			},
 			wantStatus: http.StatusOK,
-			wantBody:   `[".a"]`, // sorted: [".", ".a", ".b"], offset=1 limit=1 → [".a"]
+			wantBody:   `[".a"]`, // sorted: [".", ".a", ".b"], offset=1 limit=1 -> [".a"]
 		},
 
 		// DELETE /contexts/{context}


### PR DESCRIPTION
Comment-only. No functional change.

Em dashes and arrows do not appear anywhere in this repo's Go comments
before 2026: at tags v1.15.0 and v1.17.0 the `//` comments contain zero
non-ASCII characters, the sole exception being a `§` citing an RFC
section in a 2020 block comment. Every one in the tree today arrived in
2026, seven of the em dashes in a single commit. They are a reliable
sign a line was generated rather than typed.

This removes 18 em dashes and 24 arrows from comments, using `->` where
an arrow carried a mapping and a colon or full stop where a dash was
standing in for one. Also reordered two "Constraints ... established by
the X audit" sentences, `EMPTY` to `empty`, and replaced "idle
Begin/End cycles stay wireless" with "issue no requests".

Deliberately left alone:

- Every `—` inside a string literal, including test data.
- `≥` in kfake/sasl.go and `§` in sasl/kerberos, which are notation
  doing real work rather than prose tics.
- The en dashes in `kadm/acls.go` (`v8–v10`, 2024) and the
  `srfake/handlers.go` banners (2025). Those predate the 2026 commits
  and are the maintainer's own prose; only the one 2026 banner in that
  file was changed.
- `NOT`, `SAME`, `BEFORE` and `AFTER` as emphasis, which this repo
  genuinely uses.

Each character was dated with `git log -L` before being touched.
