### PR TITLE
kfake: per-partition fault injection

### DIFF
--- a/pkg/kfake/00_produce.go
+++ b/pkg/kfake/00_produce.go
@@ -95,6 +95,7 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 		return toresp(), nil
 	}
 
+	fc := c.faultsFor(creq)
 	now := time.Now().UnixMilli()
 	for _, rt := range req.Topics {
 		if req.Version >= 13 {
@@ -111,6 +112,10 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 		}
 		maxMessageBytes := c.data.maxMessageBytes(rt.Topic)
 		for _, rp := range rt.Partitions {
+			if e := fc.err(rt.Topic, rt.TopicID, rp.Partition); e != nil {
+				donep(rt, rp, e.Code, e.Message)
+				continue
+			}
 			pd, ok := c.data.tps.getp(rt.Topic, rp.Partition)
 			if !ok {
 				donep(rt, rp, kerr.UnknownTopicOrPartition.Code, "Unknown topic or partition.")

--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -168,6 +168,7 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		nbytes        int
 		returnEarly   bool
 		needp         tps[int]
+		fc            = c.faultsFor(creq)
 	)
 	if w == nil {
 		// Any partition that errors completes the fetch at once, as a
@@ -175,6 +176,10 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		// on data hold the request for MaxWait.
 	out:
 		for _, fp := range toFetch {
+			if fc.err(fp.topic, fp.topicID, fp.partition) != nil {
+				returnEarly = true // the fault's error
+				break out
+			}
 			if fp.staleID {
 				returnEarly = true // InconsistentTopicID or UnknownTopicID
 				break out
@@ -313,6 +318,10 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 	nbytes = 0
 full:
 	for _, fp := range toFetch {
+		if e := fc.err(fp.topic, fp.topicID, fp.partition); e != nil {
+			donep(fp.topic, fp.topicID, fp.partition, e.Code)
+			continue
+		}
 		if !c.allowedACL(creq, fp.topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
 			donep(fp.topic, fp.topicID, fp.partition, kerr.TopicAuthorizationFailed.Code)
 			continue

--- a/pkg/kfake/02_list_offsets.go
+++ b/pkg/kfake/02_list_offsets.go
@@ -54,6 +54,7 @@ func (c *Cluster) handleListOffsets(creq *clientReq) (kmsg.Response, error) {
 		return &st.Partitions[len(st.Partitions)-1]
 	}
 
+	fc := c.faultsFor(creq)
 	for _, rt := range req.Topics {
 		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
 			for _, rp := range rt.Partitions {
@@ -63,6 +64,10 @@ func (c *Cluster) handleListOffsets(creq *clientReq) (kmsg.Response, error) {
 		}
 		ps, ok := c.data.tps.gett(rt.Topic)
 		for _, rp := range rt.Partitions {
+			if e := fc.err(rt.Topic, noID, rp.Partition); e != nil {
+				donep(rt.Topic, rp.Partition, e.Code)
+				continue
+			}
 			if !ok {
 				donep(rt.Topic, rp.Partition, kerr.UnknownTopicOrPartition.Code)
 				continue

--- a/pkg/kfake/23_offset_for_leader_epoch.go
+++ b/pkg/kfake/23_offset_for_leader_epoch.go
@@ -49,6 +49,7 @@ func (c *Cluster) handleOffsetForLeaderEpoch(creq *clientReq) (kmsg.Response, er
 		return &st.Partitions[len(st.Partitions)-1]
 	}
 
+	fc := c.faultsFor(creq)
 	for _, rt := range req.Topics {
 		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
 			for _, rp := range rt.Partitions {
@@ -58,6 +59,10 @@ func (c *Cluster) handleOffsetForLeaderEpoch(creq *clientReq) (kmsg.Response, er
 		}
 		ps, ok := c.data.tps.gett(rt.Topic)
 		for _, rp := range rt.Partitions {
+			if e := fc.err(rt.Topic, noID, rp.Partition); e != nil {
+				donep(rt.Topic, rp.Partition, e.Code)
+				continue
+			}
 			if req.ReplicaID >= 0 {
 				donep(rt.Topic, rp.Partition, kerr.UnknownServerError.Code)
 				continue

--- a/pkg/kfake/78_share_fetch.go
+++ b/pkg/kfake/78_share_fetch.go
@@ -48,6 +48,7 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 	}
 
 	resp.AcquisitionLockTimeoutMillis = c.shareRecordLockDurationMs()
+	fc := c.faultsFor(creq)
 
 	// ACL: require GROUP READ.
 	if !c.allowedACL(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
@@ -164,7 +165,7 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 		if sg != nil {
 			ackTs := ackTopicsFromFetch(req.Topics)
 			sg.mu.Lock()
-			toFire := sg.processShareAcks(creq, memberID, ackTs, maxAckType, id2t, maxDelivery, onAck, onAckNotLeader)
+			toFire := sg.processShareAcks(creq, fc, memberID, ackTs, maxAckType, id2t, maxDelivery, onAck, onAckNotLeader)
 			released := sg.releaseRecordsForSessionLocked(memberID, session, id2t, maxDelivery)
 			sg.mu.Unlock()
 			ensureAckedParts(resp, ackTs, addTopic)
@@ -214,7 +215,7 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 		if w == nil {
 			ackTs := ackTopicsFromFetch(req.Topics)
 			sg.mu.Lock()
-			toFire = sg.processShareAcks(creq, memberID, ackTs, maxAckType, id2t, maxDelivery, onAck, onAckNotLeader)
+			toFire = sg.processShareAcks(creq, fc, memberID, ackTs, maxAckType, id2t, maxDelivery, onAck, onAckNotLeader)
 			sg.mu.Unlock()
 			ensureAckedParts(resp, ackTs, addTopic)
 		}
@@ -274,7 +275,7 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 	// Process piggybacked acks first (skipped on watcher re-invocation,
 	// since acks were already processed in the initial call).
 	if len(ackTs) > 0 {
-		toFire = sg.processShareAcks(creq, memberID, ackTs, maxAckType, id2t, maxDelivery, onAck, onAckNotLeader)
+		toFire = sg.processShareAcks(creq, fc, memberID, ackTs, maxAckType, id2t, maxDelivery, onAck, onAckNotLeader)
 	}
 
 	// Build target list from session partitions.
@@ -293,6 +294,10 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 			continue
 		}
 		for p := range parts {
+			if e := fc.err(topicName, topicID, p); e != nil {
+				donep(topicID, p, e.Code)
+				continue
+			}
 			pd, ok := c.data.tps.getp(topicName, p)
 			if !ok {
 				donep(topicID, p, kerr.UnknownTopicOrPartition.Code)
@@ -445,7 +450,7 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 	// fireShareWatchers fires when acks free the window, so the watcher
 	// wakes up promptly instead of the client busy-looping with empty
 	// fetches.
-	if totalRecords == 0 && w == nil {
+	if totalRecords == 0 && w == nil && !fc.fired() {
 		wait := time.Duration(req.MaxWaitMillis) * time.Millisecond
 		deadline := creq.at.Add(wait)
 		remaining := time.Until(deadline)

--- a/pkg/kfake/79_share_acknowledge.go
+++ b/pkg/kfake/79_share_acknowledge.go
@@ -30,6 +30,7 @@ func (c *Cluster) handleShareAcknowledge(creq *clientReq) (kmsg.Response, error)
 	}
 
 	resp.AcquisitionLockTimeoutMillis = c.shareRecordLockDurationMs()
+	fc := c.faultsFor(creq)
 
 	var groupID, memberID string
 	if req.GroupID != nil {
@@ -118,7 +119,7 @@ func (c *Cluster) handleShareAcknowledge(creq *clientReq) (kmsg.Response, error)
 		}
 		ackTs := ackTopicsFromAcknowledge(req.Topics)
 		sg.mu.Lock()
-		toFire := sg.processShareAcks(creq, memberID, ackTs, maxAckType, id2t, maxDelivery, onPartition, onNotLeader)
+		toFire := sg.processShareAcks(creq, fc, memberID, ackTs, maxAckType, id2t, maxDelivery, onPartition, onNotLeader)
 		released := sg.releaseRecordsForSessionLocked(memberID, session, id2t, maxDelivery)
 		sg.mu.Unlock()
 		fireAll(toFire)
@@ -147,7 +148,7 @@ func (c *Cluster) handleShareAcknowledge(creq *clientReq) (kmsg.Response, error)
 
 	ackTs := ackTopicsFromAcknowledge(req.Topics)
 	sg.mu.Lock()
-	toFire := sg.processShareAcks(creq, memberID, ackTs, maxAckType, id2t, maxDelivery, onPartition, onNotLeader)
+	toFire := sg.processShareAcks(creq, fc, memberID, ackTs, maxAckType, id2t, maxDelivery, onPartition, onNotLeader)
 	sg.mu.Unlock()
 	fireAll(toFire)
 

--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -38,6 +38,9 @@ type (
 		sleeping       map[*clientConn]*bsleep
 		controlSleep   chan sleepChs
 
+		faultsMu sync.Mutex
+		faults   []*fault
+
 		data               data
 		pids               pids
 		groups             groups

--- a/pkg/kfake/consumer_sweep_test.go
+++ b/pkg/kfake/consumer_sweep_test.go
@@ -15,34 +15,19 @@ import (
 // Regression tests for consumer.go + consumer_direct.go. Each TestAudit*
 // below fails before its corresponding kgo fix.
 
-// fenceNextFetch installs a control that answers exactly one fetch request
-// with FENCED_LEADER_EPOCH for partition 0 of the topic. The client reacts by
-// marking the cursor unusable and queueing an OffsetForLeaderEpoch validation
-// at the cursor's current offset - the validation load's completion is the
-// only thing that re-enables the cursor.
+// fenceNextFetch fails exactly one fetch of partition 0 of the topic with
+// FENCED_LEADER_EPOCH. The client reacts by marking the cursor unusable and
+// queueing an OffsetForLeaderEpoch validation at the cursor's current offset -
+// the validation load's completion is the only thing that re-enables the
+// cursor.
 func fenceNextFetch(c *Cluster, topic string) {
-	ti := c.TopicInfo(topic)
-	pi := c.PartitionInfo(topic, 0)
-	var fenced atomic.Bool
-	c.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		c.KeepControl()
-		if fenced.Swap(true) {
-			return nil, nil, false // already fenced once; serve real data
-		}
-		req := kreq.(*kmsg.FetchRequest)
-		resp := req.ResponseKind().(*kmsg.FetchResponse)
-		rt := kmsg.NewFetchResponseTopic()
-		rt.Topic = topic
-		rt.TopicID = ti.TopicID
-		rp := kmsg.NewFetchResponseTopicPartition()
-		rp.Partition = 0
-		rp.ErrorCode = kerr.FencedLeaderEpoch.Code
-		rp.HighWatermark = pi.HighWatermark
-		rp.LastStableOffset = pi.LastStableOffset
-		rp.LogStartOffset = 0
-		rt.Partitions = append(rt.Partitions, rp)
-		resp.Topics = append(resp.Topics, rt)
-		return resp, nil, true
+	c.AddFault(Fault{
+		Keys:      []int16{int16(kmsg.Fetch)},
+		Node:      -1,
+		Topic:     topic,
+		Partition: 0,
+		Err:       kerr.FencedLeaderEpoch,
+		Count:     1,
 	})
 }
 

--- a/pkg/kfake/fault_test.go
+++ b/pkg/kfake/fault_test.go
@@ -1,0 +1,282 @@
+package kfake_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// fetchIDs builds a fetch addressing partition 0 of every topic ID, outside
+// any fetch session.
+func fetchIDs(maxWait int32, ids ...[16]byte) *kmsg.FetchRequest {
+	req := kmsg.NewPtrFetchRequest()
+	req.MaxWaitMillis = maxWait
+	req.MinBytes = 1
+	req.MaxBytes = 1 << 20
+	req.SessionEpoch = -1
+	for _, id := range ids {
+		ft := kmsg.NewFetchRequestTopic()
+		ft.TopicID = id
+		fp := kmsg.NewFetchRequestTopicPartition()
+		fp.Partition = 0
+		fp.FetchOffset = 0
+		fp.PartitionMaxBytes = 1 << 20
+		fp.CurrentLeaderEpoch = -1
+		ft.Partitions = append(ft.Partitions, fp)
+		req.Topics = append(req.Topics, ft)
+	}
+	return req
+}
+
+func fetchIDsAt(t *testing.T, cl *kgo.Client, node int32, req *kmsg.FetchRequest) *kmsg.FetchResponse {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	kresp, err := cl.Broker(int(node)).RetriableRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	return kresp.(*kmsg.FetchResponse)
+}
+
+func fetchPart(t *testing.T, resp *kmsg.FetchResponse, id [16]byte) kmsg.FetchResponseTopicPartition {
+	t.Helper()
+	for _, st := range resp.Topics {
+		if st.TopicID == id && len(st.Partitions) == 1 {
+			return st.Partitions[0]
+		}
+	}
+	t.Fatalf("topic ID %x missing from fetch response", id)
+	return kmsg.FetchResponseTopicPartition{}
+}
+
+// listOffsetsAt lists the latest offset of one partition at one node and
+// returns the partition's error code.
+func listOffsetsAt(t *testing.T, cl *kgo.Client, node int32, topic string, partition int32) int16 {
+	t.Helper()
+	req := kmsg.NewPtrListOffsetsRequest()
+	rt := kmsg.NewListOffsetsRequestTopic()
+	rt.Topic = topic
+	rp := kmsg.NewListOffsetsRequestTopicPartition()
+	rp.Partition = partition
+	rp.Timestamp = -1
+	rp.CurrentLeaderEpoch = -1
+	rt.Partitions = append(rt.Partitions, rp)
+	req.Topics = append(req.Topics, rt)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	kresp, err := cl.Broker(int(node)).RetriableRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("list offsets: %v", err)
+	}
+	resp := kresp.(*kmsg.ListOffsetsResponse)
+	if len(resp.Topics) != 1 || len(resp.Topics[0].Partitions) != 1 {
+		t.Fatalf("list offsets answered %d topics, want one topic with one partition", len(resp.Topics))
+	}
+	return resp.Topics[0].Partitions[0].ErrorCode
+}
+
+// A fault with a request budget fails a producer until the budget runs out,
+// and the record lands once.
+func TestFaultProduceCount(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic))
+	// An unknown topic error parks the batch until metadata reloads, so
+	// the retries only come as fast as we allow metadata to.
+	cl := newPlainClient(t, c,
+		kgo.RetryBackoffFn(func(int) time.Duration { return 50 * time.Millisecond }),
+		kgo.UnknownTopicRetries(10),
+		kgo.MetadataMinAge(100*time.Millisecond),
+	)
+
+	h := c.AddFault(kfake.Fault{
+		Node:      -1,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.UnknownTopicOrPartition,
+		Count:     2,
+	})
+	produceSync(t, cl, &kgo.Record{Topic: topic, Value: []byte("v")})
+
+	if n := h.Fired(); n != 2 {
+		t.Errorf("fault fired %d times != 2", n)
+	}
+	if i := c.PartitionInfo(topic, 0); i.HighWatermark != 1 {
+		t.Errorf("high watermark %d != 1", i.HighWatermark)
+	}
+	h.Remove() // removing an exhausted fault is fine
+	if n := h.Fired(); n != 2 {
+		t.Errorf("fault fired %d times after removal != 2", n)
+	}
+}
+
+// A fault on one topic ID fails only that topic; the rest of the fetch is
+// answered normally and at once.
+func TestFaultFetchByTopicID(t *testing.T) {
+	t.Parallel()
+	const topic, other = "t", "other"
+	c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic, other))
+	recreateTopicRaw(t, newPlainClient(t, c), topic)
+	cl := newPlainClient(t, c)
+
+	id := c.TopicInfo(topic).TopicID
+	otherID := c.TopicInfo(other).TopicID
+	produceSync(t, cl,
+		&kgo.Record{Topic: topic, Value: []byte("v")},
+		&kgo.Record{Topic: other, Value: []byte("v")},
+	)
+
+	h := c.AddFault(kfake.Fault{
+		Node:      -1,
+		TopicID:   id,
+		Partition: -1,
+		Err:       kerr.UnknownTopicID,
+		Count:     3,
+	})
+	for i := range 3 {
+		start := time.Now()
+		resp := fetchIDsAt(t, cl, 0, fetchIDs(30000, id, otherID))
+		if p := fetchPart(t, resp, id); p.ErrorCode != kerr.UnknownTopicID.Code {
+			t.Fatalf("fetch %d: faulted partition answered %d != %d", i, p.ErrorCode, kerr.UnknownTopicID.Code)
+		}
+		if p := fetchPart(t, resp, otherID); p.ErrorCode != 0 || len(p.RecordBatches) == 0 {
+			t.Fatalf("fetch %d: unfaulted partition answered %d with %d record bytes", i, p.ErrorCode, len(p.RecordBatches))
+		}
+		if took := time.Since(start); took > 5*time.Second {
+			t.Fatalf("fetch %d took %s: a faulted partition must not wait out MaxWait", i, took)
+		}
+	}
+	if n := h.Fired(); n != 3 {
+		t.Errorf("fault fired %d times != 3", n)
+	}
+
+	resp := fetchIDsAt(t, cl, 0, fetchIDs(30000, id, otherID))
+	if p := fetchPart(t, resp, id); p.ErrorCode != 0 || len(p.RecordBatches) == 0 {
+		t.Errorf("exhausted fault still failing: %d with %d record bytes", p.ErrorCode, len(p.RecordBatches))
+	}
+	if n := h.Fired(); n != 3 {
+		t.Errorf("fault fired %d times after exhaustion != 3", n)
+	}
+}
+
+// Keys restricts a fault to one request kind.
+func TestFaultKeys(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	produceSync(t, cl, &kgo.Record{Topic: topic, Value: []byte("v")})
+
+	h := c.AddFault(kfake.Fault{
+		Keys:      []int16{int16(kmsg.Produce)},
+		Node:      -1,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.PolicyViolation,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("v")}).FirstErr()
+	if !errors.Is(err, kerr.PolicyViolation) {
+		t.Fatalf("produce err %v != policy violation", err)
+	}
+
+	id := c.TopicInfo(topic).TopicID
+	resp := fetchIDsAt(t, cl, 0, fetchIDs(30000, id))
+	if p := fetchPart(t, resp, id); p.ErrorCode != 0 || len(p.RecordBatches) == 0 {
+		t.Errorf("fetch answered %d with %d record bytes: a produce fault must not touch fetch", p.ErrorCode, len(p.RecordBatches))
+	}
+	if n := h.Fired(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+}
+
+// A fault with no budget fires until removed.
+func TestFaultRemove(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, kfake.NumBrokers(1), kfake.SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	h := c.AddFault(kfake.Fault{
+		Keys:      []int16{int16(kmsg.ListOffsets)},
+		Node:      -1,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.UnknownTopicOrPartition,
+	})
+	for i := range 3 {
+		if code := listOffsetsAt(t, cl, 0, topic, 0); code != kerr.UnknownTopicOrPartition.Code {
+			t.Fatalf("list offsets %d answered %d != %d", i, code, kerr.UnknownTopicOrPartition.Code)
+		}
+	}
+	if n := h.Fired(); n != 3 {
+		t.Errorf("fault fired %d times != 3", n)
+	}
+
+	h.Remove()
+	h.Remove() // twice is fine
+	for i := range 2 {
+		if code := listOffsetsAt(t, cl, 0, topic, 0); code != 0 {
+			t.Fatalf("list offsets %d after removal answered %d != 0", i, code)
+		}
+	}
+	if n := h.Fired(); n != 3 {
+		t.Errorf("fault fired %d times after removal != 3", n)
+	}
+}
+
+// A fault pinned to a node fires only there; Node -1 fires everywhere.
+func TestFaultNode(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, kfake.NumBrokers(2), kfake.SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	if err := c.MoveTopicPartition(topic, 0, 1); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	one := c.AddFault(kfake.Fault{
+		Keys:      []int16{int16(kmsg.ListOffsets)},
+		Node:      0,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.PolicyViolation,
+	})
+	if code := listOffsetsAt(t, cl, 1, topic, 0); code != 0 {
+		t.Errorf("leader node answered %d != 0: a node 0 fault must not fire on node 1", code)
+	}
+	if n := one.Fired(); n != 0 {
+		t.Errorf("node 0 fault fired %d times != 0", n)
+	}
+	if code := listOffsetsAt(t, cl, 0, topic, 0); code != kerr.PolicyViolation.Code {
+		t.Errorf("node 0 answered %d != %d", code, kerr.PolicyViolation.Code)
+	}
+	if n := one.Fired(); n != 1 {
+		t.Errorf("node 0 fault fired %d times != 1", n)
+	}
+	one.Remove()
+
+	any := c.AddFault(kfake.Fault{
+		Keys:      []int16{int16(kmsg.ListOffsets)},
+		Node:      -1,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.PolicyViolation,
+	})
+	for _, node := range []int32{0, 1} {
+		if code := listOffsetsAt(t, cl, node, topic, 0); code != kerr.PolicyViolation.Code {
+			t.Errorf("node %d answered %d != %d", node, code, kerr.PolicyViolation.Code)
+		}
+	}
+	if n := any.Fired(); n != 2 {
+		t.Errorf("any-node fault fired %d times != 2", n)
+	}
+}

--- a/pkg/kfake/faults.go
+++ b/pkg/kfake/faults.go
@@ -1,0 +1,188 @@
+package kfake
+
+import (
+	"slices"
+	"sync/atomic"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+)
+
+// Fault answers matching partitions of matching requests with Err instead of
+// the real response; the rest of each request is answered normally.
+//
+// A request matches if its key is in Keys (nil: any supported request kind),
+// it arrived at Node (-1: any node), and it addresses a partition matching
+// Topic or TopicID and Partition (-1: any partition of that topic). Match by
+// TopicID to fault a stale ID a client still uses after a recreation.
+//
+// Note that the zero values of Node and Partition are node 0 and partition 0,
+// not "any": kfake uses raw IDs everywhere, so you must ask for "any" with -1.
+//
+// Set exactly one of Topic or TopicID. If both are set, the ID wins; if
+// neither is set, nothing matches and Fired stays 0. A TopicID only matches
+// requests that address a topic by ID: Fetch v13+, Produce v13+, ShareFetch,
+// and ShareAcknowledge.
+//
+// We fault Produce, Fetch, ListOffsets, OffsetForLeaderEpoch, ShareFetch, and
+// ShareAcknowledge; all other requests are answered normally. A nil Err is
+// UNKNOWN_SERVER_ERROR.
+//
+// Count is a budget of requests: each matching request consumes one, and every
+// matching partition in it is failed. Zero means until removed.
+type Fault struct {
+	Keys      []int16
+	Node      int32
+	Topic     string
+	TopicID   [16]byte
+	Partition int32
+	Err       *kerr.Error
+	Count     int
+}
+
+// FaultHandle is a handle to an installed fault.
+type FaultHandle struct {
+	c *Cluster
+	f *fault
+}
+
+type fault struct {
+	keys      []int16
+	node      int32
+	topic     string
+	topicID   uuid
+	partition int32
+	err       *kerr.Error
+	fired     atomic.Int64
+
+	// left is the requests remaining, -1 for unlimited, and removed is
+	// set once we drop the fault. Both are guarded by c.faultsMu.
+	left    int
+	removed bool
+}
+
+// AddFault installs f and returns its handle. We fault inside handlers, so a
+// ControlKey control that answers a request itself bypasses faults, while one
+// that passes through sees them.
+func (c *Cluster) AddFault(f Fault) *FaultHandle {
+	ff := &fault{
+		keys:      slices.Clone(f.Keys),
+		node:      f.Node,
+		topic:     f.Topic,
+		topicID:   f.TopicID,
+		partition: f.Partition,
+		err:       f.Err,
+		left:      f.Count,
+	}
+	if ff.err == nil {
+		ff.err = kerr.UnknownServerError
+	}
+	if ff.left <= 0 {
+		ff.left = -1
+	}
+	c.faultsMu.Lock()
+	defer c.faultsMu.Unlock()
+	c.faults = append(c.faults, ff)
+	return &FaultHandle{c: c, f: ff}
+}
+
+// Fired returns how many requests the fault has answered.
+func (h *FaultHandle) Fired() int { return int(h.f.fired.Load()) }
+
+// Remove uninstalls the fault. This is safe to call twice, and safe after the
+// fault exhausted its Count and removed itself.
+func (h *FaultHandle) Remove() {
+	h.c.faultsMu.Lock()
+	defer h.c.faultsMu.Unlock()
+	h.c.rmFaultLocked(h.f)
+}
+
+func (c *Cluster) rmFaultLocked(f *fault) {
+	if f.removed {
+		return
+	}
+	f.removed = true
+	c.faults = slices.DeleteFunc(c.faults, func(o *fault) bool { return o == f })
+}
+
+// faultCheck is the faults that can match one request. A request consumes at
+// most one unit from each fault it hits, no matter how many of its partitions
+// match, so we remember what we charged.
+type faultCheck struct {
+	c       *Cluster
+	fs      []*fault
+	charged []*fault
+}
+
+// faultsFor returns the faults to consider for creq, or nil if none can match.
+func (c *Cluster) faultsFor(creq *clientReq) *faultCheck {
+	c.faultsMu.Lock()
+	defer c.faultsMu.Unlock()
+	if len(c.faults) == 0 {
+		return nil
+	}
+	key := creq.kreq.Key()
+	var fs []*fault
+	for _, f := range c.faults {
+		if f.node != -1 && f.node != creq.cc.b.node {
+			continue
+		}
+		if len(f.keys) > 0 && !slices.Contains(f.keys, key) {
+			continue
+		}
+		fs = append(fs, f)
+	}
+	if len(fs) == 0 {
+		return nil
+	}
+	return &faultCheck{c: c, fs: fs}
+}
+
+// err returns the error to answer a partition with, or nil to answer it for
+// real. The id is the topic ID the request addressed the topic by, if any.
+func (fc *faultCheck) err(t string, id uuid, p int32) *kerr.Error {
+	if fc == nil {
+		return nil
+	}
+	for _, f := range fc.fs {
+		if f.partition != -1 && f.partition != p {
+			continue
+		}
+		if f.topicID != noID {
+			if f.topicID != id {
+				continue
+			}
+		} else if f.topic == "" || f.topic != t {
+			continue
+		}
+		if !fc.charge(f) {
+			continue
+		}
+		return f.err
+	}
+	return nil
+}
+
+// fired reports whether anything in this request was faulted.
+func (fc *faultCheck) fired() bool { return fc != nil && len(fc.charged) > 0 }
+
+// charge takes a unit of f's budget for this request, if we have not taken one
+// already. A fault with nothing left removes itself.
+func (fc *faultCheck) charge(f *fault) bool {
+	if slices.Contains(fc.charged, f) {
+		return true
+	}
+	fc.c.faultsMu.Lock()
+	defer fc.c.faultsMu.Unlock()
+	if f.removed || f.left == 0 {
+		return false
+	}
+	if f.left > 0 {
+		f.left--
+		if f.left == 0 {
+			fc.c.rmFaultLocked(f)
+		}
+	}
+	f.fired.Add(1)
+	fc.charged = append(fc.charged, f)
+	return true
+}

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2348,23 +2348,15 @@ func TestRequestCachedMetadata(t *testing.T) {
 		}
 		countAfterCache := metadataRequests.Load()
 
-		// Step 2: intercept ListOffsets to return NotLeaderForPartition,
+		// Step 2: fail one ListOffsets with NotLeaderForPartition,
 		// which triggers maybeDeleteCachedMeta for the topic.
-		c.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-			lor := kreq.(*kmsg.ListOffsetsRequest)
-			resp := lor.ResponseKind().(*kmsg.ListOffsetsResponse)
-			for _, rt := range lor.Topics {
-				st := kmsg.NewListOffsetsResponseTopic()
-				st.Topic = rt.Topic
-				for _, rp := range rt.Partitions {
-					sp := kmsg.NewListOffsetsResponseTopicPartition()
-					sp.Partition = rp.Partition
-					sp.ErrorCode = kerr.NotLeaderForPartition.Code
-					st.Partitions = append(st.Partitions, sp)
-				}
-				resp.Topics = append(resp.Topics, st)
-			}
-			return resp, nil, true
+		c.AddFault(Fault{
+			Keys:      []int16{int16(kmsg.ListOffsets)},
+			Node:      -1,
+			Topic:     "topic1",
+			Partition: -1,
+			Err:       kerr.NotLeaderForPartition,
+			Count:     1,
 		})
 		adm.ListStartOffsets(ctx, "topic1")
 
@@ -4126,22 +4118,13 @@ func TestOnDataLossCallbackReentrancy(t *testing.T) {
 	// One-shot: the first produce gets OUT_OF_ORDER_SEQUENCE_NUMBER,
 	// which for a non-transactional producer (stopOnDataLoss unset)
 	// fires the data-loss callback and reloads the producer id.
-	c.ControlKey(0, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		req := kreq.(*kmsg.ProduceRequest)
-		resp := req.ResponseKind().(*kmsg.ProduceResponse)
-		for _, rt := range req.Topics {
-			respt := kmsg.NewProduceResponseTopic()
-			respt.Topic = rt.Topic
-			respt.TopicID = rt.TopicID
-			for _, rp := range rt.Partitions {
-				respp := kmsg.NewProduceResponseTopicPartition()
-				respp.Partition = rp.Partition
-				respp.ErrorCode = kerr.OutOfOrderSequenceNumber.Code
-				respt.Partitions = append(respt.Partitions, respp)
-			}
-			resp.Topics = append(resp.Topics, respt)
-		}
-		return resp, nil, true
+	c.AddFault(Fault{
+		Keys:      []int16{int16(kmsg.Produce)},
+		Node:      -1,
+		Topic:     testTopic,
+		Partition: -1,
+		Err:       kerr.OutOfOrderSequenceNumber,
+		Count:     1,
 	})
 
 	var cl *kgo.Client

--- a/pkg/kfake/share_churn_test.go
+++ b/pkg/kfake/share_churn_test.go
@@ -105,30 +105,6 @@ func TestShareFetchLeaderMoveNoHintHeals(t *testing.T) {
 	oldLeader := c.LeaderFor(topic, 0)
 	newLeader := (oldLeader + 1) % 2
 
-	// Once moved is set, every ShareFetch served by the old leader gets
-	// a manual NOT_LEADER response with CurrentLeader=-1/-1 (no hint)
-	// and no NodeEndpoints. Requests to the new leader pass through.
-	var moved atomic.Bool
-	c.ControlKey(int16(kmsg.ShareFetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		c.KeepControl()
-		if !moved.Load() || c.CurrentNode() != oldLeader {
-			return nil, nil, false
-		}
-		req := kreq.(*kmsg.ShareFetchRequest)
-		resp := req.ResponseKind().(*kmsg.ShareFetchResponse)
-		resp.AcquisitionLockTimeoutMillis = 30000
-		rt := kmsg.NewShareFetchResponseTopic()
-		rt.TopicID = ti.TopicID
-		rp := kmsg.NewShareFetchResponseTopicPartition()
-		rp.Partition = 0
-		rp.ErrorCode = kerr.NotLeaderForPartition.Code
-		rp.CurrentLeader.LeaderID = -1 // leaderless window: no hint
-		rp.CurrentLeader.LeaderEpoch = -1
-		rt.Partitions = append(rt.Partitions, rp)
-		resp.Topics = append(resp.Topics, rt)
-		return resp, nil, true
-	})
-
 	cl := shareChurnConsumer(t, c, topic, group)
 
 	if got, _ := pollShareUntil(t, cl, pre, 10*time.Second, nil); got < pre {
@@ -138,7 +114,17 @@ func TestShareFetchLeaderMoveNoHintHeals(t *testing.T) {
 	if err := c.MoveTopicPartition(topic, 0, newLeader); err != nil {
 		t.Fatal(err)
 	}
-	moved.Store(true)
+	// Every ShareFetch the old leader serves now fails with NOT_LEADER and
+	// no CurrentLeader hint: kfake leaves the hint at -1/-1 unless the
+	// handler fills it, so the client has only a metadata refresh to heal
+	// with.
+	c.AddFault(Fault{
+		Keys:      []int16{int16(kmsg.ShareFetch)},
+		Node:      oldLeader,
+		TopicID:   ti.TopicID,
+		Partition: 0,
+		Err:       kerr.NotLeaderForPartition,
+	})
 	produceN(t, c, topic, post)
 
 	// Post-fix: the stripped NOT_LEADER triggers a metadata refresh, the

--- a/pkg/kfake/share_groups.go
+++ b/pkg/kfake/share_groups.go
@@ -1146,6 +1146,7 @@ func validateOneAckBatch(first, last int64, ackTypes []int8, prevEnd *int64, max
 // Must be called from run() with g.mu held.
 func (g *shareGroup) processShareAcks(
 	creq *clientReq,
+	fc *faultCheck,
 	memberID string,
 	topics []ackTopic,
 	maxAckType int8,
@@ -1169,6 +1170,10 @@ func (g *shareGroup) processShareAcks(
 			continue
 		}
 		for _, ap := range at.partitions {
+			if e := fc.err(topicName, at.topicID, ap.partition); e != nil {
+				onPartition(at.topicID, ap.partition, e.Code)
+				continue
+			}
 			errCode := int16(0)
 			prevEnd := int64(-1)
 			for _, batch := range ap.batches {

--- a/pkg/kfake/sink_sweep_test.go
+++ b/pkg/kfake/sink_sweep_test.go
@@ -255,22 +255,13 @@ func TestAuditTxnAbortRetryAfterOperationNotAttempted(t *testing.T) {
 	// producers and is neither retriable nor recoverable under KIP-890p2,
 	// so the abort below cannot take the recovered-early-return and must
 	// reach the broker via EndTxn.
-	c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
-		preq := req.(*kmsg.ProduceRequest)
-		resp := preq.ResponseKind().(*kmsg.ProduceResponse)
-		for _, rt := range preq.Topics {
-			st := kmsg.NewProduceResponseTopic()
-			st.Topic = rt.Topic
-			st.TopicID = rt.TopicID
-			for _, rp := range rt.Partitions {
-				sp := kmsg.NewProduceResponseTopicPartition()
-				sp.Partition = rp.Partition
-				sp.ErrorCode = kerr.InvalidProducerIDMapping.Code
-				st.Partitions = append(st.Partitions, sp)
-			}
-			resp.Topics = append(resp.Topics, st)
-		}
-		return resp, nil, true
+	c.AddFault(Fault{
+		Keys:      []int16{int16(kmsg.Produce)},
+		Node:      -1,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.InvalidProducerIDMapping,
+		Count:     1,
 	})
 	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("r2")}).FirstErr(); err == nil {
 		t.Fatal("expected the injected produce failure, got success")

--- a/pkg/kfake/txn_churn_test.go
+++ b/pkg/kfake/txn_churn_test.go
@@ -87,26 +87,17 @@ func TestAuditTxnInitPidRetriableLoadFailure(t *testing.T) {
 	}
 }
 
-// failAllProduces installs a control that fails every partition of the next
-// produce request with MESSAGE_TOO_LARGE: terminal for the batch, but not a
+// failAllProduces fails every partition of the topic in the next produce
+// request with MESSAGE_TOO_LARGE: terminal for the batch, but not a
 // producer-id-failing error, mirroring a broker-side append rejection.
-func failAllProduces(c *Cluster) {
-	c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
-		preq := req.(*kmsg.ProduceRequest)
-		resp := preq.ResponseKind().(*kmsg.ProduceResponse)
-		for _, rt := range preq.Topics {
-			st := kmsg.NewProduceResponseTopic()
-			st.Topic = rt.Topic
-			st.TopicID = rt.TopicID
-			for _, rp := range rt.Partitions {
-				sp := kmsg.NewProduceResponseTopicPartition()
-				sp.Partition = rp.Partition
-				sp.ErrorCode = kerr.MessageTooLarge.Code
-				st.Partitions = append(st.Partitions, sp)
-			}
-			resp.Topics = append(resp.Topics, st)
-		}
-		return resp, nil, true
+func failAllProduces(c *Cluster, topic string) {
+	c.AddFault(Fault{
+		Keys:      []int16{int16(kmsg.Produce)},
+		Node:      -1,
+		Topic:     topic,
+		Partition: -1,
+		Err:       kerr.MessageTooLarge,
+		Count:     1,
 	})
 }
 
@@ -135,7 +126,7 @@ func TestAuditTxnV2AbortAfterFailedProduces(t *testing.T) {
 	c := newCluster(t, NumBrokers(1), SeedTopics(1, "audit-v2-abort"))
 
 	endTxns := observeEndTxns(c)
-	failAllProduces(c)
+	failAllProduces(c, "audit-v2-abort")
 
 	cl := newPlainClient(t, c, kgo.TransactionalID("audit-v2-abort"))
 	if err := cl.BeginTransaction(); err != nil {
@@ -184,7 +175,7 @@ func TestAuditTxnV1AbortAfterFailedProducesControl(t *testing.T) {
 	}
 
 	endTxns := observeEndTxns(c)
-	failAllProduces(c)
+	failAllProduces(c, "audit-v1-abort")
 
 	cl := newPlainClient(t, c, kgo.TransactionalID("audit-v1-abort"))
 	if err := cl.BeginTransaction(); err != nil {


### PR DESCRIPTION
## AddFault

`c.AddFault(kfake.Fault{...})` answers matching partitions of matching requests with a chosen error and answers the rest of each request normally.

A request matches on its key (`Keys`, nil for any supported kind) and on the node it arrived at (`Node`, -1 for any); a partition matches on `Topic` or `TopicID` plus `Partition` (-1 for any). The zero values of `Node` and `Partition` are node 0 and partition 0, not "any", since kfake uses raw IDs everywhere. `Count` is a budget of requests: a matching request consumes one and fails every partition in it that matches, and an exhausted fault removes itself. The returned `*FaultHandle` has `Fired()` (requests answered, safe from any goroutine) and `Remove()` (safe twice, and after exhaustion).

Faults apply at the point each handler emits a per-partition error code, so the rest of the request stays real: Produce, Fetch, ListOffsets, OffsetForLeaderEpoch, ShareFetch, and ShareAcknowledge. A faulted partition also completes a fetch or share fetch at once instead of holding it for MaxWait, which is what any errored partition does. Because faults live inside handlers, a `ControlKey` control that answers a request itself bypasses them, while one that passes through sees them.

Why: matching by topic ID. After a delete and recreate, a client can keep addressing the stale ID, and a test has to fail only the requests that use it; until now the only way to fail one partition was a control function rebuilding the whole response by hand.

## Converting existing tests

Six controls in the kfake tests existed only to answer a request's partitions with an error code, each rebuilding a whole response by hand to say that one thing; they are now `AddFault` calls. That removes 121 lines and adds 57, and 68 of the removed lines were building kmsg response entries. Two responses change shape and nothing asserted on the difference: the fenced fetch no longer carries the high watermark, last stable offset, and log start offset the control put on an errored partition, and the not-leader share fetch is now the handler's own response, whose leader hint is the -1/-1 the control was setting by hand. The controls left alone are not per-partition errors: they inject preferred read replicas, a negative offset, or the KIP-320 undefined-epoch sentinel, they fail a whole request or close the connection, they alternate the error code per request, or the test synchronizes on a channel the control closes.

## Tested

New tests: a produce budget of 2 (the third attempt succeeds, `Fired() == 2`, the record lands once), a fetch fault on one topic ID alongside an unfaulted topic in the same request (faulted partition errors, the other returns records, the response is immediate, exhaustion frees it), `Keys` restricting a fault to produce while a fetch of the same partition succeeds, `Remove` stopping a budgetless fault, and a node-pinned fault firing only at that node versus `Node: -1` firing at both.

`gofmt -l pkg/kfake` clean, `go vet`, the fault tests and every converted test with `-race -count=10`, the persist tests with `-race`, and the full package with `-race -skip ETL`.

This branch previously also carried a FreezeNode/UnfreezeNode feature; that work was dropped and only the fault injection remains.
