### PR TITLE
kgo: expose BalanceInfo for custom balancer implementations

### DIFF
--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -1632,7 +1632,7 @@ func (g *groupConsumer) handleJoinResp(resp *kmsg.JoinGroupResponse) (restart bo
 			"balance_protocol", protocol,
 			"leader", true,
 		)
-		plan, err = g.balanceGroup(protocol, resp.Members, resp.SkipAssignment)
+		plan, err = g.balanceGroup(protocol, resp)
 	} else if leaderNoPlan {
 		g.leader.Store(true)
 		g.cfg.logger.Log(LogLevelInfo, "joined as leader but unable to balance group due to KIP-345 limitations",

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo/internal/sticky"
@@ -84,6 +85,45 @@ type GroupMemberBalancerOrError interface {
 	BalanceOrError(topics map[string]int32) (IntoSyncAssignment, error)
 }
 
+// BalanceInfo contains information about the group being balanced and the
+// cluster it is in. We set this on balancers that implement
+// GroupMemberBalancerInfo, before we balance.
+type BalanceInfo struct {
+	// Group is the group being balanced.
+	Group string
+
+	// Generation is the generation we are balancing into. Each member's
+	// metadata contains the generation that member last knew of.
+	Generation int32
+
+	// LeaderID is the group leader's member ID, which is always you: the
+	// coordinator only asks the leader to balance. The coordinator keeps
+	// the same leader until that member leaves the group, so pinning work
+	// to the leader is stable while other members join and leave.
+	LeaderID string
+
+	// Topics returns metadata for every topic being balanced. The first
+	// call builds the result, later calls return the same map.
+	//
+	// We do not request metadata to answer this: topics we have not
+	// loaded yet are missing, and what we have can be up to MetadataMaxAge
+	// old.
+	Topics func() map[string]TopicMetadata
+
+	// Brokers returns every broker we know of, by node ID. Use this to map
+	// a partition's leader or replicas to a rack.
+	Brokers func() map[int32]BrokerMetadata
+}
+
+// GroupMemberBalancerInfo is an optional extension interface for
+// GroupMemberBalancer. If your balancer implements this, we set the info for
+// the group being balanced before balancing. ConsumerBalancer implements
+// this; see ConsumerBalancer.Info.
+type GroupMemberBalancerInfo interface {
+	GroupMemberBalancer
+	SetBalanceInfo(BalanceInfo)
+}
+
 // IntoSyncAssignment takes a balance plan and returns a list of assignments to
 // use in a kmsg.SyncGroupRequest.
 //
@@ -105,6 +145,12 @@ type ConsumerBalancer struct {
 	// partitionRacks maps topic => partition index => leader rack.
 	// nil when rack-aware assignment is not active.
 	partitionRacks map[string][]string
+
+	// info is everything we know about the group and cluster at balance
+	// time, set by the client before balancing (see balanceGroup). Zero
+	// when the balancer is constructed directly (NewConsumerBalancer) and
+	// balanced without a client.
+	info BalanceInfo
 
 	err error
 }
@@ -149,6 +195,20 @@ func (b *ConsumerBalancer) SetError(err error) {
 // if no rack info is available.
 func (b *ConsumerBalancer) PartitionRacks() map[string][]string {
 	return b.partitionRacks
+}
+
+// Info returns information about the group being balanced and the cluster it
+// is in. The client sets the info before balancing; if you construct a
+// ConsumerBalancer directly with NewConsumerBalancer and balance without a
+// client, the info is empty: LeaderID is unset and the Topics and Brokers
+// functions are nil.
+func (b *ConsumerBalancer) Info() BalanceInfo {
+	return b.info
+}
+
+// SetBalanceInfo implements GroupMemberBalancerInfo.
+func (b *ConsumerBalancer) SetBalanceInfo(info BalanceInfo) {
+	b.info = info
 }
 
 // MemberTopics returns the unique set of topics that all members are
@@ -386,7 +446,7 @@ func (g *groupConsumer) findBalancer(from, proto string) (GroupBalancer, error) 
 // returns all topics and partitions; the leader will then periodically do its
 // own metadata update to see if partition counts have changed for these random
 // topics.
-func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupResponseMember, skipBalance bool) ([]kmsg.SyncGroupRequestGroupAssignment, error) {
+func (g *groupConsumer) balanceGroup(proto string, resp *kmsg.JoinGroupResponse) ([]kmsg.SyncGroupRequestGroupAssignment, error) {
 	g.cl.cfg.logger.Log(LogLevelInfo, "balancing group as leader")
 
 	b, err := g.findBalancer("balance group", proto)
@@ -394,6 +454,7 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 		return nil, err
 	}
 
+	members := resp.Members
 	sortJoinMembers(members)
 
 	memberBalancer, topics, err := b.MemberBalancer(members)
@@ -473,6 +534,33 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 		cb.partitionRacks = g.buildPartitionRacks(cb, topicPartitionCount)
 	}
 
+	// Balancers that opt in receive everything we know about the group and
+	// cluster at balance time. Topics and Brokers are functions so that
+	// balancers that never read them (sticky, range, roundrobin) do not
+	// pay for building the snapshots.
+	if ib, ok := memberBalancer.(GroupMemberBalancerInfo); ok {
+		var topicsMdBuilder, brokersMdBuilder sync.Once
+		var topicsMd map[string]TopicMetadata
+		var brokersMd map[int32]BrokerMetadata
+		ib.SetBalanceInfo(BalanceInfo{
+			Group:      g.cfg.group,
+			Generation: resp.Generation,
+			LeaderID:   resp.LeaderID,
+			Topics: func() map[string]TopicMetadata {
+				topicsMdBuilder.Do(func() { // Only build the topics once
+					topicsMd = g.cl.balanceInfoTopics(topics)
+				})
+				return topicsMd
+			},
+			Brokers: func() map[int32]BrokerMetadata {
+				brokersMdBuilder.Do(func() { // Only build the brokers once
+					brokersMd = g.cl.balanceInfoBrokers()
+				})
+				return brokersMd
+			},
+		})
+	}
+
 	// If the returned balancer is a ConsumerBalancer (which it likely
 	// always will be), then we can print some useful debugging information
 	// about what member interests are.
@@ -503,7 +591,7 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 	// interested in and are now tracking them for metadata updates. We
 	// have logged the current interests, we do not need to actually
 	// balance.
-	if skipBalance {
+	if resp.SkipAssignment {
 		switch proto := b.ProtocolName(); proto {
 		case RangeBalancer().ProtocolName(),
 			RoundRobinBalancer().ProtocolName(),
@@ -644,6 +732,60 @@ func (g *groupConsumer) buildPartitionRacks(b *ConsumerBalancer, topicPartitionC
 		}
 	}
 	return nil
+}
+
+// balanceInfoTopics builds the BalanceInfo.Topics map of topic metadata
+func (cl *Client) balanceInfoTopics(topics map[string]struct{}) map[string]TopicMetadata {
+	// Shallow copy out of the cache in a small critical section
+	// since cachedMetaTopic is not modified after placement into cl.metaCache
+	cached := make(map[string]cachedMetaTopic, len(topics))
+	cl.metaCache.mu.Lock()
+	for topic := range topics {
+		if ct, ok := cl.metaCache.topics[topic]; ok {
+			cached[topic] = ct
+		}
+	}
+	cl.metaCache.mu.Unlock()
+
+	// Outside of the lock build the public TopicMetadata
+	m := make(map[string]TopicMetadata, len(cached))
+	for topic, ct := range cached {
+		t := TopicMetadata{
+			Topic:      topic,
+			Partitions: make([]PartitionMetadata, 0, len(ct.t.Partitions)),
+			ID:         ct.id,
+			Err:        kerr.ErrorForCode(ct.t.ErrorCode),
+		}
+		for _, p := range ct.t.Partitions {
+			t.Partitions = append(t.Partitions, PartitionMetadata{
+				Topic:           topic,
+				Partition:       p.Partition,
+				Leader:          p.Leader,
+				LeaderEpoch:     p.LeaderEpoch,
+				Replicas:        slices.Clone(p.Replicas),
+				ISR:             slices.Clone(p.ISR),
+				OfflineReplicas: slices.Clone(p.OfflineReplicas),
+				Err:             kerr.ErrorForCode(p.ErrorCode),
+			})
+		}
+		// Sort by partition
+		sort.Slice(t.Partitions, func(i, j int) bool {
+			return t.Partitions[i].Partition < t.Partitions[j].Partition
+		})
+		m[topic] = t
+	}
+	return m
+}
+
+// balanceInfoBrokers builds the BalanceInfo.Brokers map of broker metadata
+func (cl *Client) balanceInfoBrokers() map[int32]BrokerMetadata {
+	cl.brokersMu.RLock()
+	defer cl.brokersMu.RUnlock()
+	m := make(map[int32]BrokerMetadata, len(cl.brokers))
+	for _, b := range cl.brokers {
+		m[b.meta.NodeID] = b.meta
+	}
+	return m
 }
 
 // helper func; range and roundrobin use v0

--- a/pkg/kgo/group_balancer_test.go
+++ b/pkg/kgo/group_balancer_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -548,5 +549,228 @@ func TestNeedRackMeta(t *testing.T) {
 		if got := test.g.needRackMeta(test.b, topics); got != test.exp {
 			t.Errorf("%s: got %v, expected %v", test.name, got, test.exp)
 		}
+	}
+}
+
+var _ GroupMemberBalancerInfo = new(ConsumerBalancer)
+
+// balanceFn adapts a func to ConsumerBalancerBalance for tests.
+type balanceFn func(*ConsumerBalancer, map[string]int32) IntoSyncAssignment
+
+func (f balanceFn) Balance(b *ConsumerBalancer, topics map[string]int32) IntoSyncAssignment {
+	return f(b, topics)
+}
+
+func TestConsumerBalancerInfo(t *testing.T) {
+	t.Parallel()
+
+	members := []kmsg.JoinGroupResponseMember{
+		{MemberID: "a", ProtocolMetadata: simpleMemberMetadata([]string{"t1"}, 0)},
+		{MemberID: "b", ProtocolMetadata: simpleMemberMetadata([]string{"t1"}, 0)},
+	}
+
+	var seen BalanceInfo
+	b, err := NewConsumerBalancer(balanceFn(func(b *ConsumerBalancer, _ map[string]int32) IntoSyncAssignment {
+		seen = b.Info()
+		return b.NewPlan()
+	}), members)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Without SetBalanceInfo -- NewConsumerBalancer without a client --
+	// Info returns the zero value.
+	if info := b.Info(); info.Group != "" || info.Generation != 0 || info.LeaderID != "" || info.Topics != nil || info.Brokers != nil {
+		t.Errorf("got non-zero info %+v before SetBalanceInfo", info)
+	}
+
+	expTopics := map[string]TopicMetadata{"t1": {Topic: "t1"}}
+	expBrokers := map[int32]BrokerMetadata{1: {NodeID: 1}}
+	b.SetBalanceInfo(BalanceInfo{
+		Group:      "g",
+		Generation: 2,
+		LeaderID:   "b",
+		Topics:     func() map[string]TopicMetadata { return expTopics },
+		Brokers:    func() map[int32]BrokerMetadata { return expBrokers },
+	})
+
+	// The info set must be exactly what Balance observes through Info.
+	if _, err := b.BalanceOrError(map[string]int32{"t1": 1}); err != nil {
+		t.Fatal(err)
+	}
+	if seen.Group != "g" || seen.Generation != 2 || seen.LeaderID != "b" {
+		t.Errorf("got info %+v in balance, expected group g, generation 2, leader b", seen)
+	}
+	if !reflect.DeepEqual(seen.Topics(), expTopics) || !reflect.DeepEqual(seen.Brokers(), expBrokers) {
+		t.Errorf("got topics %+v brokers %+v in balance, expected %+v and %+v", seen.Topics(), seen.Brokers(), expTopics, expBrokers)
+	}
+}
+
+func TestBalanceInfoTopics(t *testing.T) {
+	t.Parallel()
+
+	cl := new(Client)
+	cl.metaCache.topics = map[string]cachedMetaTopic{
+		"t1": {
+			id: [16]byte{1},
+			t: kmsg.MetadataResponseTopic{
+				// Deliberately out of partition order: the cache
+				// keeps the broker's response order, the snapshot
+				// promises partition order.
+				Partitions: []kmsg.MetadataResponseTopicPartition{
+					{
+						Partition:       1,
+						Leader:          2,
+						LeaderEpoch:     5,
+						Replicas:        []int32{2, 3},
+						ISR:             []int32{2},
+						OfflineReplicas: []int32{3},
+					},
+					{
+						Partition:   0,
+						Leader:      3,
+						LeaderEpoch: 4,
+						Replicas:    []int32{3, 2},
+						ISR:         []int32{3, 2},
+						ErrorCode:   kerr.NotLeaderForPartition.Code,
+					},
+				},
+			},
+		},
+		"terr":   {t: kmsg.MetadataResponseTopic{ErrorCode: kerr.UnknownTopicOrPartition.Code}},
+		"tother": {}, // cached but not being balanced: must not appear
+	}
+
+	// tmissing is being balanced but is not in the cache: must be missing.
+	got := cl.balanceInfoTopics(map[string]struct{}{"t1": {}, "terr": {}, "tmissing": {}})
+	exp := map[string]TopicMetadata{
+		"t1": {
+			Topic: "t1",
+			ID:    [16]byte{1},
+			Partitions: []PartitionMetadata{
+				{Topic: "t1", Partition: 0, Leader: 3, LeaderEpoch: 4, Replicas: []int32{3, 2}, ISR: []int32{3, 2}, Err: kerr.NotLeaderForPartition},
+				{Topic: "t1", Partition: 1, Leader: 2, LeaderEpoch: 5, Replicas: []int32{2, 3}, ISR: []int32{2}, OfflineReplicas: []int32{3}},
+			},
+		},
+		"terr": {Topic: "terr", Partitions: []PartitionMetadata{}, Err: kerr.UnknownTopicOrPartition},
+	}
+	if !reflect.DeepEqual(got, exp) {
+		t.Errorf("got topics != exp\ngot: %#v\nexp: %#v\n", got, exp)
+	}
+
+	// The snapshot is deep copied: mutating it must not corrupt the cache.
+	got["t1"].Partitions[1].Replicas[0] = 99
+	if r := cl.metaCache.topics["t1"].t.Partitions[0].Replicas[0]; r != 2 {
+		t.Errorf("mutating snapshot changed cached replica to %d", r)
+	}
+}
+
+func TestBalanceInfoBrokers(t *testing.T) {
+	t.Parallel()
+
+	rack := "rack1"
+	cl := new(Client)
+	cl.brokers = []*broker{
+		{meta: BrokerMetadata{NodeID: 1, Host: "h1", Port: 9092, Rack: &rack}},
+		{meta: BrokerMetadata{NodeID: 2, Host: "h2", Port: 9092}},
+	}
+
+	got := cl.balanceInfoBrokers()
+	exp := map[int32]BrokerMetadata{
+		1: {NodeID: 1, Host: "h1", Port: 9092, Rack: &rack},
+		2: {NodeID: 2, Host: "h2", Port: 9092},
+	}
+	if !reflect.DeepEqual(got, exp) {
+		t.Errorf("got brokers != exp\ngot: %#v\nexp: %#v\n", got, exp)
+	}
+}
+
+// infoGroupBalancer is a GroupBalancer whose balance callback receives the
+// ConsumerBalancer, for testing the info that balanceGroup sets.
+type infoGroupBalancer struct {
+	onBalance func(*ConsumerBalancer)
+}
+
+func (*infoGroupBalancer) ProtocolName() string { return "test-info" }
+func (*infoGroupBalancer) IsCooperative() bool  { return false }
+func (*infoGroupBalancer) JoinGroupMetadata(interests []string, _ map[string][]int32, generation int32) []byte {
+	return simpleMemberMetadata(interests, generation)
+}
+
+func (*infoGroupBalancer) ParseSyncAssignment(assignment []byte) (map[string][]int32, error) {
+	return ParseConsumerSyncAssignment(assignment)
+}
+
+func (ib *infoGroupBalancer) MemberBalancer(members []kmsg.JoinGroupResponseMember) (GroupMemberBalancer, map[string]struct{}, error) {
+	b, err := NewConsumerBalancer(balanceFn(func(b *ConsumerBalancer, _ map[string]int32) IntoSyncAssignment {
+		ib.onBalance(b)
+		return b.NewPlan()
+	}), members)
+	return b, b.MemberTopics(), err
+}
+
+// TestBalanceGroupSetsBalanceInfo drives balanceGroup itself -- no network is
+// needed when the group's topics are already in tps -- to test the info the
+// client sets before balancing, including that the Topics and Brokers
+// snapshots are built once and memoized.
+func TestBalanceGroupSetsBalanceInfo(t *testing.T) {
+	t.Parallel()
+
+	cl := new(Client)
+	cl.cfg.logger = new(nopLogger)
+	cl.cfg.group = "g"
+	cl.metaCache.topics = map[string]cachedMetaTopic{
+		"t1": {t: kmsg.MetadataResponseTopic{
+			Partitions: []kmsg.MetadataResponseTopicPartition{{Partition: 0, Leader: 1}},
+		}},
+	}
+	cl.brokers = []*broker{{meta: BrokerMetadata{NodeID: 1, Host: "h1", Port: 9092}}}
+
+	var balanced bool
+	gb := &infoGroupBalancer{onBalance: func(b *ConsumerBalancer) {
+		balanced = true
+		info := b.Info()
+		if info.Group != "g" || info.Generation != 7 || info.LeaderID != "b" {
+			t.Errorf("got info %+v, expected group g, generation 7, leader b", info)
+		}
+
+		topics, brokers := info.Topics(), info.Brokers()
+		if len(topics) != 1 || len(topics["t1"].Partitions) != 1 || topics["t1"].Partitions[0].Leader != 1 {
+			t.Errorf("got topics %+v, expected t1 with partition 0 led by broker 1", topics)
+		}
+		if len(brokers) != 1 || brokers[1].Host != "h1" {
+			t.Errorf("got brokers %+v, expected broker 1 on h1", brokers)
+		}
+
+		// The first call builds the result, later calls return the
+		// same map: wiping what the snapshots are built from must
+		// change nothing.
+		cl.metaCache.topics = nil
+		cl.brokers = nil
+		if reflect.ValueOf(info.Topics()).Pointer() != reflect.ValueOf(topics).Pointer() {
+			t.Error("second Topics call did not return the memoized map")
+		}
+		if reflect.ValueOf(info.Brokers()).Pointer() != reflect.ValueOf(brokers).Pointer() {
+			t.Error("second Brokers call did not return the memoized map")
+		}
+	}}
+	cl.cfg.balancers = []GroupBalancer{gb}
+
+	g := &groupConsumer{cl: cl, cfg: &cl.cfg, tps: newTopicsPartitions()}
+	g.tps.storeTopics([]string{"t1"})
+
+	resp := &kmsg.JoinGroupResponse{
+		Generation: 7,
+		LeaderID:   "b",
+		Members: []kmsg.JoinGroupResponseMember{
+			{MemberID: "a", ProtocolMetadata: simpleMemberMetadata([]string{"t1"}, 0)},
+			{MemberID: "b", ProtocolMetadata: simpleMemberMetadata([]string{"t1"}, 0)},
+		},
+	}
+	if _, err := g.balanceGroup("test-info", resp); err != nil {
+		t.Fatal(err)
+	}
+	if !balanced {
+		t.Fatal("balance was never invoked")
 	}
 }

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -15,6 +15,34 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo/internal/xsync"
 )
 
+// PartitionMetadata contains information about a partition and its replicas.
+//
+// This mirrors kadm.PartitionDetail as a general type in kgo, alongside
+// TopicMetadata and BrokerMetadata.
+type PartitionMetadata struct {
+	Topic     string // Topic is the topic containing this partition.
+	Partition int32  // Partition is the partition number.
+
+	Leader          int32   // Leader is the broker leader, if there is one, otherwise -1.
+	LeaderEpoch     int32   // LeaderEpoch is the epoch of the broker leader, or -1 if the broker does not support leader epochs.
+	Replicas        []int32 // Replicas is the set of replica brokers.
+	ISR             []int32 // ISR is the set of in sync replica brokers.
+	OfflineReplicas []int32 // OfflineReplicas is the set of offline replica brokers.
+
+	Err error // Err is non-nil if the partition currently has a load error.
+}
+
+// TopicMetadata contains information about a topic and its partitions.
+//
+// This mirrors kadm.TopicDetail as a general type in kgo, alongside
+// PartitionMetadata and BrokerMetadata.
+type TopicMetadata struct {
+	Topic      string              // Topic is the topic name.
+	ID         [16]byte            // ID is the topic ID; all zero if the broker does not support topic IDs.
+	Partitions []PartitionMetadata // Partitions contains metadata for the topic's partitions, ordered by partition.
+	Err        error               // Err is non-nil if the topic currently has a load error.
+}
+
 type metawait struct {
 	mu         xsync.Mutex
 	c          *sync.Cond


### PR DESCRIPTION
This is the `FirstBalancer`, an eager group balancer (protocol `"first"`) that assigns all partitions to the group leader. Everyone else joins as a hot standby and gets nothing. When the active member leaves, everything moves to the newly elected leader. Since the coordinator keeps the same leader until it leaves, standbys joining or leaving never migrate partitions. Failover only happens when the active member itself goes away.

We run this in our system in production and have for several months. Some of our services need exactly one instance consuming all partitions (stateful processing where the one instance processing messages has to control the universe) with standbys ready for fast failover where rebalancing is cheap and fast but startup cost is slow by comparison. The group protocol already does leader election, so we lean on that instead of running an external lock service. We built it on franz-go's public balancer interfaces (modeled closely on the roundrobin balancer) and figured the community would benefit from having it upstream.

For this changeset to work, balancers need to see the leader ID through the `GroupBalancer` interface, so `balanceGroup` now passes it into an unexported field on `ConsumerBalancer` (same spot as the KIP-881 rack injection). No public API changes. If no leader is known (external use for example), it falls back to the first member sorted by instance ID then member ID which is always at index 0. That way there's always a member that has all the partitions even if the leader cannot be dereferenced.