### PR TITLE
kotel: preallocate trace attribute slices

### DIFF
--- a/plugin/kotel/tracer.go
+++ b/plugin/kotel/tracer.go
@@ -99,24 +99,99 @@ func NewTracer(opts ...TracerOpt) *Tracer {
 	return t
 }
 
-func (t *Tracer) maybeKeyAttr(attrs []attribute.KeyValue, r *kgo.Record) []attribute.KeyValue {
+func (t *Tracer) keyAttr(r *kgo.Record) (attribute.KeyValue, bool) {
 	if r.Key == nil {
-		return attrs
+		return attribute.KeyValue{}, false
 	}
-	var keykey string
 	if t.keyFormatter != nil {
-		k, err := t.keyFormatter(r)
-		if err != nil || !utf8.ValidString(k) {
-			return attrs
+		key, err := t.keyFormatter(r)
+		if err != nil || !utf8.ValidString(key) {
+			return attribute.KeyValue{}, false
 		}
-		keykey = k
-	} else {
-		if !utf8.Valid(r.Key) {
-			return attrs
-		}
-		keykey = string(r.Key)
+		return semconv.MessagingKafkaMessageKeyKey.String(key), true
 	}
-	return append(attrs, semconv.MessagingKafkaMessageKeyKey.String(keykey))
+	if !utf8.Valid(r.Key) {
+		return attribute.KeyValue{}, false
+	}
+	return semconv.MessagingKafkaMessageKeyKey.String(string(r.Key)), true
+}
+
+func (t *Tracer) publishAttrs(r *kgo.Record) []attribute.KeyValue {
+	topic := r.Topic
+	key, hasKey := t.keyAttr(r)
+	tombstone := r.Key != nil && r.Value == nil
+	n := 4
+	if hasKey {
+		n++
+	}
+	if t.clientID != "" {
+		n++
+	}
+	if tombstone {
+		n++
+	}
+
+	attrs := make([]attribute.KeyValue, 0, n)
+	attrs = append(attrs,
+		semconv.MessagingSystemKey.String("kafka"),
+		semconv.MessagingDestinationKindTopic,
+		semconv.MessagingDestinationName(topic),
+		semconv.MessagingOperationPublish,
+	)
+	if hasKey {
+		attrs = append(attrs, key)
+	}
+	if t.clientID != "" {
+		attrs = append(attrs, semconv.MessagingKafkaClientIDKey.String(t.clientID))
+	}
+	if tombstone {
+		attrs = append(attrs, semconv.MessagingKafkaMessageTombstoneKey.Bool(true))
+	}
+	return attrs
+}
+
+func (t *Tracer) consumerAttrs(r *kgo.Record, operation attribute.KeyValue) []attribute.KeyValue {
+	topic := r.Topic
+	partition := r.Partition
+	offset := r.Offset
+	key, hasKey := t.keyAttr(r)
+	tombstone := r.Key != nil && r.Value == nil
+	n := 6
+	if hasKey {
+		n++
+	}
+	if t.clientID != "" {
+		n++
+	}
+	if t.consumerGroup != "" {
+		n++
+	}
+	if tombstone {
+		n++
+	}
+
+	attrs := make([]attribute.KeyValue, 0, n)
+	attrs = append(attrs,
+		semconv.MessagingSystemKey.String("kafka"),
+		semconv.MessagingSourceKindTopic,
+		semconv.MessagingSourceName(topic),
+		operation,
+		semconv.MessagingKafkaSourcePartition(int(partition)),
+		semconv.MessagingKafkaMessageOffsetKey.Int64(offset),
+	)
+	if hasKey {
+		attrs = append(attrs, key)
+	}
+	if t.clientID != "" {
+		attrs = append(attrs, semconv.MessagingKafkaClientIDKey.String(t.clientID))
+	}
+	if t.consumerGroup != "" {
+		attrs = append(attrs, semconv.MessagingKafkaConsumerGroupKey.String(t.consumerGroup))
+	}
+	if tombstone {
+		attrs = append(attrs, semconv.MessagingKafkaMessageTombstoneKey.Bool(true))
+	}
+	return attrs
 }
 
 // WithProcessSpan starts a new span for the "process" operation on a consumer
@@ -130,24 +205,7 @@ func (t *Tracer) maybeKeyAttr(attrs []attribute.KeyValue, r *kgo.Record) []attri
 // iteration of your processing for the record.
 func (t *Tracer) WithProcessSpan(r *kgo.Record) (context.Context, trace.Span) {
 	// Set up the span options.
-	attrs := []attribute.KeyValue{
-		semconv.MessagingSystemKey.String("kafka"),
-		semconv.MessagingSourceKindTopic,
-		semconv.MessagingSourceName(r.Topic),
-		semconv.MessagingOperationProcess,
-		semconv.MessagingKafkaSourcePartition(int(r.Partition)),
-		semconv.MessagingKafkaMessageOffsetKey.Int64(r.Offset),
-	}
-	attrs = t.maybeKeyAttr(attrs, r)
-	if t.clientID != "" {
-		attrs = append(attrs, semconv.MessagingKafkaClientIDKey.String(t.clientID))
-	}
-	if t.consumerGroup != "" {
-		attrs = append(attrs, semconv.MessagingKafkaConsumerGroupKey.String(t.consumerGroup))
-	}
-	if r.Key != nil && r.Value == nil {
-		attrs = append(attrs, semconv.MessagingKafkaMessageTombstoneKey.Bool(true))
-	}
+	attrs := t.consumerAttrs(r, semconv.MessagingOperationProcess)
 	opts := []trace.SpanStartOption{
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindConsumer),
@@ -178,19 +236,7 @@ func (t *Tracer) WithProcessSpan(r *kgo.Record) (context.Context, trace.Span) {
 // hook.
 func (t *Tracer) OnProduceRecordBuffered(r *kgo.Record) {
 	// Set up span options.
-	attrs := []attribute.KeyValue{
-		semconv.MessagingSystemKey.String("kafka"),
-		semconv.MessagingDestinationKindTopic,
-		semconv.MessagingDestinationName(r.Topic),
-		semconv.MessagingOperationPublish,
-	}
-	attrs = t.maybeKeyAttr(attrs, r)
-	if t.clientID != "" {
-		attrs = append(attrs, semconv.MessagingKafkaClientIDKey.String(t.clientID))
-	}
-	if r.Key != nil && r.Value == nil {
-		attrs = append(attrs, semconv.MessagingKafkaMessageTombstoneKey.Bool(true))
-	}
+	attrs := t.publishAttrs(r)
 	opts := []trace.SpanStartOption{
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindProducer),
@@ -230,24 +276,7 @@ func (t *Tracer) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 // processing.
 func (t *Tracer) OnFetchRecordBuffered(r *kgo.Record) {
 	// Set up the span options.
-	attrs := []attribute.KeyValue{
-		semconv.MessagingSystemKey.String("kafka"),
-		semconv.MessagingSourceKindTopic,
-		semconv.MessagingSourceName(r.Topic),
-		semconv.MessagingOperationReceive,
-		semconv.MessagingKafkaSourcePartition(int(r.Partition)),
-		semconv.MessagingKafkaMessageOffsetKey.Int64(r.Offset),
-	}
-	attrs = t.maybeKeyAttr(attrs, r)
-	if t.clientID != "" {
-		attrs = append(attrs, semconv.MessagingKafkaClientIDKey.String(t.clientID))
-	}
-	if t.consumerGroup != "" {
-		attrs = append(attrs, semconv.MessagingKafkaConsumerGroupKey.String(t.consumerGroup))
-	}
-	if r.Key != nil && r.Value == nil {
-		attrs = append(attrs, semconv.MessagingKafkaMessageTombstoneKey.Bool(true))
-	}
+	attrs := t.consumerAttrs(r, semconv.MessagingOperationReceive)
 	opts := []trace.SpanStartOption{
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindConsumer),

--- a/plugin/kotel/tracer_test.go
+++ b/plugin/kotel/tracer_test.go
@@ -1,13 +1,19 @@
 package kotel
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 func TestNewTracer(t *testing.T) {
@@ -58,4 +64,168 @@ func TestNewTracer(t *testing.T) {
 			assert.Equal(t, tc.want, result)
 		})
 	}
+}
+
+func TestTracerKeyAttr(t *testing.T) {
+	errKey := errors.New("format key")
+	tests := []struct {
+		name      string
+		key       []byte
+		formatter func(*kgo.Record) (string, error)
+		want      attribute.KeyValue
+		wantOK    bool
+	}{
+		{name: "nil"},
+		{
+			name:   "valid",
+			key:    []byte("key"),
+			want:   semconv.MessagingKafkaMessageKeyKey.String("key"),
+			wantOK: true,
+		},
+		{name: "invalid UTF-8", key: []byte{0xff}},
+		{
+			name: "formatted",
+			key:  []byte{0xff},
+			formatter: func(*kgo.Record) (string, error) {
+				return "formatted", nil
+			},
+			want:   semconv.MessagingKafkaMessageKeyKey.String("formatted"),
+			wantOK: true,
+		},
+		{
+			name: "formatter error",
+			key:  []byte("key"),
+			formatter: func(*kgo.Record) (string, error) {
+				return "", errKey
+			},
+		},
+		{
+			name: "formatter invalid UTF-8",
+			key:  []byte("key"),
+			formatter: func(*kgo.Record) (string, error) {
+				return "\xff", nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tracer := &Tracer{keyFormatter: test.formatter}
+			got, ok := tracer.keyAttr(&kgo.Record{Key: test.key})
+			assert.Equal(t, test.wantOK, ok)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestTracerAttributeBuilders(t *testing.T) {
+	tracer := &Tracer{clientID: "client", consumerGroup: "group"}
+	record := &kgo.Record{
+		Topic:     "orders",
+		Partition: 3,
+		Offset:    42,
+		Key:       []byte("key"),
+	}
+
+	t.Run("publish", func(t *testing.T) {
+		got := tracer.publishAttrs(record)
+		want := []attribute.KeyValue{
+			semconv.MessagingSystemKey.String("kafka"),
+			semconv.MessagingDestinationKindTopic,
+			semconv.MessagingDestinationName("orders"),
+			semconv.MessagingOperationPublish,
+			semconv.MessagingKafkaMessageKeyKey.String("key"),
+			semconv.MessagingKafkaClientIDKey.String("client"),
+			semconv.MessagingKafkaMessageTombstoneKey.Bool(true),
+		}
+		assert.Equal(t, want, got)
+		assert.Equal(t, len(got), cap(got))
+	})
+
+	t.Run("consumer", func(t *testing.T) {
+		got := tracer.consumerAttrs(record, semconv.MessagingOperationReceive)
+		want := []attribute.KeyValue{
+			semconv.MessagingSystemKey.String("kafka"),
+			semconv.MessagingSourceKindTopic,
+			semconv.MessagingSourceName("orders"),
+			semconv.MessagingOperationReceive,
+			semconv.MessagingKafkaSourcePartition(3),
+			semconv.MessagingKafkaMessageOffsetKey.Int64(42),
+			semconv.MessagingKafkaMessageKeyKey.String("key"),
+			semconv.MessagingKafkaClientIDKey.String("client"),
+			semconv.MessagingKafkaConsumerGroupKey.String("group"),
+			semconv.MessagingKafkaMessageTombstoneKey.Bool(true),
+		}
+		assert.Equal(t, want, got)
+		assert.Equal(t, len(got), cap(got))
+	})
+
+	t.Run("preserves formatter evaluation order", func(t *testing.T) {
+		calls := 0
+		tracer := &Tracer{keyFormatter: func(r *kgo.Record) (string, error) {
+			calls++
+			r.Topic = "changed"
+			return "", errors.New("format key")
+		}}
+		got := tracer.publishAttrs(&kgo.Record{Topic: "orders", Key: []byte("key"), Value: []byte("value")})
+		want := []attribute.KeyValue{
+			semconv.MessagingSystemKey.String("kafka"),
+			semconv.MessagingDestinationKindTopic,
+			semconv.MessagingDestinationName("orders"),
+			semconv.MessagingOperationPublish,
+		}
+		assert.Equal(t, want, got)
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, len(got), cap(got))
+	})
+}
+
+func BenchmarkTracerRecordLifecycle(b *testing.B) {
+	tracer := NewTracer(
+		TracerProvider(tracenoop.NewTracerProvider()),
+		TracerPropagator(propagation.TraceContext{}),
+		ClientID("benchmark-client"),
+		ConsumerGroup("benchmark-group"),
+	)
+	key := []byte("customer-1234567890")
+
+	b.Run("produce", func(b *testing.B) {
+		record := &kgo.Record{Topic: "orders", Key: key, Value: []byte("value")}
+		b.ReportAllocs()
+		for b.Loop() {
+			record.Context = context.Background()
+			tracer.OnProduceRecordBuffered(record)
+			tracer.OnProduceRecordUnbuffered(record, nil)
+		}
+	})
+
+	b.Run("fetch", func(b *testing.B) {
+		record := &kgo.Record{
+			Topic:     "orders",
+			Partition: 3,
+			Offset:    42,
+			Key:       key,
+			Value:     []byte("value"),
+			Headers: []kgo.RecordHeader{{
+				Key:   "traceparent",
+				Value: []byte("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"),
+			}},
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			record.Context = context.Background()
+			tracer.OnFetchRecordBuffered(record)
+			tracer.OnFetchRecordUnbuffered(record, true)
+		}
+	})
+
+	b.Run("process", func(b *testing.B) {
+		record := &kgo.Record{Topic: "orders", Partition: 3, Offset: 42, Key: key, Value: []byte("value")}
+		b.ReportAllocs()
+		for b.Loop() {
+			record.Context = context.Background()
+			_, span := tracer.WithProcessSpan(record)
+			span.End()
+		}
+	})
 }


### PR DESCRIPTION
The trace hooks build their fixed attributes in a slice with no spare capacity, then append optional attributes. The first append allocates a larger backing array and copies the slice.

This change preallocates the required capacity and shares attribute construction between receive and process. The API and emitted telemetry are unchanged.

These benchmarks use a no-op tracer provider, a 19-byte key, a client ID, and a consumer group:

| Path | Before | After |
|---|---:|---:|
| Produce | 1,056 B/op, 9 allocs/op | 672 B/op, 8 allocs/op |
| Fetch | 1,584 B/op, 10 allocs/op | 944 B/op, 9 allocs/op |
| Process | 1,440 B/op, 8 allocs/op | 800 B/op, 7 allocs/op |

A ten-minute randomized A/B test against a local Kafka broker ran 243 pairs. Each run produced and consumed 20,000 records using `AlwaysSample` and a `BatchSpanProcessor`. The change allocated about 20.5 MB less and made about 40,000 fewer allocations per run. Median paired elapsed time was 1.75% lower, although timing will vary by workload.
