### PR TITLE
kfake: fetch fidelity around topic recreation

### DIFF
--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -94,6 +94,12 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		fetchOffset  int64
 		maxBytes     int32
 		currentEpoch int32
+		// staleID marks a session entry whose topic ID no longer
+		// resolves while its cached name still does: the topic was
+		// recreated under that name. Kafka resolves a session entry's
+		// name once, at insertion, so the entry reaches the log by
+		// name and fails the ID check there.
+		staleID bool
 	}
 	var toFetch []fetchPartition
 
@@ -131,14 +137,18 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		for key, sp := range session.partitions {
 			if !inRequest[key] {
 				topic := key.t
+				var staleID bool
 				if sp.topicID != (uuid{}) {
 					// v13+ entries are addressed by the ID they
-					// were added with: if it no longer resolves
-					// (deleted, or recreated with a new ID), the
-					// lookups below miss and the entry answers
-					// UNKNOWN_TOPIC_ID with the stored ID, like a
-					// real broker. It never re-addresses by name.
-					topic = c.data.id2t[sp.topicID]
+					// were added with. If it no longer resolves,
+					// the entry keeps the name it was inserted
+					// under, like a real broker: a deleted topic
+					// answers UNKNOWN_TOPIC_ID, a recreated one
+					// INCONSISTENT_TOPIC_ID from a broker hosting
+					// the new incarnation.
+					if _, ok := c.data.id2t[sp.topicID]; !ok {
+						staleID = true
+					}
 				}
 				toFetch = append(toFetch, fetchPartition{
 					topic:        topic,
@@ -147,6 +157,7 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 					fetchOffset:  sp.fetchOffset,
 					maxBytes:     sp.maxBytes,
 					currentEpoch: sp.currentEpoch,
+					staleID:      staleID,
 				})
 			}
 		}
@@ -164,6 +175,10 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		// on data hold the request for MaxWait.
 	out:
 		for _, fp := range toFetch {
+			if fp.staleID {
+				returnEarly = true // InconsistentTopicID or UnknownTopicID
+				break out
+			}
 			t, ok := c.data.tps.gett(fp.topic)
 			if !ok {
 				returnEarly = true // UnknownTopicID or UnknownTopicOrPartition
@@ -308,6 +323,18 @@ full:
 				donep(fp.topic, fp.topicID, fp.partition, kerr.UnknownTopicID.Code)
 			} else {
 				donep(fp.topic, fp.topicID, fp.partition, kerr.UnknownTopicOrPartition.Code)
+			}
+			continue
+		}
+		if fp.staleID {
+			// The session entry's name now belongs to a new
+			// incarnation. A broker hosting it rejects the stale ID
+			// as inconsistent; one that does not is simply not the
+			// leader.
+			if pd.leader != creq.cc.b && !slices.Contains(pd.followers, creq.cc.b.node) {
+				donep(fp.topic, fp.topicID, fp.partition, kerr.NotLeaderForPartition.Code)
+			} else {
+				donep(fp.topic, fp.topicID, fp.partition, kerr.InconsistentTopicID.Code)
 			}
 			continue
 		}

--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -159,18 +159,27 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		needp         tps[int]
 	)
 	if w == nil {
+		// Any partition that errors completes the fetch at once, as a
+		// real broker's fetch purgatory does; only partitions waiting
+		// on data hold the request for MaxWait.
 	out:
 		for _, fp := range toFetch {
 			t, ok := c.data.tps.gett(fp.topic)
 			if !ok {
-				continue
+				returnEarly = true // UnknownTopicID or UnknownTopicOrPartition
+				break out
 			}
 			pd, ok := t[fp.partition]
 			if !ok {
-				continue
+				returnEarly = true // UnknownTopicID or UnknownTopicOrPartition
+				break out
 			}
 			if pd.leader != creq.cc.b && !slices.Contains(pd.followers, creq.cc.b.node) {
 				returnEarly = true // NotLeaderForPartition
+				break out
+			}
+			if le := fp.currentEpoch; le != -1 && le != pd.epoch {
+				returnEarly = true // FencedLeaderEpoch or UnknownLeaderEpoch
 				break out
 			}
 			segIdx, metaIdx, ok, atEnd := pd.searchOffset(fp.fetchOffset)

--- a/pkg/kfake/fetch_recreation_test.go
+++ b/pkg/kfake/fetch_recreation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -34,6 +35,36 @@ func fetchByID(sessionID, sessionEpoch, maxWait int32, id [16]byte, partitions .
 	return req
 }
 
+func recreateTopicRaw(t *testing.T, cl *kgo.Client, topic string) {
+	t.Helper()
+	ctx := context.Background()
+	del := kmsg.NewPtrDeleteTopicsRequest()
+	del.TopicNames = []string{topic}
+	dt := kmsg.NewDeleteTopicsRequestTopic()
+	dt.Topic = kmsg.StringPtr(topic)
+	del.Topics = append(del.Topics, dt)
+	dresp, err := del.RequestWith(ctx, cl)
+	if err == nil {
+		err = kerr.ErrorForCode(dresp.Topics[0].ErrorCode)
+	}
+	if err != nil {
+		t.Fatalf("delete topic: %v", err)
+	}
+	cr := kmsg.NewPtrCreateTopicsRequest()
+	ct := kmsg.NewCreateTopicsRequestTopic()
+	ct.Topic = topic
+	ct.NumPartitions = 1
+	ct.ReplicationFactor = 1
+	cr.Topics = append(cr.Topics, ct)
+	cresp, err := cr.RequestWith(ctx, cl)
+	if err == nil {
+		err = kerr.ErrorForCode(cresp.Topics[0].ErrorCode)
+	}
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+}
+
 // A fetch with a partition that errors completes at once, like a real
 // broker's fetch purgatory, rather than holding the request for MaxWait.
 func TestFetchPartitionErrorCompletesImmediately(t *testing.T) {
@@ -58,5 +89,57 @@ func TestFetchPartitionErrorCompletesImmediately(t *testing.T) {
 	}
 	if ec := resp.Topics[0].Partitions[0].ErrorCode; ec != kerr.UnknownTopicID.Code {
 		t.Errorf("got %v; want UNKNOWN_TOPIC_ID", kerr.ErrorForCode(ec))
+	}
+}
+
+// A session entry keeps the name it was inserted under. After the topic is
+// recreated, an incremental fetch that leaves the entry to the session is
+// rejected as INCONSISTENT_TOPIC_ID by the broker hosting the new
+// incarnation, while a full fetch by the old ID is UNKNOWN_TOPIC_ID, as on a
+// real broker.
+func TestFetchSessionRecreatedTopic(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	ctx := context.Background()
+
+	oldID := c.TopicInfo(topic).TopicID
+	first, err := fetchByID(0, 0, 100, oldID, 0).RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ErrorCode != 0 || first.SessionID <= 0 {
+		t.Fatalf("session not established: err %v, session %d", kerr.ErrorForCode(first.ErrorCode), first.SessionID)
+	}
+
+	recreateTopicRaw(t, cl, topic)
+	if c.TopicInfo(topic).TopicID == oldID {
+		t.Fatal("recreation kept the topic ID")
+	}
+
+	incr, err := fetchByID(first.SessionID, 1, 100, oldID).RequestWith(ctx, cl) // no topics: the session's entry answers
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incr.ErrorCode != 0 || len(incr.Topics) != 1 || len(incr.Topics[0].Partitions) != 1 {
+		t.Fatalf("unexpected incremental response: err %v, topics %+v", kerr.ErrorForCode(incr.ErrorCode), incr.Topics)
+	}
+	if got := incr.Topics[0].TopicID; got != oldID {
+		t.Errorf("incremental response addressed %x; want the session's stale ID %x", got, oldID)
+	}
+	if ec := incr.Topics[0].Partitions[0].ErrorCode; ec != kerr.InconsistentTopicID.Code {
+		t.Errorf("incremental fetch got %v; want INCONSISTENT_TOPIC_ID", kerr.ErrorForCode(ec))
+	}
+
+	full, err := fetchByID(0, 0, 100, oldID, 0).RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(full.Topics) != 1 || len(full.Topics[0].Partitions) != 1 {
+		t.Fatalf("unexpected full response: %+v", full.Topics)
+	}
+	if ec := full.Topics[0].Partitions[0].ErrorCode; ec != kerr.UnknownTopicID.Code {
+		t.Errorf("full fetch got %v; want UNKNOWN_TOPIC_ID", kerr.ErrorForCode(ec))
 	}
 }

--- a/pkg/kfake/fetch_recreation_test.go
+++ b/pkg/kfake/fetch_recreation_test.go
@@ -1,0 +1,62 @@
+package kfake_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// fetchByID builds a topic-ID addressed fetch (the client negotiates v13+).
+func fetchByID(sessionID, sessionEpoch, maxWait int32, id [16]byte, partitions ...int32) *kmsg.FetchRequest {
+	req := kmsg.NewPtrFetchRequest()
+	req.MaxWaitMillis = maxWait
+	req.MinBytes = 1
+	req.MaxBytes = 1 << 20
+	req.SessionID = sessionID
+	req.SessionEpoch = sessionEpoch
+	if len(partitions) > 0 {
+		ft := kmsg.NewFetchRequestTopic()
+		ft.TopicID = id
+		for _, p := range partitions {
+			fp := kmsg.NewFetchRequestTopicPartition()
+			fp.Partition = p
+			fp.FetchOffset = 0
+			fp.PartitionMaxBytes = 1 << 20
+			fp.CurrentLeaderEpoch = -1
+			ft.Partitions = append(ft.Partitions, fp)
+		}
+		req.Topics = append(req.Topics, ft)
+	}
+	return req
+}
+
+// A fetch with a partition that errors completes at once, like a real
+// broker's fetch purgatory, rather than holding the request for MaxWait.
+func TestFetchPartitionErrorCompletesImmediately(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	ctx := context.Background()
+
+	unknown := c.TopicInfo(topic).TopicID
+	unknown[0]++
+	start := time.Now()
+	resp, err := fetchByID(0, 0, 5000, unknown, 0).RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("fetch of an unknown topic ID took %v; want an immediate completion", elapsed)
+	}
+	if len(resp.Topics) != 1 || len(resp.Topics[0].Partitions) != 1 {
+		t.Fatalf("unexpected response shape: %+v", resp.Topics)
+	}
+	if ec := resp.Topics[0].Partitions[0].ErrorCode; ec != kerr.UnknownTopicID.Code {
+		t.Errorf("got %v; want UNKNOWN_TOPIC_ID", kerr.ErrorForCode(ec))
+	}
+}


### PR DESCRIPTION
Two fidelity fixes in kfake's fetch handling, found while testing kgo's topic recreation handling against it.

* A fetch completes as soon as any partition errors, as a real broker's fetch purgatory does. kfake held the request for the full MaxWait whenever an unknown topic or partition, or a leader epoch mismatch, was the only thing in it, which skews any test that measures how a client paces its retries after a rejection.
* An established fetch session's entry keeps the name it was inserted under, as Kafka does. After the topic is recreated under that name, an incremental fetch that leaves the entry to the session gets INCONSISTENT_TOPIC_ID from a broker hosting the new incarnation (NOT_LEADER_OR_FOLLOWER from one that does not); only a full fetch gets UNKNOWN_TOPIC_ID. kfake answered UNKNOWN_TOPIC_ID for all three.

Both come with tests. The whole kfake package passes under -race.