### PR TITLE
kfake: two transactional broker-accuracy fixes

### DIFF
--- a/pkg/kfake/00_produce.go
+++ b/pkg/kfake/00_produce.go
@@ -216,6 +216,16 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 					errCode = kerr.InvalidTxnState.Code
 				}
 
+				// Brokers below 2.5 (KIP-360) have no
+				// accept-any-first-sequence for unknown producer
+				// state: an append continuing its sequence into a log
+				// that never saw the producer is rejected. We model
+				// this for transactional appends only, keeping the
+				// 2.5+ leniency above for idempotent-only producers.
+				if errCode == 0 && txnal && !window.seen && b.FirstSequence != 0 && c.maxVersion(int16(kmsg.InitProducerID)) < 3 {
+					errCode = kerr.UnknownProducerID.Code
+				}
+
 				if errCode == 0 {
 					switch {
 					case window == nil && b.ProducerEpoch != -1:

--- a/pkg/kfake/18_api_versions.go
+++ b/pkg/kfake/18_api_versions.go
@@ -154,6 +154,23 @@ func (c *Cluster) checkReqVersion(key, version int16) error {
 	return nil
 }
 
+// maxVersion returns the max version we advertise for a request key, or -1 if
+// we do not advertise the key at all.
+func (c *Cluster) maxVersion(key int16) int16 {
+	v, exists := apiVersionsKeys[key]
+	if !exists {
+		return -1
+	}
+	if c.cfg.maxVersions == nil {
+		return v.MaxVersion
+	}
+	cfgMax, ok := c.cfg.maxVersions.LookupMaxKeyVersion(key)
+	if !ok {
+		return -1
+	}
+	return min(cfgMax, v.MaxVersion)
+}
+
 var (
 	apiVersionsMu   sync.Mutex
 	apiVersionsKeys = make(map[int16]kmsg.ApiVersionsResponseApiKey)

--- a/pkg/kfake/behavior_test.go
+++ b/pkg/kfake/behavior_test.go
@@ -2149,6 +2149,98 @@ func TestTxnNonTransactionalProduceDuringTx(t *testing.T) {
 	}
 }
 
+// TestTxnProduceUnknownProducerIDPre360 verifies that below KIP-360
+// (InitProducerID v3, Kafka 2.5), a transactional append continuing its
+// sequence into a log that has never seen the producer is rejected with
+// UNKNOWN_PRODUCER_ID. At 2.5 and above the broker seeds state from any
+// first sequence and the same append is accepted.
+func TestTxnProduceUnknownProducerIDPre360(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name    string
+		initMax int16
+		want    int16
+	}{
+		{"pre-360", 2, kerr.UnknownProducerID.Code},
+		{"post-360", 4, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			topic := "t-unknown-pid-" + test.name
+			txid := "txid-unknown-pid-" + test.name
+
+			v := kversion.Stable()
+			v.SetMaxKeyVersion(0, 11) // Produce v11: partitions are added explicitly
+			v.SetMaxKeyVersion(22, test.initMax)
+			c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic), kfake.MaxVersions(v))
+			cl := newPlainClient(t, c, kgo.MaxVersions(v))
+			ctx := context.Background()
+
+			initResp := initProducerID(t, cl, txid, -1, -1, 60000)
+			if initResp.ErrorCode != 0 {
+				t.Fatalf("init: %v", kerr.ErrorForCode(initResp.ErrorCode))
+			}
+
+			addReq := kmsg.NewAddPartitionsToTxnRequest()
+			addReq.TransactionalID = txid
+			addReq.ProducerID = initResp.ProducerID
+			addReq.ProducerEpoch = initResp.ProducerEpoch
+			addT := kmsg.NewAddPartitionsToTxnRequestTopic()
+			addT.Topic = topic
+			addT.Partitions = []int32{0}
+			addReq.Topics = append(addReq.Topics, addT)
+			if _, err := addReq.RequestWith(ctx, cl); err != nil {
+				t.Fatalf("add partitions: %v", err)
+			}
+
+			// Continue the sequence at 7 into a log that has never
+			// seen this producer, as a producer whose topic was
+			// deleted and recreated under it does.
+			rec := kmsg.Record{Key: []byte("k"), Value: []byte("v")}
+			rec.Length = int32(len(rec.AppendTo(nil)) - 1)
+			now := time.Now().UnixMilli()
+			batch := kmsg.RecordBatch{
+				PartitionLeaderEpoch: -1,
+				Magic:                2,
+				Attributes:           0x0010, // transactional
+				LastOffsetDelta:      0,
+				FirstTimestamp:       now,
+				MaxTimestamp:         now,
+				ProducerID:           initResp.ProducerID,
+				ProducerEpoch:        initResp.ProducerEpoch,
+				FirstSequence:        7,
+				NumRecords:           1,
+				Records:              rec.AppendTo(nil),
+			}
+			raw := batch.AppendTo(nil)
+			batch.Length = int32(len(raw) - 12)
+			raw = batch.AppendTo(nil)
+			batch.CRC = int32(crc32.Checksum(raw[21:], crc32.MakeTable(crc32.Castagnoli)))
+
+			produceReq := kmsg.NewProduceRequest()
+			produceReq.Version = 11
+			produceReq.Acks = -1
+			produceReq.TimeoutMillis = 5000
+			rt := kmsg.NewProduceRequestTopic()
+			rt.Topic = topic
+			rp := kmsg.NewProduceRequestTopicPartition()
+			rp.Partition = 0
+			rp.Records = batch.AppendTo(nil)
+			rt.Partitions = append(rt.Partitions, rp)
+			produceReq.Topics = append(produceReq.Topics, rt)
+
+			produceResp, err := produceReq.RequestWith(ctx, cl)
+			if err != nil {
+				t.Fatalf("produce: %v", err)
+			}
+			if got := produceResp.Topics[0].Partitions[0].ErrorCode; got != test.want {
+				t.Fatalf("got %v, want %v", kerr.ErrorForCode(got), kerr.ErrorForCode(test.want))
+			}
+		})
+	}
+}
+
 // TestClassicIncompatibleProtocolRejected verifies that a member whose
 // protocols are not supported by all existing members is rejected with
 // INCONSISTENT_GROUP_PROTOCOL.

--- a/pkg/kfake/cover_test.go
+++ b/pkg/kfake/cover_test.go
@@ -2,6 +2,7 @@ package kfake
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -1977,6 +1978,75 @@ func TestTxnAbortRecordsInvisibleToReadCommitted(t *testing.T) {
 	fs.EachRecord(func(r *kgo.Record) { count++ })
 	if count != 5 {
 		t.Errorf("read_committed consumer saw %d records, want 5 (aborted should be invisible)", count)
+	}
+}
+
+// TestTxnReinitAbortsOpenTxn verifies that a fresh InitProducerID on a
+// transactional ID that has an open transaction aborts it. The producer ID is
+// reused across the init, so leaving the transaction open means the next
+// commit's marker covers the abandoned records and a read_committed consumer
+// sees them.
+func TestTxnReinitAbortsOpenTxn(t *testing.T) {
+	t.Parallel()
+	topic := "txn-reinit-aborts"
+	txnID := "txn-reinit-aborts-id"
+	c := newCoverCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Produce 3 records and walk away without ending the transaction.
+	abandoned := newCoverClient(t, c,
+		kgo.DefaultProduceTopic(topic),
+		kgo.TransactionalID(txnID),
+	)
+	if err := abandoned.BeginTransaction(); err != nil {
+		t.Fatal(err)
+	}
+	for range 3 {
+		if err := abandoned.ProduceSync(ctx, kgo.StringRecord("abandoned")).FirstErr(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A second client on the same transactional ID inits fresh, taking
+	// the ID over, and commits 2 records of its own.
+	taker := newCoverClient(t, c,
+		kgo.DefaultProduceTopic(topic),
+		kgo.TransactionalID(txnID),
+	)
+	if err := taker.BeginTransaction(); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := taker.ProduceSync(ctx, kgo.StringRecord("committed")).FirstErr(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := taker.EndTransaction(ctx, kgo.TryCommit); err != nil {
+		t.Fatal(err)
+	}
+
+	consumer := newCoverClient(t, c,
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.FetchIsolationLevel(kgo.ReadCommitted()),
+		kgo.FetchMaxWait(250*time.Millisecond),
+	)
+	var got []string
+	deadline := time.After(3 * time.Second)
+	for len(got) < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("timeout: got %v, want 2 committed records", got)
+		default:
+		}
+		consumer.PollRecords(ctx, 10).EachRecord(func(r *kgo.Record) { got = append(got, string(r.Value)) })
+	}
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer shortCancel()
+	consumer.PollRecords(shortCtx, 10).EachRecord(func(r *kgo.Record) { got = append(got, string(r.Value)) })
+	if want := []string{"committed", "committed"}; !slices.Equal(got, want) {
+		t.Errorf("read_committed consumer saw %v, want %v", got, want)
 	}
 }
 

--- a/pkg/kfake/persist_test.go
+++ b/pkg/kfake/persist_test.go
@@ -1822,21 +1822,14 @@ func TestPersistCleanRestartInProgressTxn(t *testing.T) {
 			}
 		}
 
-		// Save PID/epoch for manual EndTxn after restart.
-		initReq := kmsg.NewInitProducerIDRequest()
-		txnID := "txn-clean-restart"
-		initReq.TransactionalID = &txnID
-		initReq.TransactionTimeoutMillis = 30000
-		initReq.ProducerID = -1
-		initReq.ProducerEpoch = -1
-		plainCl := newPlainClient(t, c)
-		initResp, err := initReq.RequestWith(ctx, plainCl)
-		if err != nil {
-			t.Fatal(err)
-		}
-		savedPID = initResp.ProducerID
-		savedEpoch = initResp.ProducerEpoch
-		plainCl.Close()
+		// Save PID/epoch for manual EndTxn after restart. We cannot
+		// use InitProducerID for this: a fresh init on a live
+		// transactional ID aborts its open transaction and bumps the
+		// epoch. Read the state directly in the cluster's goroutine.
+		c.admin(func() {
+			pidinf := c.pids.byTxid["txn-clean-restart"]
+			savedPID, savedEpoch = pidinf.id, pidinf.epoch
+		})
 
 		cl.Close()
 		c.Close()

--- a/pkg/kfake/txns.go
+++ b/pkg/kfake/txns.go
@@ -664,6 +664,13 @@ func (pids *pids) create(txidp *string, txTimeout int32) (int64, int16) {
 	// to avoid FNV-64 hash collisions between different txids.
 	if txidp != nil {
 		if pidinf, ok := pids.byTxid[*txidp]; ok {
+			// Abort any in-flight transaction before bumping, same
+			// as the KIP-360 path above. Leaving the old epoch's
+			// writes pending lets the next commit swallow them into
+			// its own range.
+			if pidinf.inTx {
+				pidinf.endTx(false)
+			}
 			pidinf = pids.bumpEpoch(pidinf)
 			pidinf.lastActive = time.Now()
 			return pidinf.id, pidinf.epoch


### PR DESCRIPTION
Split out of #1364 so it can land on its own. Both are kfake broker-accuracy
fixes with no kgo dependency; #1364 rebases on top.

**abort the open transaction on a transactional id re-init.** A fresh
InitProducerID on a transactional ID with an ongoing transaction left it open
while bumping the epoch. The producer id is reused across the init, so the old
epoch's writes stayed pending until the same id's next commit swallowed them
into its own range, surfacing abandoned records to read_committed consumers.
The KIP-360 init path directly above already aborts.

**reject pre-2.5 txn appends into unseen producer state.** Brokers below
KIP-360 (InitProducerID v3, Kafka 2.5) have no accept-any-first-sequence for
empty producer state: an append continuing its sequence into a log that never
saw the producer is answered UNKNOWN_PRODUCER_ID. Real 2.1 does this; kfake
pinned to 2.1 accepted the append. Transactional appends only, so idempotent-only
appends keep the 2.5+ leniency of #1281.

Each fix has a test that fails without it. Full kfake suite passes under -race
(ETL skipped); golangci-lint clean.