### PR TITLE
ci,kgo: keep the share ETL test from archiving records, and say why it hung

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -127,6 +127,9 @@ jobs:
                 KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: 1
                 KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: 1
                 KAFKA_SHARE_COORDINATOR_STATE_TOPIC_NUM_PARTITIONS: 5
+                # The share ETL test releases, bails, and kills enough that
+                # a record can hit the default limit of 5 and be archived.
+                KAFKA_GROUP_SHARE_DELIVERY_COUNT_LIMIT: 10
                 KAFKA_SASL_ENABLED_MECHANISMS: SCRAM-SHA-256
                 KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/jaas.conf"
               volumes:
@@ -152,6 +155,9 @@ jobs:
           KGO_TEST_STABLE_FETCH: true
           KGO_TEST_SCRAM_SEEDS: 127.0.0.1:9094
           KGO_TEST_SCRAM: testuser:testpass
+      - name: Dump Kafka logs
+        if: failure()
+        run: docker compose logs --no-color kafka
       - name: Cleanup
         if: always()
         run: docker compose down -v

--- a/pkg/kgo/share_test.go
+++ b/pkg/kgo/share_test.go
@@ -379,8 +379,10 @@ func TestShareGroupETL(t *testing.T) {
 	}
 
 	// Without -race, a 500k-record 2-hop share ETL finishes in 20-60s
-	// even when running alongside TestGroupETL / TestTxnEtl. 5m is
-	// generous slack.
+	// even when running alongside TestGroupETL / TestTxnEtl. 4m is
+	// generous slack and stays under CI's `go test -timeout 5m`, so a
+	// hang fails with the missing keys below instead of dying in the
+	// alarm's goroutine dump.
 	//
 	// Under -race the whole hot path (atomics, maps, channels) is
 	// instrumented and can slow full-suite execution ~10x on a single
@@ -388,7 +390,7 @@ func TestShareGroupETL(t *testing.T) {
 	// We use 19m there so this test doesn't fail in the 1-in-20 long-tail
 	// iteration. Outer `go test -timeout` must be >= 20m when running
 	// with -race.
-	testCtxTimeout := 5 * time.Minute
+	testCtxTimeout := 4 * time.Minute
 	if testIsRace {
 		testCtxTimeout = 19 * time.Minute
 	}
@@ -653,12 +655,14 @@ func TestShareGroupETL(t *testing.T) {
 		if ctx.Err() != nil {
 			lvl1.mu.Lock()
 			n1 := len(lvl1.accepted)
+			dc1 := lvl1.maxDC
 			// Collect up to 20 missing keys (at level 2) to aid
 			// debugging: on chaos failures, knowing which keys
 			// never propagated is far more useful than the raw
 			// accept count.
 			var missing []int
 			lvl2.mu.Lock()
+			dc2 := lvl2.maxDC
 			for i := range totalRecords {
 				if _, rej := lvl1.rejected[i]; rej && lvl1.accepted[i] == 0 {
 					continue
@@ -672,8 +676,8 @@ func TestShareGroupETL(t *testing.T) {
 			}
 			lvl2.mu.Unlock()
 			lvl1.mu.Unlock()
-			t.Fatalf("timed out: level 1 accepted %d, level 2 accepted %d, expected %d; first missing at level 2: %v",
-				n1, n, expected, missing)
+			t.Fatalf("timed out: level 1 accepted %d (max dc %d), level 2 accepted %d (max dc %d), expected %d; first missing at level 2: %v",
+				n1, dc1, n, dc2, expected, missing)
 		}
 		time.Sleep(500 * time.Millisecond)
 	}


### PR DESCRIPTION
TestShareGroupETL hung on master (run 33579223497) until go test's 5m alarm with every consumer long-polling and nothing logged for four minutes. Its release, bail-out, and kill churn bumps delivery counts; a record that hits the broker's default limit of 5 is archived silently, and level 2 then waits forever for a key that is never delivered. Against kfake the same churn peaks at delivery count 4. Raise the CI broker's limit to 10, the most a group may use by default.

The test's own deadline was also 5m, the same as go test's, so its missing-keys report never won the race against the alarm. Drop it to 4m and include each level's max delivery count in the report. Dump the broker log when the job fails; the compose-based job never captured it.

Audited on the way: kgo's share ack and session paths lose nothing without telling the broker (each costs one delivery count), and Kafka 4.3.1's SharePartition has no stall on the acquire, throttle, or lock-timeout paths; nothing share-related landed on the 4.3 branch after 4.3.1.
