### PR TITLE
kfake: per-partition fault injection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -180,6 +180,11 @@ linters:
       - examples$
       - pkg/kmsg/generated\.go$ # generated from generate/definitions - fix typos there, not here
     rules:
+      # A kfake request handler answers the client with an error code inside
+      # the response and returns no error to the connection; nilerr reads
+      # returning that response as swallowing the error.
+      - linters: [nilerr]
+        path: ^pkg/kfake/[0-9]+_
       - linters: [noctx] # test code doesn't need request contexts
         path: _test\.go$
       - linters: [revive]

--- a/pkg/kfake/00_produce.go
+++ b/pkg/kfake/00_produce.go
@@ -45,14 +45,21 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
+	// A fault can answer a partition before the work runs. The work's own
+	// answer for that partition must not add an entry or replace the code.
+	answered := make(map[tp]int)
 	donep := func(t kmsg.ProduceRequestTopic, p kmsg.ProduceRequestTopicPartition, errCode int16, errMsg string) *kmsg.ProduceResponseTopicPartition {
+		ps := tdone[id(t)]
+		if i, ok := answered[tp{t.Topic, p.Partition}]; ok {
+			return &ps[i]
+		}
+		answered[tp{t.Topic, p.Partition}] = len(ps)
 		sp := kmsg.NewProduceResponseTopicPartition()
 		sp.Partition = p.Partition
 		sp.ErrorCode = errCode
 		if req.Version >= 8 && errMsg != "" {
 			sp.ErrorMessage = &errMsg
 		}
-		ps := tdone[id(t)]
 		ps = append(ps, sp)
 		tdone[id(t)] = ps
 		return &ps[len(ps)-1]
@@ -105,12 +112,20 @@ func (c *Cluster) handleProduce(creq *clientReq) (kmsg.Response, error) {
 			}
 			rt.Topic = topic
 		}
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationWrite) {
-			donet(rt, kerr.TopicAuthorizationFailed.Code, kerr.TopicAuthorizationFailed.Message)
+		tk := faultKey{topic: rt.Topic, topicID: rt.TopicID}
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationWrite, tk); e != nil && creq.skipsWork(e) { // a timed-out append falls through to the per-partition checks
+			donet(rt, e.Code, e.Message)
 			continue
 		}
 		maxMessageBytes := c.data.maxMessageBytes(rt.Topic)
 		for _, rp := range rt.Partitions {
+			e := creq.faults.check(tk.part(rp.Partition))
+			if e != nil {
+				donep(rt, rp, e.Code, e.Message)
+				if creq.skipsWork(e) { // a timed-out append still appends
+					continue
+				}
+			}
 			pd, ok := c.data.tps.getp(rt.Topic, rp.Partition)
 			if !ok {
 				donep(rt, rp, kerr.UnknownTopicOrPartition.Code, "Unknown topic or partition.")

--- a/pkg/kfake/01_fetch.go
+++ b/pkg/kfake/01_fetch.go
@@ -168,6 +168,7 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		nbytes        int
 		returnEarly   bool
 		needp         tps[int]
+		fc            = creq.faults
 	)
 	if w == nil {
 		// Any partition that errors completes the fetch at once, as a
@@ -175,6 +176,10 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 		// on data hold the request for MaxWait.
 	out:
 		for _, fp := range toFetch {
+			if e := fc.check(faultKey{topic: fp.topic, topicID: fp.topicID}.part(fp.partition)); e != nil {
+				returnEarly = true // the fault's error
+				break out
+			}
 			if fp.staleID {
 				returnEarly = true // InconsistentTopicID or UnknownTopicID
 				break out
@@ -313,8 +318,8 @@ func (c *Cluster) handleFetch(creq *clientReq, w *watchFetch) (kmsg.Response, er
 	nbytes = 0
 full:
 	for _, fp := range toFetch {
-		if !c.allowedACL(creq, fp.topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
-			donep(fp.topic, fp.topicID, fp.partition, kerr.TopicAuthorizationFailed.Code)
+		if e := c.deny(creq, fp.topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, faultKey{topic: fp.topic, topicID: fp.topicID}.part(fp.partition)); e != nil {
+			donep(fp.topic, fp.topicID, fp.partition, e.Code)
 			continue
 		}
 		pd, ok := c.data.tps.getp(fp.topic, fp.partition)

--- a/pkg/kfake/02_list_offsets.go
+++ b/pkg/kfake/02_list_offsets.go
@@ -55,14 +55,19 @@ func (c *Cluster) handleListOffsets(creq *clientReq) (kmsg.Response, error) {
 	}
 
 	for _, rt := range req.Topics {
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+		tk := faultKey{topic: rt.Topic}
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, tk); e != nil {
 			for _, rp := range rt.Partitions {
-				donep(rt.Topic, rp.Partition, kerr.TopicAuthorizationFailed.Code)
+				donep(rt.Topic, rp.Partition, e.Code)
 			}
 			continue
 		}
 		ps, ok := c.data.tps.gett(rt.Topic)
 		for _, rp := range rt.Partitions {
+			if e := creq.faults.check(tk.part(rp.Partition)); e != nil {
+				donep(rt.Topic, rp.Partition, e.Code)
+				continue
+			}
 			if !ok {
 				donep(rt.Topic, rp.Partition, kerr.UnknownTopicOrPartition.Code)
 				continue

--- a/pkg/kfake/03_metadata.go
+++ b/pkg/kfake/03_metadata.go
@@ -78,6 +78,10 @@ func (c *Cluster) handleMetadata(creq *clientReq) (kmsg.Response, error) {
 		return &st.Partitions[len(st.Partitions)-1]
 	}
 	okp := func(t string, id uuid, p int32, pd *partData) {
+		if e := creq.faults.check(faultKey{topic: t, topicID: id}.part(p)); e != nil {
+			donep(t, id, p, e.Code)
+			return
+		}
 		nreplicas := c.data.treplicas[t]
 		if nreplicas > len(c.bs) {
 			nreplicas = len(c.bs)
@@ -115,8 +119,8 @@ func (c *Cluster) handleMetadata(creq *clientReq) (kmsg.Response, error) {
 			topic = *rt.Topic
 		}
 
-		if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
-			donet(topic, rt.TopicID, kerr.TopicAuthorizationFailed.Code)
+		if e := c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic}); e != nil {
+			donet(topic, rt.TopicID, e.Code)
 			continue
 		}
 
@@ -143,7 +147,7 @@ func (c *Cluster) handleMetadata(creq *clientReq) (kmsg.Response, error) {
 	if req.Topics == nil && c.data.tps != nil {
 		for topic, ps := range c.data.tps {
 			// For listing all topics, filter to only authorized topics
-			if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+			if e := c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic}); e != nil {
 				continue
 			}
 			id := c.data.t2id[topic]

--- a/pkg/kfake/10_find_coordinator.go
+++ b/pkg/kfake/10_find_coordinator.go
@@ -66,23 +66,19 @@ func (c *Cluster) handleFindCoordinator(creq *clientReq) (kmsg.Response, error) 
 		}
 
 		// ACL check based on coordinator type
-		var allowed bool
-		var errCode int16
+		var e *kerr.Error
 		switch req.CoordinatorType {
 		case 0: // Group
-			allowed = c.allowedACL(creq, key, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe)
-			errCode = kerr.GroupAuthorizationFailed.Code
+			e = c.deny(creq, key, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: key})
 		case 1: // Transaction
-			allowed = c.allowedACL(creq, key, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationDescribe)
-			errCode = kerr.TransactionalIDAuthorizationFailed.Code
+			e = c.deny(creq, key, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationDescribe, faultKey{txnID: key})
 		case 2: // Share (KIP-932): requires CLUSTER CLUSTER_ACTION
 			// (matching Java's KafkaApis.handleFindCoordinatorRequest
 			// which calls authHelper.authorizeClusterOperation(CLUSTER_ACTION)).
-			allowed = c.allowedClusterACL(creq, kmsg.ACLOperationClusterAction)
-			errCode = kerr.ClusterAuthorizationFailed.Code
+			e = c.denyCluster(creq, kmsg.ACLOperationClusterAction)
 		}
-		if !allowed {
-			sc.ErrorCode = errCode
+		if e != nil {
+			sc.ErrorCode = e.Code
 			continue
 		}
 

--- a/pkg/kfake/16_list_groups.go
+++ b/pkg/kfake/16_list_groups.go
@@ -31,7 +31,7 @@ func (c *Cluster) handleListGroups(creq *clientReq) (kmsg.Response, error) {
 		if c.coordinator(sg.name).node != creq.cc.b.node {
 			continue
 		}
-		if !c.allowedACL(creq, sg.name, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
+		if e := c.deny(creq, sg.name, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: sg.name}); e != nil {
 			continue
 		}
 		// Determine state. Use waitControl to safely read member count.

--- a/pkg/kfake/18_api_versions.go
+++ b/pkg/kfake/18_api_versions.go
@@ -24,8 +24,8 @@ import (
 
 func init() { regKey(18, 0, 4) }
 
-func (c *Cluster) handleApiVersions(kreq kmsg.Request) (kmsg.Response, error) {
-	req := kreq.(*kmsg.ApiVersionsRequest)
+func (c *Cluster) handleApiVersions(creq *clientReq) (kmsg.Response, error) {
+	req := creq.kreq.(*kmsg.ApiVersionsRequest)
 	resp := req.ResponseKind().(*kmsg.ApiVersionsResponse)
 
 	if resp.Version > 3 && resp.Version > apiVersionsKeys[18].MaxVersion {

--- a/pkg/kfake/19_create_topics.go
+++ b/pkg/kfake/19_create_topics.go
@@ -37,7 +37,14 @@ func (c *Cluster) handleCreateTopics(creq *clientReq) (kmsg.Response, error) {
 	// Check if user has CREATE on CLUSTER (allows creating any topic)
 	clusterCreate := c.allowedClusterACL(creq, kmsg.ACLOperationCreate)
 
+	// A fault can answer a topic before the work runs. The work's own
+	// answer for that topic must not add an entry or replace the code.
+	answered := make(map[string]int)
 	donet := func(t string, errCode int16) *kmsg.CreateTopicsResponseTopic {
+		if i, ok := answered[t]; ok {
+			return &resp.Topics[i]
+		}
+		answered[t] = len(resp.Topics)
 		st := kmsg.NewCreateTopicsResponseTopic()
 		st.Topic = t
 		st.ErrorCode = errCode
@@ -72,9 +79,16 @@ func (c *Cluster) handleCreateTopics(creq *clientReq) (kmsg.Response, error) {
 
 	for _, rt := range req.Topics {
 		// ACL check: cluster CREATE or topic CREATE
-		if !clusterCreate && !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationCreate) {
-			donet(rt.Topic, kerr.TopicAuthorizationFailed.Code)
-			continue
+		tk := faultKey{topic: rt.Topic}
+		e := creq.faults.check(tk)
+		if !clusterCreate {
+			e = c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationCreate, tk)
+		}
+		if e != nil {
+			donet(rt.Topic, e.Code)
+			if creq.skipsWork(e) { // a timed-out create still creates the topic
+				continue
+			}
 		}
 		if _, ok := c.data.tps.gett(rt.Topic); ok {
 			donet(rt.Topic, kerr.TopicAlreadyExists.Code)

--- a/pkg/kfake/20_delete_topics.go
+++ b/pkg/kfake/20_delete_topics.go
@@ -31,7 +31,22 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
+	// A fault can answer a topic before the work runs. The work's own
+	// answer for that topic must not add an entry or replace the code.
+	type answerKey struct {
+		t  string
+		id uuid
+	}
+	answered := make(map[answerKey]int)
 	donet := func(t *string, id uuid, errCode int16) *kmsg.DeleteTopicsResponseTopic {
+		k := answerKey{id: id}
+		if t != nil {
+			k.t = *t
+		}
+		if i, ok := answered[k]; ok {
+			return &resp.Topics[i]
+		}
+		answered[k] = len(resp.Topics)
 		st := kmsg.NewDeleteTopicsResponseTopic()
 		st.Topic = t
 		st.TopicID = id
@@ -118,13 +133,15 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 			id = rt.TopicID
 		}
 		// ACL check: DESCRIBE first (to identify topic), then DELETE
-		if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
-			donet(&topic, id, kerr.TopicAuthorizationFailed.Code)
-			continue
+		e := c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic})
+		if e == nil {
+			e = c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDelete, faultKey{topic: topic})
 		}
-		if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDelete) {
-			donet(&topic, id, kerr.TopicAuthorizationFailed.Code)
-			continue
+		if e != nil {
+			donet(&topic, id, e.Code)
+			if creq.skipsWork(e) { // a timed-out delete still deletes the topic
+				continue
+			}
 		}
 		t, ok := c.data.tps.gett(topic)
 		if !ok {

--- a/pkg/kfake/21_delete_records.go
+++ b/pkg/kfake/21_delete_records.go
@@ -39,24 +39,37 @@ func (c *Cluster) handleDeleteRecords(creq *clientReq) (kmsg.Response, error) {
 		resp.Topics = append(resp.Topics, st)
 		return &resp.Topics[len(resp.Topics)-1]
 	}
+	// A fault can answer a partition before the work runs. The work's own
+	// answer for that partition must not add an entry or replace the code.
+	answered := make(map[tp]int)
 	donep := func(t string, p int32, errCode int16) *kmsg.DeleteRecordsResponseTopicPartition {
+		st := donet(t)
+		if i, ok := answered[tp{t, p}]; ok {
+			return &st.Partitions[i]
+		}
+		answered[tp{t, p}] = len(st.Partitions)
 		sp := kmsg.NewDeleteRecordsResponseTopicPartition()
 		sp.Partition = p
 		sp.ErrorCode = errCode
-		st := donet(t)
 		st.Partitions = append(st.Partitions, sp)
 		return &st.Partitions[len(st.Partitions)-1]
 	}
 
 	for _, rt := range req.Topics {
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDelete) {
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDelete, faultKey{topic: rt.Topic}); e != nil && creq.skipsWork(e) { // a timed-out delete falls through to the per-partition checks
 			for _, rp := range rt.Partitions {
-				donep(rt.Topic, rp.Partition, kerr.TopicAuthorizationFailed.Code)
+				donep(rt.Topic, rp.Partition, e.Code)
 			}
 			continue
 		}
 		ps, ok := c.data.tps.gett(rt.Topic)
 		for _, rp := range rt.Partitions {
+			if e := creq.faults.check(faultKey{topic: rt.Topic}.part(rp.Partition)); e != nil {
+				donep(rt.Topic, rp.Partition, e.Code)
+				if creq.skipsWork(e) { // a timed-out delete still deletes
+					continue
+				}
+			}
 			if !ok {
 				donep(rt.Topic, rp.Partition, kerr.UnknownTopicOrPartition.Code)
 				continue

--- a/pkg/kfake/22_init_producer_id.go
+++ b/pkg/kfake/22_init_producer_id.go
@@ -28,20 +28,20 @@ func (c *Cluster) handleInitProducerID(creq *clientReq) (kmsg.Response, error) {
 
 	// ACL check: transactional requires WRITE on TxnID, non-transactional requires
 	// IDEMPOTENT_WRITE on Cluster or WRITE on any Topic.
+	var e *kerr.Error
 	if req.TransactionalID != nil {
-		if !c.allowedACL(creq, *req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite) {
-			resp := req.ResponseKind().(*kmsg.InitProducerIDResponse)
-			resp.ErrorCode = kerr.TransactionalIDAuthorizationFailed.Code
-			return resp, nil
-		}
+		e = c.deny(creq, *req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite, faultKey{txnID: *req.TransactionalID})
 	} else {
 		// Non-transactional: need idempotent write on cluster or write on any topic
+		e = creq.faults.check(faultKey{})
 		if !c.allowedClusterACL(creq, kmsg.ACLOperationIdempotentWrite) && !c.anyAllowedACL(creq, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationWrite) {
-			resp := req.ResponseKind().(*kmsg.InitProducerIDResponse)
-			resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-			return resp, nil
+			e = kerr.ClusterAuthorizationFailed
 		}
 	}
-
+	if e != nil {
+		resp := req.ResponseKind().(*kmsg.InitProducerIDResponse)
+		resp.ErrorCode = e.Code
+		return resp, nil
+	}
 	return c.pids.doInitProducerID(creq), nil
 }

--- a/pkg/kfake/23_offset_for_leader_epoch.go
+++ b/pkg/kfake/23_offset_for_leader_epoch.go
@@ -50,14 +50,19 @@ func (c *Cluster) handleOffsetForLeaderEpoch(creq *clientReq) (kmsg.Response, er
 	}
 
 	for _, rt := range req.Topics {
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+		tk := faultKey{topic: rt.Topic}
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, tk); e != nil {
 			for _, rp := range rt.Partitions {
-				donep(rt.Topic, rp.Partition, kerr.TopicAuthorizationFailed.Code)
+				donep(rt.Topic, rp.Partition, e.Code)
 			}
 			continue
 		}
 		ps, ok := c.data.tps.gett(rt.Topic)
 		for _, rp := range rt.Partitions {
+			if e := creq.faults.check(tk.part(rp.Partition)); e != nil {
+				donep(rt.Topic, rp.Partition, e.Code)
+				continue
+			}
 			if req.ReplicaID >= 0 {
 				donep(rt.Topic, rp.Partition, kerr.UnknownServerError.Code)
 				continue

--- a/pkg/kfake/24_add_partitions_to_txn.go
+++ b/pkg/kfake/24_add_partitions_to_txn.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -43,14 +42,14 @@ func (c *Cluster) handleAddPartitionsToTxn(creq *clientReq) (kmsg.Response, erro
 	}
 
 	// ACL check: WRITE on TxnID
-	if !c.allowedACL(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite) {
-		return errResp(kerr.TransactionalIDAuthorizationFailed.Code), nil
+	if e := c.deny(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite, faultKey{txnID: req.TransactionalID}); e != nil {
+		return errResp(e.Code), nil
 	}
 
 	// ACL check: WRITE on each Topic
 	for _, rt := range req.Topics {
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationWrite) {
-			return errResp(kerr.TopicAuthorizationFailed.Code), nil
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationWrite, faultKey{txnID: req.TransactionalID, topic: rt.Topic}); e != nil {
+			return errResp(e.Code), nil
 		}
 	}
 

--- a/pkg/kfake/25_add_offsets_to_txn.go
+++ b/pkg/kfake/25_add_offsets_to_txn.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -26,16 +25,16 @@ func (c *Cluster) handleAddOffsetsToTxn(creq *clientReq) (kmsg.Response, error) 
 	}
 
 	// ACL check: WRITE on TxnID
-	if !c.allowedACL(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite) {
+	if e := c.deny(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite, faultKey{txnID: req.TransactionalID}); e != nil {
 		resp := req.ResponseKind().(*kmsg.AddOffsetsToTxnResponse)
-		resp.ErrorCode = kerr.TransactionalIDAuthorizationFailed.Code
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
 	// ACL check: READ on Group
-	if !c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
+	if e := c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil {
 		resp := req.ResponseKind().(*kmsg.AddOffsetsToTxnResponse)
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 

--- a/pkg/kfake/26_end_txn.go
+++ b/pkg/kfake/26_end_txn.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -28,9 +27,9 @@ func (c *Cluster) handleEndTxn(creq *clientReq) (kmsg.Response, error) {
 	}
 
 	// ACL check: WRITE on TxnID
-	if !c.allowedACL(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite) {
+	if e := c.deny(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite, faultKey{txnID: req.TransactionalID}); e != nil {
 		resp := req.ResponseKind().(*kmsg.EndTxnResponse)
-		resp.ErrorCode = kerr.TransactionalIDAuthorizationFailed.Code
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 

--- a/pkg/kfake/27_write_txn_markers.go
+++ b/pkg/kfake/27_write_txn_markers.go
@@ -50,19 +50,33 @@ func (c *Cluster) handleWriteTxnMarkers(creq *clientReq) (kmsg.Response, error) 
 				respPart := kmsg.NewWriteTxnMarkersResponseMarkerTopicPartition()
 				respPart.Partition = p
 
-				switch {
-				case !clusterAuthorized:
+				// setErr sets the code unless a fault already answered.
+				setErr := func(code int16) {
+					if respPart.ErrorCode == 0 {
+						respPart.ErrorCode = code
+					}
+				}
+				if !clusterAuthorized {
 					respPart.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-				case !topicExists:
-					respPart.ErrorCode = kerr.UnknownTopicOrPartition.Code
+					respTopic.Partitions = append(respTopic.Partitions, respPart)
+					continue
+				}
+				if fe := creq.faults.check(faultKey{topic: mt.Topic}.part(p)); fe != nil {
+					respPart.ErrorCode = fe.Code
+					if creq.skipsWork(fe) { // a timed-out marker is still written
+						respTopic.Partitions = append(respTopic.Partitions, respPart)
+						continue
+					}
+				}
+				pd, ok := ps[p]
+				switch {
+				case !topicExists, !ok:
+					setErr(kerr.UnknownTopicOrPartition.Code)
+				case pd.leader != creq.cc.b:
+					setErr(kerr.NotLeaderForPartition.Code)
 				default:
-					pd, ok := ps[p]
-					if !ok {
-						respPart.ErrorCode = kerr.UnknownTopicOrPartition.Code
-					} else if pd.leader != creq.cc.b {
-						respPart.ErrorCode = kerr.NotLeaderForPartition.Code
-					} else if off := c.writeTxnMarker(pd, m.ProducerID, m.ProducerEpoch, m.Committed); off < 0 {
-						respPart.ErrorCode = kerr.UnknownServerError.Code
+					if off := c.writeTxnMarker(pd, m.ProducerID, m.ProducerEpoch, m.Committed); off < 0 {
+						setErr(kerr.UnknownServerError.Code)
 					}
 				}
 				respTopic.Partitions = append(respTopic.Partitions, respPart)

--- a/pkg/kfake/28_txn_offset_commit.go
+++ b/pkg/kfake/28_txn_offset_commit.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -44,19 +43,19 @@ func (c *Cluster) handleTxnOffsetCommit(creq *clientReq) (kmsg.Response, error) 
 	}
 
 	// ACL check: WRITE on TxnID
-	if !c.allowedACL(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite) {
-		return errResp(kerr.TransactionalIDAuthorizationFailed.Code), nil
+	if e := c.deny(creq, req.TransactionalID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationWrite, faultKey{txnID: req.TransactionalID}); e != nil && creq.skipsWork(e) { // a timed-out commit falls through to the per-partition checks
+		return errResp(e.Code), nil
 	}
 
 	// ACL check: READ on Group
-	if !c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		return errResp(kerr.GroupAuthorizationFailed.Code), nil
+	if e := c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{txnID: req.TransactionalID, group: req.Group}); e != nil && creq.skipsWork(e) {
+		return errResp(e.Code), nil
 	}
 
 	// ACL check: READ on each Topic
 	for _, rt := range req.Topics {
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
-			return errResp(kerr.TopicAuthorizationFailed.Code), nil
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, faultKey{txnID: req.TransactionalID, group: req.Group, topic: rt.Topic}); e != nil && creq.skipsWork(e) {
+			return errResp(e.Code), nil
 		}
 	}
 

--- a/pkg/kfake/29_describe_acls.go
+++ b/pkg/kfake/29_describe_acls.go
@@ -25,8 +25,8 @@ func (c *Cluster) handleDescribeACLs(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribe) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+	if e := c.denyCluster(creq, kmsg.ACLOperationDescribe); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 

--- a/pkg/kfake/30_create_acls.go
+++ b/pkg/kfake/30_create_acls.go
@@ -29,11 +29,17 @@ func (c *Cluster) handleCreateACLs(creq *clientReq) (kmsg.Response, error) {
 
 	for _, cr := range req.Creations {
 		result := kmsg.CreateACLsResponseResult{}
+		fe := creq.faults.check(faultKey{resource: cr.ResourceName})
 		if !clusterAllowed {
-			result.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-			result.ErrorMessage = kmsg.StringPtr(kerr.ClusterAuthorizationFailed.Message)
-			resp.Results = append(resp.Results, result)
-			continue
+			fe = kerr.ClusterAuthorizationFailed
+		}
+		if fe != nil {
+			result.ErrorCode = fe.Code
+			result.ErrorMessage = kmsg.StringPtr(fe.Message)
+			if creq.skipsWork(fe) { // a timed-out creation still creates the ACL
+				resp.Results = append(resp.Results, result)
+				continue
+			}
 		}
 
 		if err := validateACLCreation(cr); err != "" {

--- a/pkg/kfake/31_delete_acls.go
+++ b/pkg/kfake/31_delete_acls.go
@@ -30,11 +30,21 @@ func (c *Cluster) handleDeleteACLs(creq *clientReq) (kmsg.Response, error) {
 
 	for _, rf := range req.Filters {
 		result := kmsg.DeleteACLsResponseResult{}
+		var name string
+		if rf.ResourceName != nil {
+			name = *rf.ResourceName
+		}
+		fe := creq.faults.check(faultKey{resource: name})
 		if !clusterAllowed {
-			result.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-			result.ErrorMessage = kmsg.StringPtr(kerr.ClusterAuthorizationFailed.Message)
-			resp.Results = append(resp.Results, result)
-			continue
+			fe = kerr.ClusterAuthorizationFailed
+		}
+		if fe != nil {
+			result.ErrorCode = fe.Code
+			result.ErrorMessage = kmsg.StringPtr(fe.Message)
+			if creq.skipsWork(fe) { // a timed-out deletion still deletes the ACLs
+				resp.Results = append(resp.Results, result)
+				continue
+			}
 		}
 
 		filter := aclFilter{

--- a/pkg/kfake/32_describe_configs.go
+++ b/pkg/kfake/32_describe_configs.go
@@ -94,8 +94,8 @@ outer:
 		rr := &req.Resources[i]
 		switch rr.ResourceType {
 		case kmsg.ConfigResourceTypeBroker:
-			if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribeConfigs) {
-				doner(rr.ResourceName, rr.ResourceType, kerr.ClusterAuthorizationFailed.Code)
+			if e := c.denyCluster(creq, kmsg.ACLOperationDescribeConfigs); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
 				continue outer
 			}
 			id := int32(-1)
@@ -107,13 +107,17 @@ outer:
 					continue outer
 				}
 			}
+			if e := creq.faults.check(faultKey{resource: rr.ResourceName}); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
+				continue
+			}
 			r := doner(rr.ResourceName, rr.ResourceType, 0)
 			c.brokerConfigs(id, rfn(r))
 			filter(rr, r)
 
 		case kmsg.ConfigResourceTypeTopic:
-			if !c.allowedACL(creq, rr.ResourceName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribeConfigs) {
-				doner(rr.ResourceName, rr.ResourceType, kerr.TopicAuthorizationFailed.Code)
+			if e := c.deny(creq, rr.ResourceName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribeConfigs, faultKey{resource: rr.ResourceName}); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
 				continue
 			}
 			if _, ok := c.data.tps.gett(rr.ResourceName); !ok {

--- a/pkg/kfake/33_alter_configs.go
+++ b/pkg/kfake/33_alter_configs.go
@@ -36,7 +36,18 @@ func (c *Cluster) handleAlterConfigs(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
+	type resource struct {
+		n string
+		t kmsg.ConfigResourceType
+	}
+	answered := make(map[resource]bool)
 	doner := func(n string, t kmsg.ConfigResourceType, errCode int16) {
+		// A fault can answer a resource before the work runs. The
+		// work's own answer for that resource must not add an entry or
+		// replace the code.
+		if answered[resource{n, t}] {
+			return
+		}
 		st := kmsg.NewAlterConfigsResponseResource()
 		st.ResourceName = n
 		st.ResourceType = t
@@ -49,9 +60,12 @@ outer:
 		rr := &req.Resources[i]
 		switch rr.ResourceType {
 		case kmsg.ConfigResourceTypeBroker:
-			if !c.allowedClusterACL(creq, kmsg.ACLOperationAlterConfigs) {
-				doner(rr.ResourceName, rr.ResourceType, kerr.ClusterAuthorizationFailed.Code)
-				continue outer
+			if e := c.denyCluster(creq, kmsg.ACLOperationAlterConfigs); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
+				answered[resource{rr.ResourceName, rr.ResourceType}] = true
+				if creq.skipsWork(e) { // a timed-out alter still applies
+					continue outer
+				}
 			}
 			if rr.ResourceName != "" {
 				iid, err := strconv.Atoi(rr.ResourceName)
@@ -81,9 +95,12 @@ outer:
 			c.persistBrokerConfigsState()
 
 		case kmsg.ConfigResourceTypeTopic:
-			if !c.allowedACL(creq, rr.ResourceName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationAlterConfigs) {
-				doner(rr.ResourceName, rr.ResourceType, kerr.TopicAuthorizationFailed.Code)
-				continue
+			if e := c.deny(creq, rr.ResourceName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationAlterConfigs, faultKey{resource: rr.ResourceName}); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
+				answered[resource{rr.ResourceName, rr.ResourceType}] = true
+				if creq.skipsWork(e) { // a timed-out alter still applies
+					continue
+				}
 			}
 			if _, ok := c.data.tps.gett(rr.ResourceName); !ok {
 				doner(rr.ResourceName, rr.ResourceType, kerr.UnknownTopicOrPartition.Code)

--- a/pkg/kfake/34_alter_replica_log_dirs.go
+++ b/pkg/kfake/34_alter_replica_log_dirs.go
@@ -27,7 +27,7 @@ func (c *Cluster) handleAlterReplicaLogDirs(creq *clientReq) (kmsg.Response, err
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationAlter) {
+	if e := c.denyCluster(creq, kmsg.ACLOperationAlter); e != nil {
 		// Return cluster authorization failed for all partitions
 		for _, rd := range req.Dirs {
 			for _, t := range rd.Topics {
@@ -36,7 +36,7 @@ func (c *Cluster) handleAlterReplicaLogDirs(creq *clientReq) (kmsg.Response, err
 				for _, p := range t.Partitions {
 					sp := kmsg.NewAlterReplicaLogDirsResponseTopicPartition()
 					sp.Partition = p
-					sp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+					sp.ErrorCode = e.Code
 					st.Partitions = append(st.Partitions, sp)
 				}
 				resp.Topics = append(resp.Topics, st)
@@ -67,6 +67,10 @@ func (c *Cluster) handleAlterReplicaLogDirs(creq *clientReq) (kmsg.Response, err
 	for _, rd := range req.Dirs {
 		for _, t := range rd.Topics {
 			for _, p := range t.Partitions {
+				if e := creq.faults.check(faultKey{topic: t.Topic, resource: rd.Dir}.part(p)); e != nil {
+					donep(t.Topic, p, e.Code)
+					continue
+				}
 				d, ok := c.data.tps.getp(t.Topic, p)
 				if !ok {
 					donep(t.Topic, p, kerr.UnknownTopicOrPartition.Code)

--- a/pkg/kfake/35_describe_log_dirs.go
+++ b/pkg/kfake/35_describe_log_dirs.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -30,8 +29,8 @@ func (c *Cluster) handleDescribeLogDirs(creq *clientReq) (kmsg.Response, error) 
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribe) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+	if e := c.denyCluster(creq, kmsg.ACLOperationDescribe); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
@@ -71,6 +70,11 @@ func (c *Cluster) handleDescribeLogDirs(creq *clientReq) (kmsg.Response, error) 
 	for dir, ts := range individual {
 		rd := kmsg.NewDescribeLogDirsResponseDir()
 		rd.Dir = dir
+		if e := creq.faults.check(faultKey{resource: dir}); e != nil {
+			rd.ErrorCode = e.Code
+			resp.Dirs = append(resp.Dirs, rd)
+			continue
+		}
 		rd.TotalBytes = totalSpace[dir]
 		rd.UsableBytes = 32 << 30
 		for t, ps := range ts {

--- a/pkg/kfake/37_create_partitions.go
+++ b/pkg/kfake/37_create_partitions.go
@@ -33,7 +33,14 @@ func (c *Cluster) handleCreatePartitions(creq *clientReq) (kmsg.Response, error)
 		return nil, err
 	}
 
+	// A fault can answer a topic before the work runs. The work's own
+	// answer for that topic must not add an entry or replace the code.
+	answered := make(map[string]int)
 	donet := func(t string, errCode int16) *kmsg.CreatePartitionsResponseTopic {
+		if i, ok := answered[t]; ok {
+			return &resp.Topics[i]
+		}
+		answered[t] = len(resp.Topics)
 		st := kmsg.NewCreatePartitionsResponseTopic()
 		st.Topic = t
 		st.ErrorCode = errCode
@@ -67,9 +74,11 @@ func (c *Cluster) handleCreatePartitions(creq *clientReq) (kmsg.Response, error)
 	}
 
 	for _, rt := range req.Topics {
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationAlter) {
-			donet(rt.Topic, kerr.TopicAuthorizationFailed.Code)
-			continue
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationAlter, faultKey{topic: rt.Topic}); e != nil {
+			donet(rt.Topic, e.Code)
+			if creq.skipsWork(e) { // a timed-out create still adds the partitions
+				continue
+			}
 		}
 		t, ok := c.data.tps.gett(rt.Topic)
 		if !ok {

--- a/pkg/kfake/43_elect_leaders.go
+++ b/pkg/kfake/43_elect_leaders.go
@@ -28,12 +28,21 @@ func (c *Cluster) handleElectLeaders(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationAlter) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-		return resp, nil
+	if e := c.denyCluster(creq, kmsg.ACLOperationAlter); e != nil {
+		resp.ErrorCode = e.Code
+		if creq.skipsWork(e) { // a timed-out election still elects
+			return resp, nil
+		}
 	}
 
+	answered := make(map[tp]bool)
 	donep := func(topic string, partition int32, errCode int16) {
+		// A fault can answer a partition before the work runs. The
+		// work's own answer for that partition must not add an entry or
+		// replace the code.
+		if answered[tp{topic, partition}] {
+			return
+		}
 		for i := range resp.Topics {
 			if resp.Topics[i].Topic == topic {
 				sp := kmsg.NewElectLeadersResponseTopicPartition()
@@ -61,12 +70,26 @@ func (c *Cluster) handleElectLeaders(creq *clientReq) (kmsg.Response, error) {
 
 	if req.Topics == nil {
 		c.data.tps.each(func(t string, p int32, pd *partData) {
+			if e := creq.faults.check(faultKey{topic: t}.part(p)); e != nil {
+				donep(t, p, e.Code)
+				answered[tp{t, p}] = true
+				if creq.skipsWork(e) { // a timed-out election still elects
+					return
+				}
+			}
 			elect(t, p, pd)
 		})
 	} else {
 		for i := range req.Topics {
 			rt := &req.Topics[i]
 			for _, p := range rt.Partitions {
+				if e := creq.faults.check(faultKey{topic: rt.Topic}.part(p)); e != nil {
+					donep(rt.Topic, p, e.Code)
+					answered[tp{rt.Topic, p}] = true
+					if creq.skipsWork(e) { // a timed-out election still elects
+						continue
+					}
+				}
 				pd, ok := c.data.tps.getp(rt.Topic, p)
 				if !ok {
 					donep(rt.Topic, p, kerr.UnknownTopicOrPartition.Code)

--- a/pkg/kfake/44_incremental_alter_configs.go
+++ b/pkg/kfake/44_incremental_alter_configs.go
@@ -36,7 +36,18 @@ func (c *Cluster) handleIncrementalAlterConfigs(creq *clientReq) (kmsg.Response,
 		return nil, err
 	}
 
+	type resource struct {
+		n string
+		t kmsg.ConfigResourceType
+	}
+	answered := make(map[resource]bool)
 	doner := func(n string, t kmsg.ConfigResourceType, errCode int16) {
+		// A fault can answer a resource before the work runs. The
+		// work's own answer for that resource must not add an entry or
+		// replace the code.
+		if answered[resource{n, t}] {
+			return
+		}
 		st := kmsg.NewIncrementalAlterConfigsResponseResource()
 		st.ResourceName = n
 		st.ResourceType = t
@@ -49,9 +60,12 @@ outer:
 		rr := &req.Resources[i]
 		switch rr.ResourceType {
 		case kmsg.ConfigResourceTypeBroker:
-			if !c.allowedClusterACL(creq, kmsg.ACLOperationAlterConfigs) {
-				doner(rr.ResourceName, rr.ResourceType, kerr.ClusterAuthorizationFailed.Code)
-				continue outer
+			if e := c.denyCluster(creq, kmsg.ACLOperationAlterConfigs); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
+				answered[resource{rr.ResourceName, rr.ResourceType}] = true
+				if creq.skipsWork(e) { // a timed-out alter still applies
+					continue outer
+				}
 			}
 			if rr.ResourceName != "" {
 				iid, err := strconv.Atoi(rr.ResourceName)
@@ -104,9 +118,12 @@ outer:
 			c.persistBrokerConfigsState()
 
 		case kmsg.ConfigResourceTypeTopic:
-			if !c.allowedACL(creq, rr.ResourceName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationAlterConfigs) {
-				doner(rr.ResourceName, rr.ResourceType, kerr.TopicAuthorizationFailed.Code)
-				continue
+			if e := c.deny(creq, rr.ResourceName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationAlterConfigs, faultKey{resource: rr.ResourceName}); e != nil {
+				doner(rr.ResourceName, rr.ResourceType, e.Code)
+				answered[resource{rr.ResourceName, rr.ResourceType}] = true
+				if creq.skipsWork(e) { // a timed-out alter still applies
+					continue
+				}
 			}
 			if _, ok := c.data.tps.gett(rr.ResourceName); !ok {
 				doner(rr.ResourceName, rr.ResourceType, kerr.UnknownTopicOrPartition.Code)

--- a/pkg/kfake/45_alter_partition_assignments.go
+++ b/pkg/kfake/45_alter_partition_assignments.go
@@ -28,9 +28,11 @@ func (c *Cluster) handleAlterPartitionAssignments(creq *clientReq) (kmsg.Respons
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationAlter) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-		return resp, nil
+	if e := c.denyCluster(creq, kmsg.ACLOperationAlter); e != nil {
+		resp.ErrorCode = e.Code
+		if creq.skipsWork(e) {
+			return resp, nil
+		}
 	}
 
 	for _, rt := range req.Topics {
@@ -42,7 +44,12 @@ func (c *Cluster) handleAlterPartitionAssignments(creq *clientReq) (kmsg.Respons
 			sp := kmsg.NewAlterPartitionAssignmentsResponseTopicPartition()
 			sp.Partition = rp.Partition
 
-			if !ok {
+			// If replicas is non-nil, we "accept" the reassignment request
+			// but do nothing since kfake doesn't actually support multi-broker
+			// reassignment. ErrorCode stays 0 (success).
+			if e := creq.faults.check(faultKey{topic: rt.Topic}.part(rp.Partition)); e != nil {
+				sp.ErrorCode = e.Code
+			} else if !ok {
 				sp.ErrorCode = kerr.UnknownTopicOrPartition.Code
 			} else if _, pok := t[rp.Partition]; !pok {
 				sp.ErrorCode = kerr.UnknownTopicOrPartition.Code
@@ -51,9 +58,6 @@ func (c *Cluster) handleAlterPartitionAssignments(creq *clientReq) (kmsg.Respons
 				// any reassignments in progress.
 				sp.ErrorCode = kerr.NoReassignmentInProgress.Code
 			}
-			// If replicas is non-nil, we "accept" the reassignment request
-			// but do nothing since kfake doesn't actually support multi-broker
-			// reassignment. ErrorCode stays 0 (success).
 
 			st.Partitions = append(st.Partitions, sp)
 		}

--- a/pkg/kfake/46_list_partition_reassignments.go
+++ b/pkg/kfake/46_list_partition_reassignments.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -26,8 +25,8 @@ func (c *Cluster) handleListPartitionReassignments(creq *clientReq) (kmsg.Respon
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribe) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+	if e := c.denyCluster(creq, kmsg.ACLOperationDescribe); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 

--- a/pkg/kfake/48_describe_client_quotas.go
+++ b/pkg/kfake/48_describe_client_quotas.go
@@ -1,7 +1,6 @@
 package kfake
 
 import (
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -28,13 +27,25 @@ func (c *Cluster) handleDescribeClientQuotas(creq *clientReq) (kmsg.Response, er
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribeConfigs) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+	if e := c.denyCluster(creq, kmsg.ACLOperationDescribeConfigs); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
 	for _, quota := range c.quotas {
 		if matchesQuotaFilter(quota, req.Components, req.Strict) {
+			var faulted bool
+			for _, e := range quota.entity {
+				if e.name != nil {
+					if fe := creq.faults.check(faultKey{resource: *e.name}); fe != nil {
+						resp.ErrorCode = fe.Code
+						faulted = true
+					}
+				}
+			}
+			if faulted {
+				continue
+			}
 			entry := kmsg.NewDescribeClientQuotasResponseEntry()
 			for _, e := range quota.entity {
 				ee := kmsg.NewDescribeClientQuotasResponseEntryEntity()

--- a/pkg/kfake/49_alter_client_quotas.go
+++ b/pkg/kfake/49_alter_client_quotas.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
@@ -31,10 +30,11 @@ func (c *Cluster) handleAlterClientQuotas(creq *clientReq) (kmsg.Response, error
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationAlterConfigs) {
+	clusterErr := c.denyCluster(creq, kmsg.ACLOperationAlterConfigs)
+	if clusterErr != nil && creq.skipsWork(clusterErr) { // a timed-out alter still applies
 		for _, entry := range req.Entries {
 			re := kmsg.NewAlterClientQuotasResponseEntry()
-			re.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+			re.ErrorCode = clusterErr.Code
 			for _, e := range entry.Entity {
 				ee := kmsg.NewAlterClientQuotasResponseEntryEntity()
 				ee.Type = e.Type
@@ -48,11 +48,23 @@ func (c *Cluster) handleAlterClientQuotas(creq *clientReq) (kmsg.Response, error
 
 	for _, entry := range req.Entries {
 		re := kmsg.NewAlterClientQuotasResponseEntry()
+		faultErr := clusterErr
 		for _, e := range entry.Entity {
 			ee := kmsg.NewAlterClientQuotasResponseEntryEntity()
 			ee.Type = e.Type
 			ee.Name = e.Name
 			re.Entity = append(re.Entity, ee)
+			if e.Name != nil && faultErr == nil {
+				faultErr = creq.faults.check(faultKey{resource: *e.Name})
+			}
+		}
+		if faultErr != nil {
+			re.ErrorCode = faultErr.Code
+			re.ErrorMessage = kmsg.StringPtr(faultErr.Message)
+			if creq.skipsWork(faultErr) { // a timed-out alter still applies
+				resp.Entries = append(resp.Entries, re)
+				continue
+			}
 		}
 
 		if !req.ValidateOnly {

--- a/pkg/kfake/50_describe_user_scram_credentials.go
+++ b/pkg/kfake/50_describe_user_scram_credentials.go
@@ -24,8 +24,8 @@ func (c *Cluster) handleDescribeUserSCRAMCredentials(creq *clientReq) (kmsg.Resp
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribe) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+	if e := c.denyCluster(creq, kmsg.ACLOperationDescribe); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
@@ -55,6 +55,10 @@ func (c *Cluster) handleDescribeUserSCRAMCredentials(creq *clientReq) (kmsg.Resp
 
 	for u, duplicated := range describe {
 		sr := addr(u)
+		if e := creq.faults.check(faultKey{resource: u}); e != nil {
+			sr.ErrorCode = e.Code
+			continue
+		}
 		if duplicated {
 			sr.ErrorCode = kerr.DuplicateResource.Code
 			continue

--- a/pkg/kfake/51_alter_user_scram_credentials.go
+++ b/pkg/kfake/51_alter_user_scram_credentials.go
@@ -28,17 +28,17 @@ func (c *Cluster) handleAlterUserSCRAMCredentials(creq *clientReq) (kmsg.Respons
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationAlter) {
+	if e := c.denyCluster(creq, kmsg.ACLOperationAlter); e != nil && creq.skipsWork(e) { // a timed-out change still changes the credentials
 		for _, d := range req.Deletions {
 			sr := kmsg.NewAlterUserSCRAMCredentialsResponseResult()
 			sr.User = d.Name
-			sr.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+			sr.ErrorCode = e.Code
 			resp.Results = append(resp.Results, sr)
 		}
 		for _, u := range req.Upsertions {
 			sr := kmsg.NewAlterUserSCRAMCredentialsResponseResult()
 			sr.User = u.Name
-			sr.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+			sr.ErrorCode = e.Code
 			resp.Results = append(resp.Results, sr)
 		}
 		return resp, nil
@@ -50,16 +50,38 @@ func (c *Cluster) handleAlterUserSCRAMCredentials(creq *clientReq) (kmsg.Respons
 		resp.Results = append(resp.Results, sr)
 		return &resp.Results[len(resp.Results)-1]
 	}
+	// A fault can answer a user before the work runs. The work's own answer
+	// for that user must not add an entry or replace the code.
+	answered := make(map[string]bool)
 	doneu := func(u string, code int16) {
+		if answered[u] {
+			return
+		}
 		sr := addr(u)
 		sr.ErrorCode = code
 	}
 
 	users := make(map[string]int16)
+	faulted := func(u string) bool {
+		e := creq.faults.check(faultKey{resource: u})
+		if e == nil {
+			return false
+		}
+		doneu(u, e.Code)
+		answered[u] = true
+		if creq.skipsWork(e) { // a timed-out change still changes the credential
+			users[u] = e.Code
+			return true
+		}
+		return false
+	}
 
 	// Validate everything up front, keeping track of all (and duplicate)
 	// users. If we are not controller, we fail with our users map.
 	for _, d := range req.Deletions {
+		if faulted(d.Name) {
+			continue
+		}
 		if d.Name == "" {
 			users[d.Name] = kerr.UnacceptableCredential.Code
 			continue
@@ -71,6 +93,9 @@ func (c *Cluster) handleAlterUserSCRAMCredentials(creq *clientReq) (kmsg.Respons
 		users[d.Name] = 0
 	}
 	for _, u := range req.Upsertions {
+		if faulted(u.Name) {
+			continue
+		}
 		if u.Name == "" || u.Iterations < 4096 || u.Iterations > 16384 { // Kafka min/max
 			users[u.Name] = kerr.UnacceptableCredential.Code
 			continue

--- a/pkg/kfake/57_update_features.go
+++ b/pkg/kfake/57_update_features.go
@@ -54,9 +54,11 @@ func (c *Cluster) handleUpdateFeatures(creq *clientReq) (kmsg.Response, error) {
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationAlter) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
-		return resp, nil
+	if e := c.denyCluster(creq, kmsg.ACLOperationAlter); e != nil {
+		resp.ErrorCode = e.Code
+		if creq.skipsWork(e) { // a timed-out update still updates
+			return resp, nil
+		}
 	}
 
 	// Build per-feature results, then collapse into the top-level error
@@ -65,7 +67,13 @@ func (c *Cluster) handleUpdateFeatures(creq *clientReq) (kmsg.Response, error) {
 	pending := make(map[string]int16, len(req.FeatureUpdates))
 	seen := make(map[string]bool, len(req.FeatureUpdates))
 
+	// A fault can answer a feature before the work runs. The work's own
+	// answer for that feature must not add an entry or replace the code.
+	answered := make(map[string]bool)
 	fail := func(name string, err *kerr.Error, msg string) {
+		if answered[name] {
+			return
+		}
 		r := kmsg.NewUpdateFeaturesResponseResult()
 		r.Feature = name
 		r.ErrorCode = err.Code
@@ -75,12 +83,23 @@ func (c *Cluster) handleUpdateFeatures(creq *clientReq) (kmsg.Response, error) {
 		results = append(results, r)
 	}
 	ok := func(name string) {
+		if answered[name] {
+			return
+		}
 		r := kmsg.NewUpdateFeaturesResponseResult()
 		r.Feature = name
 		results = append(results, r)
 	}
 
 	for _, fu := range req.FeatureUpdates {
+		if e := creq.faults.check(faultKey{resource: fu.Feature}); e != nil {
+			fail(fu.Feature, e, "")
+			answered[fu.Feature] = true
+			if creq.skipsWork(e) { // a timed-out update still updates the feature
+				seen[fu.Feature] = true
+				continue
+			}
+		}
 		if seen[fu.Feature] {
 			fail(fu.Feature, kerr.InvalidRequest, "duplicate feature update")
 			continue

--- a/pkg/kfake/66_list_transactions.go
+++ b/pkg/kfake/66_list_transactions.go
@@ -23,5 +23,6 @@ func (c *Cluster) handleListTransactions(creq *clientReq) (kmsg.Response, error)
 	if err := c.checkReqVersion(creq.kreq.Key(), creq.kreq.GetVersion()); err != nil {
 		return nil, err
 	}
+
 	return c.pids.doListTransactions(creq), nil
 }

--- a/pkg/kfake/74_list_config_resources.go
+++ b/pkg/kfake/74_list_config_resources.go
@@ -32,8 +32,8 @@ func (c *Cluster) handleListConfigResources(creq *clientReq) (kmsg.Response, err
 		return nil, err
 	}
 
-	if !c.allowedClusterACL(creq, kmsg.ACLOperationDescribeConfigs) {
-		resp.ErrorCode = kerr.ClusterAuthorizationFailed.Code
+	if e := c.denyCluster(creq, kmsg.ACLOperationDescribeConfigs); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 

--- a/pkg/kfake/75_describe_topic_partitions.go
+++ b/pkg/kfake/75_describe_topic_partitions.go
@@ -105,9 +105,9 @@ func (c *Cluster) handleDescribeTopicPartitions(creq *clientReq) (kmsg.Response,
 			break
 		}
 
-		if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+		if e := c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic}); e != nil {
 			if !fetchAll {
-				addTopic(topic, kerr.TopicAuthorizationFailed.Code, noID, false)
+				addTopic(topic, e.Code, noID, false)
 			}
 			continue
 		}

--- a/pkg/kfake/76_share_group_heartbeat.go
+++ b/pkg/kfake/76_share_group_heartbeat.go
@@ -40,8 +40,8 @@ func (c *Cluster) handleShareGroupHeartbeat(creq *clientReq) (kmsg.Response, err
 	if ke := c.validateGroup(creq, req.GroupID); ke != nil {
 		return errResp(ke.Code)
 	}
-	if !c.allowedACL(creq, req.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		return errResp(kerr.GroupAuthorizationFailed.Code)
+	if e := c.deny(creq, req.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.GroupID}); e != nil {
+		return errResp(e.Code)
 	}
 	if req.MemberID == "" || len(req.MemberID) > 36 {
 		return errResp(kerr.InvalidRequest.Code)
@@ -56,8 +56,8 @@ func (c *Cluster) handleShareGroupHeartbeat(creq *clientReq) (kmsg.Response, err
 		return errResp(kerr.InvalidRequest.Code)
 	}
 	for _, topic := range req.SubscribedTopicNames {
-		if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
-			return errResp(kerr.TopicAuthorizationFailed.Code)
+		if e := c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic}); e != nil {
+			return errResp(e.Code)
 		}
 	}
 

--- a/pkg/kfake/77_share_group_describe.go
+++ b/pkg/kfake/77_share_group_describe.go
@@ -45,8 +45,8 @@ func (c *Cluster) handleShareGroupDescribe(creq *clientReq) (kmsg.Response, erro
 		}
 
 		// ACL: require GROUP DESCRIBE.
-		if !c.allowedACL(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
-			rg.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		if e := c.deny(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: groupID}); e != nil {
+			rg.ErrorCode = e.Code
 			resp.Groups = append(resp.Groups, rg)
 			continue
 		}
@@ -91,10 +91,10 @@ func (c *Cluster) handleShareGroupDescribe(creq *clientReq) (kmsg.Response, erro
 			// containing only the error (no state/epoch/assignor
 			// metadata leaked).
 			for topic := range allTopics {
-				if !c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+				if e := c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic}); e != nil {
 					rg = kmsg.NewShareGroupDescribeResponseGroup()
 					rg.GroupID = groupID
-					rg.ErrorCode = kerr.TopicAuthorizationFailed.Code
+					rg.ErrorCode = e.Code
 					return
 				}
 			}

--- a/pkg/kfake/78_share_fetch.go
+++ b/pkg/kfake/78_share_fetch.go
@@ -48,10 +48,11 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 	}
 
 	resp.AcquisitionLockTimeoutMillis = c.shareRecordLockDurationMs()
+	fc := creq.faults
 
 	// ACL: require GROUP READ.
-	if !c.allowedACL(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := c.deny(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: groupID}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
@@ -286,13 +287,18 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 			}
 			continue
 		}
-		if !c.allowedACL(creq, topicName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
+		tk := faultKey{topic: topicName, topicID: topicID}
+		if e := c.deny(creq, topicName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, tk); e != nil {
 			for p := range parts {
-				donep(topicID, p, kerr.TopicAuthorizationFailed.Code)
+				donep(topicID, p, e.Code)
 			}
 			continue
 		}
 		for p := range parts {
+			if e := fc.check(tk.part(p)); e != nil {
+				donep(topicID, p, e.Code)
+				continue
+			}
 			pd, ok := c.data.tps.getp(topicName, p)
 			if !ok {
 				donep(topicID, p, kerr.UnknownTopicOrPartition.Code)
@@ -445,7 +451,7 @@ func (c *Cluster) handleShareFetch(creq *clientReq, w *watchShareFetch) (kmsg.Re
 	// fireShareWatchers fires when acks free the window, so the watcher
 	// wakes up promptly instead of the client busy-looping with empty
 	// fetches.
-	if totalRecords == 0 && w == nil {
+	if totalRecords == 0 && w == nil && !fc.anyHit() { // a faulted partition completes the fetch at once
 		wait := time.Duration(req.MaxWaitMillis) * time.Millisecond
 		deadline := creq.at.Add(wait)
 		remaining := time.Until(deadline)

--- a/pkg/kfake/79_share_acknowledge.go
+++ b/pkg/kfake/79_share_acknowledge.go
@@ -40,8 +40,8 @@ func (c *Cluster) handleShareAcknowledge(creq *clientReq) (kmsg.Response, error)
 	}
 
 	// ACL: require GROUP READ.
-	if !c.allowedACL(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := c.deny(creq, groupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: groupID}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 

--- a/pkg/kfake/90_describe_share_group_offsets.go
+++ b/pkg/kfake/90_describe_share_group_offsets.go
@@ -44,8 +44,8 @@ func (c *Cluster) handleDescribeShareGroupOffsets(creq *clientReq) (kmsg.Respons
 		}
 
 		// ACL: require GROUP DESCRIBE.
-		if !c.allowedACL(creq, rg.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
-			rsg.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		if e := c.deny(creq, rg.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: rg.GroupID}); e != nil {
+			rsg.ErrorCode = e.Code
 			resp.Groups = append(resp.Groups, rsg)
 			continue
 		}
@@ -88,7 +88,7 @@ func (c *Cluster) handleDescribeShareGroupOffsets(creq *clientReq) (kmsg.Respons
 				rst.TopicID = c.data.t2id[tr.topic]
 
 				// ACL: per-topic DESCRIBE check.
-				if !c.allowedACL(creq, tr.topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+				if e := c.deny(creq, tr.topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: tr.topic}); e != nil {
 					if isDescribeAll {
 						// Describe-all: silently filter unauthorized topics.
 						continue
@@ -96,7 +96,7 @@ func (c *Cluster) handleDescribeShareGroupOffsets(creq *clientReq) (kmsg.Respons
 					for _, partition := range tr.partitions {
 						rsp := kmsg.NewDescribeShareGroupOffsetsResponseGroupTopicPartition()
 						rsp.Partition = partition
-						rsp.ErrorCode = kerr.TopicAuthorizationFailed.Code
+						rsp.ErrorCode = e.Code
 						rsp.StartOffset = -1
 						rsp.Lag = -1
 						rst.Partitions = append(rst.Partitions, rsp)
@@ -108,6 +108,14 @@ func (c *Cluster) handleDescribeShareGroupOffsets(creq *clientReq) (kmsg.Respons
 				for _, partition := range tr.partitions {
 					rsp := kmsg.NewDescribeShareGroupOffsetsResponseGroupTopicPartition()
 					rsp.Partition = partition
+
+					if e := creq.faults.check(faultKey{group: rg.GroupID, topic: tr.topic}.part(partition)); e != nil {
+						rsp.ErrorCode = e.Code
+						rsp.StartOffset = -1
+						rsp.Lag = -1
+						rst.Partitions = append(rst.Partitions, rsp)
+						continue
+					}
 
 					pd, ok := c.data.tps.getp(tr.topic, partition)
 					if !ok {

--- a/pkg/kfake/91_alter_share_group_offsets.go
+++ b/pkg/kfake/91_alter_share_group_offsets.go
@@ -31,8 +31,8 @@ func (c *Cluster) handleAlterShareGroupOffsets(creq *clientReq) (kmsg.Response, 
 	}
 
 	// ACL: require GROUP READ (Kafka uses READ, not ALTER).
-	if !c.allowedACL(creq, req.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := c.deny(creq, req.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.GroupID}); e != nil && creq.skipsWork(e) { // a timed-out reset falls through to the per-partition checks
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
@@ -42,16 +42,16 @@ func (c *Cluster) handleAlterShareGroupOffsets(creq *clientReq) (kmsg.Response, 
 	// Pre-lookup topic IDs, valid partitions, and ACL results while
 	// in run() where c.data is safe to read.
 	type alterTopicInfo struct {
-		id      uuid
-		valid   map[int32]struct{}
-		aclDeny bool
+		id    uuid
+		valid map[int32]struct{}
+		deny  *kerr.Error
 	}
 	topicInfo := make(map[string]alterTopicInfo, len(req.Topics))
 	for _, rt := range req.Topics {
 		info := alterTopicInfo{id: c.data.t2id[rt.Topic]}
 		// ACL: per-topic READ check.
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
-			info.aclDeny = true
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, faultKey{topic: rt.Topic, topicID: info.id}); e != nil && creq.skipsWork(e) { // a timed-out reset falls through to the per-partition check
+			info.deny = e
 		} else {
 			info.valid = make(map[int32]struct{})
 			for _, rp := range rt.Partitions {
@@ -80,11 +80,11 @@ func (c *Cluster) handleAlterShareGroupOffsets(creq *clientReq) (kmsg.Response, 
 			info := topicInfo[rt.Topic]
 			rst.TopicID = info.id
 
-			if info.aclDeny {
+			if info.deny != nil {
 				for j := range rt.Partitions {
 					rsp := kmsg.NewAlterShareGroupOffsetsResponseTopicPartition()
 					rsp.Partition = rt.Partitions[j].Partition
-					rsp.ErrorCode = kerr.TopicAuthorizationFailed.Code
+					rsp.ErrorCode = info.deny.Code
 					rst.Partitions = append(rst.Partitions, rsp)
 				}
 				resp.Topics = append(resp.Topics, rst)
@@ -96,8 +96,18 @@ func (c *Cluster) handleAlterShareGroupOffsets(creq *clientReq) (kmsg.Response, 
 				rsp := kmsg.NewAlterShareGroupOffsetsResponseTopicPartition()
 				rsp.Partition = rp.Partition
 
+				e := creq.faults.check(faultKey{group: req.GroupID, topic: rt.Topic, topicID: info.id}.part(rp.Partition))
+				if e != nil {
+					rsp.ErrorCode = e.Code
+					if creq.skipsWork(e) { // a timed-out reset still resets
+						rst.Partitions = append(rst.Partitions, rsp)
+						continue
+					}
+				}
 				if _, ok := info.valid[rp.Partition]; !ok {
-					rsp.ErrorCode = kerr.UnknownTopicOrPartition.Code
+					if e == nil {
+						rsp.ErrorCode = kerr.UnknownTopicOrPartition.Code
+					}
 					rst.Partitions = append(rst.Partitions, rsp)
 					continue
 				}

--- a/pkg/kfake/92_delete_share_group_offsets.go
+++ b/pkg/kfake/92_delete_share_group_offsets.go
@@ -31,8 +31,8 @@ func (c *Cluster) handleDeleteShareGroupOffsets(creq *clientReq) (kmsg.Response,
 	}
 
 	// ACL: require GROUP DELETE.
-	if !c.allowedACL(creq, req.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDelete) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := c.deny(creq, req.GroupID, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDelete, faultKey{group: req.GroupID}); e != nil && creq.skipsWork(e) { // a timed-out delete falls through to the per-topic checks
+		resp.ErrorCode = e.Code
 		return resp, nil
 	}
 
@@ -45,15 +45,15 @@ func (c *Cluster) handleDeleteShareGroupOffsets(creq *clientReq) (kmsg.Response,
 	// Pre-lookup topic IDs and ACL results while in run() where
 	// c.data is safe.
 	type deleteTopicInfo struct {
-		id      uuid
-		exists  bool
-		aclDeny bool
+		id     uuid
+		exists bool
+		deny   *kerr.Error
 	}
 	topicInfo := make(map[string]deleteTopicInfo, len(req.Topics))
 	for _, rt := range req.Topics {
 		info := deleteTopicInfo{id: c.data.t2id[rt.Topic]}
-		if !c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
-			info.aclDeny = true
+		if e := c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, faultKey{topic: rt.Topic, topicID: info.id}); e != nil {
+			info.deny = e
 		}
 		if _, ok := c.data.tps[rt.Topic]; ok {
 			info.exists = true
@@ -75,18 +75,20 @@ func (c *Cluster) handleDeleteShareGroupOffsets(creq *clientReq) (kmsg.Response,
 			info := topicInfo[rt.Topic]
 			rst.TopicID = info.id
 
-			if info.aclDeny {
-				rst.ErrorCode = kerr.TopicAuthorizationFailed.Code
-				resp.Topics = append(resp.Topics, rst)
-				continue
+			if info.deny != nil {
+				rst.ErrorCode = info.deny.Code
+				if creq.skipsWork(info.deny) { // a timed-out delete still deletes
+					resp.Topics = append(resp.Topics, rst)
+					continue
+				}
 			}
 			if !info.exists {
-				rst.ErrorCode = kerr.UnknownTopicOrPartition.Code
-				resp.Topics = append(resp.Topics, rst)
-				continue
+				if info.deny == nil {
+					rst.ErrorCode = kerr.UnknownTopicOrPartition.Code
+				}
+			} else {
+				delete(sg.partitions, rt.Topic)
 			}
-
-			delete(sg.partitions, rt.Topic)
 			resp.Topics = append(resp.Topics, rst)
 		}
 		sg.mu.Unlock() // not deferred: maybeQuit below acquires sg.mu

--- a/pkg/kfake/CLAUDE.md
+++ b/pkg/kfake/CLAUDE.md
@@ -184,16 +184,19 @@ ACL support is in `acl.go`. Uses kmsg types directly (`kmsg.ACLResourceType`, `k
 
 When implementing a new Kafka protocol handler, you MUST add ACL checks. I will provide links to Kafka documentation specifying which resources and operations to check.
 
+Handlers do not call allowedACL directly: c.deny and c.denyCluster check the
+ACL and the faults for that entity together (see the section below).
+
 Common patterns:
 ```go
 // Check specific resource
-if !c.allowedACL(creq, topicName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
-    return errResp(kerr.TopicAuthorizationFailed.Code), nil
+if e := c.deny(creq, topicName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, faultKey{topic: topicName}); e != nil {
+    return errResp(e.Code), nil
 }
 
 // Check cluster-level operation
-if !c.allowedClusterACL(creq, kmsg.ACLOperationAlter) {
-    return errResp(kerr.ClusterAuthorizationFailed.Code), nil
+if e := c.denyCluster(creq, kmsg.ACLOperationAlter); e != nil {
+    return errResp(e.Code), nil
 }
 
 // Check if user has ANY permission on resource type (e.g., InitProducerID without txn)
@@ -211,6 +214,39 @@ if !c.anyAllowedACL(creq, kmsg.ACLResourceTypeCluster, kmsg.ACLOperationIdempote
 | Group | Read, Delete, Describe |
 | Cluster | Create, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite |
 | TransactionalId | Describe, Write |
+
+## Faults and authorization in handlers
+
+Adding a request:
+- `regKey(NN, min, max)` in `NN_<name>.go`, the handler in the `cluster.go` switch, `checkReqVersion` first.
+
+Authorization and faults:
+- Check every resource the request touches through `c.deny` (topic, group, transactional ID: pass the resource type and operation) or `c.denyCluster`.
+- Check beside the point the handler emits that entity's error, before any side effect.
+- A request that carries partitions also calls `creq.faults.check` inside the partition loop, with the partition in the key.
+- A request with nothing to authorize goes in the `entityless` set in `faults.go`.
+
+The fault key:
+- Name every identifier the request carries that is known at that site: topic, topicID, partition, group, txnID, resource.
+- A selector the key does not name never matches, so a missing field silently drops faults.
+
+Emission:
+- Answer first with `e.Code` (and `e.Message` where the response carries one), then:
+```go
+if creq.skipsWork(e) {
+    continue
+}
+```
+- A kind whose real broker can answer REQUEST_TIMED_OUT after applying the work goes in the `afterApply` table in `faults.go`.
+- Such a kind's emission closure keeps the first answer for an entity; see `donep` in `00_produce.go`.
+
+Tests after touching a handler:
+- `TestFaultCoverage`: every registered key answers a selector-less fault.
+- The ACL tests for that request.
+- The package with `-race`.
+
+Comments:
+- ASCII, terse, plain statements. "we" is the broker, "you" is the caller.
 
 ## Authorized Operations (KIP-430)
 

--- a/pkg/kfake/client_conn.go
+++ b/pkg/kfake/client_conn.go
@@ -40,6 +40,7 @@ type (
 		corr      int32
 		seq       uint32
 		topicMeta topicMetaSnap // snapshot for group assignment (consumer/share)
+		faults    *faultCheck   // faults that can match this request, see Fault
 
 		// Pre-validated error topics to merge into the response,
 		// used when TopicID resolution fails for some topics while

--- a/pkg/kfake/cluster.go
+++ b/pkg/kfake/cluster.go
@@ -38,6 +38,10 @@ type (
 		sleeping       map[*clientConn]*bsleep
 		controlSleep   chan sleepChs
 
+		faultsMu  sync.Mutex
+		faults    []*fault
+		faultCond *sync.Cond // broadcast on every fault hit, see FaultHandle.Wait
+
 		data               data
 		pids               pids
 		groups             groups
@@ -591,6 +595,10 @@ outer:
 		}
 
 		kreq = creq.kreq
+		creq.faults = c.faultsFor(creq)
+		if kresp = creq.faults.topLevel(kreq); kresp != nil {
+			goto afterControl
+		}
 		switch k := kmsg.Key(kreq.Key()); k {
 		case kmsg.Produce:
 			kresp, err = c.handleProduce(creq)
@@ -621,7 +629,7 @@ outer:
 		case kmsg.SASLHandshake:
 			kresp, err = c.handleSASLHandshake(creq)
 		case kmsg.ApiVersions:
-			kresp, err = c.handleApiVersions(kreq)
+			kresp, err = c.handleApiVersions(creq)
 		case kmsg.CreateTopics:
 			kresp, err = c.handleCreateTopics(creq)
 		case kmsg.DeleteTopics:

--- a/pkg/kfake/consumer_sweep_test.go
+++ b/pkg/kfake/consumer_sweep_test.go
@@ -15,68 +15,29 @@ import (
 // Regression tests for consumer.go + consumer_direct.go. Each TestAudit*
 // below fails before its corresponding kgo fix.
 
-// fenceNextFetch installs a control that answers exactly one fetch request
-// with FENCED_LEADER_EPOCH for partition 0 of the topic. The client reacts by
-// marking the cursor unusable and queueing an OffsetForLeaderEpoch validation
-// at the cursor's current offset - the validation load's completion is the
-// only thing that re-enables the cursor.
+// fenceNextFetch fails exactly one fetch of partition 0 of the topic with
+// FENCED_LEADER_EPOCH. The client marks the cursor unusable and queues an
+// OffsetForLeaderEpoch validation. Only that validation re-enables the
+// cursor.
 func fenceNextFetch(c *Cluster, topic string) {
-	ti := c.TopicInfo(topic)
-	pi := c.PartitionInfo(topic, 0)
-	var fenced atomic.Bool
-	c.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		c.KeepControl()
-		if fenced.Swap(true) {
-			return nil, nil, false // already fenced once; serve real data
-		}
-		req := kreq.(*kmsg.FetchRequest)
-		resp := req.ResponseKind().(*kmsg.FetchResponse)
-		rt := kmsg.NewFetchResponseTopic()
-		rt.Topic = topic
-		rt.TopicID = ti.TopicID
-		rp := kmsg.NewFetchResponseTopicPartition()
-		rp.Partition = 0
-		rp.ErrorCode = kerr.FencedLeaderEpoch.Code
-		rp.HighWatermark = pi.HighWatermark
-		rp.LastStableOffset = pi.LastStableOffset
-		rp.LogStartOffset = 0
-		rt.Partitions = append(rt.Partitions, rp)
-		resp.Topics = append(resp.Topics, rt)
-		return resp, nil, true
+	c.Fault(Fault{
+		Keys:       []kmsg.Key{kmsg.Fetch},
+		Topic:      topic,
+		Partitions: []int32{0},
+		Err:        kerr.FencedLeaderEpoch,
+		Count:      1,
 	})
 }
 
-// failNextOFLE installs a control that answers exactly one
-// OffsetForLeaderEpoch request with a retriable NOT_LEADER_FOR_PARTITION
-// error, closing entered as it does. The retriable failure makes the client
-// keep the validation load pending (it schedules a reload), opening a window
-// in which the load exists but has not completed - without ever blocking the
-// cluster's request loop.
-func failNextOFLE(c *Cluster) (entered chan struct{}) {
-	entered = make(chan struct{})
-	var once atomic.Bool
-	c.ControlKey(int16(kmsg.OffsetForLeaderEpoch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		c.KeepControl()
-		if once.Swap(true) {
-			return nil, nil, false // later validations are served for real
-		}
-		req := kreq.(*kmsg.OffsetForLeaderEpochRequest)
-		resp := req.ResponseKind().(*kmsg.OffsetForLeaderEpochResponse)
-		for _, rt := range req.Topics {
-			st := kmsg.NewOffsetForLeaderEpochResponseTopic()
-			st.Topic = rt.Topic
-			for _, rp := range rt.Partitions {
-				sp := kmsg.NewOffsetForLeaderEpochResponseTopicPartition()
-				sp.Partition = rp.Partition
-				sp.ErrorCode = kerr.NotLeaderForPartition.Code
-				st.Partitions = append(st.Partitions, sp)
-			}
-			resp.Topics = append(resp.Topics, st)
-		}
-		close(entered)
-		return resp, nil, true
+// failNextOFLE fails exactly one OffsetForLeaderEpoch request with a
+// retryable NOT_LEADER_FOR_PARTITION. The client schedules a reload and
+// keeps the validation load pending, so the load exists but has not
+// completed.
+func failNextOFLE(c *Cluster) *FaultHandle {
+	return c.Fault(Fault{
+		Keys: []kmsg.Key{kmsg.OffsetForLeaderEpoch},
+		Err:  kerr.NotLeaderForPartition,
 	})
-	return entered
 }
 
 // TestAuditSetOffsetsNotClobberedByPendingLoad verifies that SetOffsets on a
@@ -110,13 +71,13 @@ func TestAuditSetOffsetsNotClobberedByPendingLoad(t *testing.T) {
 
 	// Fence the next fetch so the client queues an epoch validation at
 	// offset 10, and fail that validation retriably so it stays pending.
-	ofleEntered := failNextOFLE(c)
+	ofle := failNextOFLE(c)
 	fenceNextFetch(c, topic)
 
-	select {
-	case <-ofleEntered:
-	case <-time.After(8 * time.Second):
-		t.Fatal("timed out waiting for the epoch validation load to be issued")
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer waitCancel()
+	if err := ofle.Wait(waitCtx, 1); err != nil {
+		t.Fatalf("waiting for the epoch validation load to be issued: %v", err)
 	}
 
 	// The validation load for offset 10 is now pending (its retriable
@@ -159,12 +120,12 @@ func TestAuditStopSessionPromptWhilePendingReload(t *testing.T) {
 	)
 	collectRecords(t, cl, msgs, 8*time.Second)
 
-	ofleEntered := failNextOFLE(c)
+	ofle := failNextOFLE(c)
 	fenceNextFetch(c, topic)
-	select {
-	case <-ofleEntered:
-	case <-time.After(8 * time.Second):
-		t.Fatal("timed out waiting for the epoch validation load to be issued")
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer waitCancel()
+	if err := ofle.Wait(waitCtx, 1); err != nil {
+		t.Fatalf("waiting for the epoch validation load to be issued: %v", err)
 	}
 
 	// The epoch validation is now reload-looping. Stopping the session
@@ -206,38 +167,13 @@ func TestAuditPendingReloadSurvivesPartitionRevoke(t *testing.T) {
 	c := newCluster(t, NumBrokers(1), SeedTopics(1, kept, dropped))
 	produceN(t, c, kept, msgs)
 
-	var failKept atomic.Bool
-	failKept.Store(true)
-	var signaled atomic.Bool
-	keptFailing := make(chan struct{})
-
-	// Fail the kept topic's offset listing with a retriable error while
-	// failKept is set, keeping it in a reload loop. Everything else (the
-	// dropped topic, and the kept topic once we allow it) lists to offset 0,
-	// the log start of these freshly seeded topics.
-	c.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		c.KeepControl()
-		req := kreq.(*kmsg.ListOffsetsRequest)
-		resp := req.ResponseKind().(*kmsg.ListOffsetsResponse)
-		for _, rt := range req.Topics {
-			st := kmsg.NewListOffsetsResponseTopic()
-			st.Topic = rt.Topic
-			for _, rp := range rt.Partitions {
-				sp := kmsg.NewListOffsetsResponseTopicPartition()
-				sp.Partition = rp.Partition
-				if rt.Topic == kept && failKept.Load() {
-					sp.ErrorCode = kerr.NotLeaderForPartition.Code
-					if !signaled.Swap(true) {
-						close(keptFailing)
-					}
-				} else {
-					sp.Offset = 0
-				}
-				st.Partitions = append(st.Partitions, sp)
-			}
-			resp.Topics = append(resp.Topics, st)
-		}
-		return resp, nil, true
+	// Fail the kept topic's offset listing with a retryable error. It stays
+	// in a reload loop until we remove the fault.
+	failKept := c.Fault(Fault{
+		Keys:  []kmsg.Key{kmsg.ListOffsets},
+		Topic: kept,
+		Err:   kerr.NotLeaderForPartition,
+		Count: -1,
 	})
 
 	cl := newPlainClient(t, c,
@@ -263,12 +199,12 @@ func TestAuditPendingReloadSurvivesPartitionRevoke(t *testing.T) {
 		}
 	}()
 
-	// Wait for the kept partition to enter its retriable reload loop. Firing
+	// Wait for the kept partition to enter its retryable reload loop. Firing
 	// the revoke now lands while the reload is in flight or in its backoff.
-	select {
-	case <-keptFailing:
-	case <-time.After(10 * time.Second):
-		t.Fatal("kept partition never entered the offset reload loop")
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer waitCancel()
+	if err := failKept.Wait(waitCtx, 1); err != nil {
+		t.Fatalf("kept partition never entered the offset reload loop: %v", err)
 	}
 
 	// Stop the session by revoking the OTHER partition. kept is retained, so
@@ -277,7 +213,7 @@ func TestAuditPendingReloadSurvivesPartitionRevoke(t *testing.T) {
 
 	// Let kept's listing succeed. It only resumes if the reload survived the
 	// stop; if it was dropped, kept has no cursor and never lists again.
-	failKept.Store(false)
+	failKept.Remove()
 
 	got := 0
 	deadline := time.After(15 * time.Second)
@@ -362,12 +298,12 @@ func TestAuditTxnAbortRewindNotClobberedByPendingLoad(t *testing.T) {
 	}
 	pollN(msgs - committed)
 
-	ofleEntered := failNextOFLE(c)
+	ofle := failNextOFLE(c)
 	fenceNextFetch(c, topic)
-	select {
-	case <-ofleEntered:
-	case <-time.After(8 * time.Second):
-		t.Fatal("timed out waiting for the epoch validation load to be issued")
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer waitCancel()
+	if err := ofle.Wait(waitCtx, 1); err != nil {
+		t.Fatalf("waiting for the epoch validation load to be issued: %v", err)
 	}
 
 	if _, err := s.End(ctx, kgo.TryAbort); err != nil {

--- a/pkg/kfake/fault_test.go
+++ b/pkg/kfake/fault_test.go
@@ -1,0 +1,1475 @@
+package kfake
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// hasErrorCode reports whether any error code anywhere in resp is code.
+func hasErrorCode(resp kmsg.Response, code int16) bool {
+	var walk func(v reflect.Value) bool
+	walk = func(v reflect.Value) bool {
+		switch v.Kind() {
+		case reflect.Pointer, reflect.Interface:
+			return !v.IsNil() && walk(v.Elem())
+		case reflect.Slice, reflect.Array:
+			for i := range v.Len() {
+				if walk(v.Index(i)) {
+					return true
+				}
+			}
+		case reflect.Struct:
+			t := v.Type()
+			for i := range v.NumField() {
+				f := t.Field(i)
+				if !f.IsExported() {
+					continue
+				}
+				if f.Type.Kind() == reflect.Int16 && (f.Name == "ErrorCode" || f.Name == "AcknowledgeErrorCode") {
+					if v.Field(i).Int() == int64(code) {
+						return true
+					}
+					continue
+				}
+				if walk(v.Field(i)) {
+					return true
+				}
+			}
+		default:
+		}
+		return false
+	}
+	return walk(reflect.ValueOf(resp))
+}
+
+// coverageReq builds a minimal request of the key that names something we can
+// fault. It returns nil for a key we cannot exercise.
+func coverageReq(key int16, topic string, id [16]byte, group, txnID string) kmsg.Request {
+	part := func() kmsg.Request { return kmsg.RequestForKey(key) }
+	switch kmsg.Key(key) {
+	case kmsg.Produce:
+		req := kmsg.NewPtrProduceRequest()
+		req.Acks = -1
+		req.TimeoutMillis = 1000
+		rt := kmsg.NewProduceRequestTopic()
+		rt.Topic, rt.TopicID = topic, id
+		rp := kmsg.NewProduceRequestTopicPartition()
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.Fetch:
+		req := kmsg.NewPtrFetchRequest()
+		req.MaxWaitMillis = 100
+		req.MinBytes = 1
+		req.SessionEpoch = -1
+		rt := kmsg.NewFetchRequestTopic()
+		rt.Topic, rt.TopicID = topic, id
+		rp := kmsg.NewFetchRequestTopicPartition()
+		rp.CurrentLeaderEpoch = -1
+		rp.PartitionMaxBytes = 1 << 20
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.ListOffsets:
+		req := kmsg.NewPtrListOffsetsRequest()
+		req.ReplicaID = -1
+		rt := kmsg.NewListOffsetsRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewListOffsetsRequestTopicPartition()
+		rp.Timestamp, rp.CurrentLeaderEpoch = -1, -1
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.Metadata:
+		req := kmsg.NewPtrMetadataRequest()
+		rt := kmsg.NewMetadataRequestTopic()
+		rt.Topic, rt.TopicID = kmsg.StringPtr(topic), id
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.OffsetCommit:
+		req := kmsg.NewPtrOffsetCommitRequest()
+		req.Group = group
+		req.Generation = -1
+		rt := kmsg.NewOffsetCommitRequestTopic()
+		rt.Topic, rt.TopicID = topic, id
+		rp := kmsg.NewOffsetCommitRequestTopicPartition()
+		rp.LeaderEpoch = -1
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.OffsetFetch:
+		req := kmsg.NewPtrOffsetFetchRequest()
+		rg := kmsg.NewOffsetFetchRequestGroup()
+		rg.Group = group
+		rg.MemberEpoch = -1
+		rt := kmsg.NewOffsetFetchRequestGroupTopic()
+		rt.Topic, rt.TopicID = topic, id
+		rt.Partitions = append(rt.Partitions, 0)
+		rg.Topics = append(rg.Topics, rt)
+		req.Groups = append(req.Groups, rg)
+		return req
+	case kmsg.FindCoordinator:
+		req := kmsg.NewPtrFindCoordinatorRequest()
+		req.CoordinatorKeys = []string{group}
+		req.CoordinatorKey = group
+		return req
+	case kmsg.JoinGroup:
+		req := kmsg.NewPtrJoinGroupRequest()
+		req.Group = group
+		req.SessionTimeoutMillis = 10000
+		req.RebalanceTimeoutMillis = 10000
+		req.ProtocolType = "consumer"
+		p := kmsg.NewJoinGroupRequestProtocol()
+		p.Name = "range"
+		req.Protocols = append(req.Protocols, p)
+		return req
+	case kmsg.Heartbeat:
+		req := kmsg.NewPtrHeartbeatRequest()
+		req.Group = group
+		req.Generation = -1
+		return req
+	case kmsg.LeaveGroup:
+		req := kmsg.NewPtrLeaveGroupRequest()
+		req.Group = group
+		m := kmsg.NewLeaveGroupRequestMember()
+		m.MemberID = "m"
+		req.Members = append(req.Members, m)
+		return req
+	case kmsg.SyncGroup:
+		req := kmsg.NewPtrSyncGroupRequest()
+		req.Group = group
+		req.Generation = -1
+		return req
+	case kmsg.DescribeGroups:
+		req := kmsg.NewPtrDescribeGroupsRequest()
+		req.Groups = []string{group}
+		return req
+	case kmsg.CreateTopics:
+		req := kmsg.NewPtrCreateTopicsRequest()
+		rt := kmsg.NewCreateTopicsRequestTopic()
+		rt.Topic = "coverage-created"
+		rt.NumPartitions, rt.ReplicationFactor = 1, 1
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.DeleteTopics:
+		req := kmsg.NewPtrDeleteTopicsRequest()
+		rt := kmsg.NewDeleteTopicsRequestTopic()
+		rt.Topic = kmsg.StringPtr("coverage-deleted")
+		req.Topics = append(req.Topics, rt)
+		req.TopicNames = []string{"coverage-deleted"}
+		return req
+	case kmsg.DeleteRecords:
+		req := kmsg.NewPtrDeleteRecordsRequest()
+		rt := kmsg.NewDeleteRecordsRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewDeleteRecordsRequestTopicPartition()
+		rp.Offset = -1
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.InitProducerID:
+		req := kmsg.NewPtrInitProducerIDRequest()
+		req.TransactionalID = kmsg.StringPtr(txnID)
+		req.TransactionTimeoutMillis = 10000
+		req.ProducerID, req.ProducerEpoch = -1, -1
+		return req
+	case kmsg.OffsetForLeaderEpoch:
+		req := kmsg.NewPtrOffsetForLeaderEpochRequest()
+		req.ReplicaID = -1
+		rt := kmsg.NewOffsetForLeaderEpochRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewOffsetForLeaderEpochRequestTopicPartition()
+		rp.CurrentLeaderEpoch = -1
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.AddPartitionsToTxn:
+		req := kmsg.NewPtrAddPartitionsToTxnRequest()
+		req.Version = 3 // v4+ is the broker to broker batched shape
+		req.TransactionalID = txnID
+		req.ProducerEpoch = -1
+		rt := kmsg.NewAddPartitionsToTxnRequestTopic()
+		rt.Topic = topic
+		rt.Partitions = []int32{0}
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.AddOffsetsToTxn:
+		req := kmsg.NewPtrAddOffsetsToTxnRequest()
+		req.TransactionalID = txnID
+		req.Group = group
+		req.ProducerEpoch = -1
+		return req
+	case kmsg.EndTxn:
+		req := kmsg.NewPtrEndTxnRequest()
+		req.TransactionalID = txnID
+		req.ProducerEpoch = -1
+		return req
+	case kmsg.WriteTxnMarkers:
+		req := kmsg.NewPtrWriteTxnMarkersRequest()
+		m := kmsg.NewWriteTxnMarkersRequestMarker()
+		mt := kmsg.NewWriteTxnMarkersRequestMarkerTopic()
+		mt.Topic = topic
+		mt.Partitions = []int32{0}
+		m.Topics = append(m.Topics, mt)
+		req.Markers = append(req.Markers, m)
+		return req
+	case kmsg.TxnOffsetCommit:
+		req := kmsg.NewPtrTxnOffsetCommitRequest()
+		req.TransactionalID = txnID
+		req.Group = group
+		req.ProducerEpoch = -1
+		req.Generation = -1
+		rt := kmsg.NewTxnOffsetCommitRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewTxnOffsetCommitRequestTopicPartition()
+		rp.LeaderEpoch = -1
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.CreateACLs:
+		req := kmsg.NewPtrCreateACLsRequest()
+		cr := kmsg.NewCreateACLsRequestCreation()
+		cr.ResourceType = kmsg.ACLResourceTypeTopic
+		cr.ResourceName = topic
+		cr.ResourcePatternType = kmsg.ACLResourcePatternTypeLiteral
+		cr.Principal = "User:coverage"
+		cr.Host = "*"
+		cr.Operation = kmsg.ACLOperationRead
+		cr.PermissionType = kmsg.ACLPermissionTypeAllow
+		req.Creations = append(req.Creations, cr)
+		return req
+	case kmsg.DeleteACLs:
+		req := kmsg.NewPtrDeleteACLsRequest()
+		f := kmsg.NewDeleteACLsRequestFilter()
+		f.ResourceType = kmsg.ACLResourceTypeTopic
+		f.ResourceName = kmsg.StringPtr(topic)
+		f.ResourcePatternType = kmsg.ACLResourcePatternTypeLiteral
+		f.Operation = kmsg.ACLOperationAny
+		f.PermissionType = kmsg.ACLPermissionTypeAny
+		req.Filters = append(req.Filters, f)
+		return req
+	case kmsg.DescribeConfigs:
+		req := kmsg.NewPtrDescribeConfigsRequest()
+		rr := kmsg.NewDescribeConfigsRequestResource()
+		rr.ResourceType = kmsg.ConfigResourceTypeTopic
+		rr.ResourceName = topic
+		req.Resources = append(req.Resources, rr)
+		return req
+	case kmsg.AlterConfigs:
+		req := kmsg.NewPtrAlterConfigsRequest()
+		rr := kmsg.NewAlterConfigsRequestResource()
+		rr.ResourceType = kmsg.ConfigResourceTypeTopic
+		rr.ResourceName = topic
+		req.Resources = append(req.Resources, rr)
+		return req
+	case kmsg.IncrementalAlterConfigs:
+		req := kmsg.NewPtrIncrementalAlterConfigsRequest()
+		rr := kmsg.NewIncrementalAlterConfigsRequestResource()
+		rr.ResourceType = kmsg.ConfigResourceTypeTopic
+		rr.ResourceName = topic
+		req.Resources = append(req.Resources, rr)
+		return req
+	case kmsg.AlterReplicaLogDirs:
+		req := kmsg.NewPtrAlterReplicaLogDirsRequest()
+		rd := kmsg.NewAlterReplicaLogDirsRequestDir()
+		rd.Dir = "/kfake"
+		rt := kmsg.NewAlterReplicaLogDirsRequestDirTopic()
+		rt.Topic = topic
+		rt.Partitions = []int32{0}
+		rd.Topics = append(rd.Topics, rt)
+		req.Dirs = append(req.Dirs, rd)
+		return req
+	case kmsg.CreatePartitions:
+		req := kmsg.NewPtrCreatePartitionsRequest()
+		rt := kmsg.NewCreatePartitionsRequestTopic()
+		rt.Topic = topic
+		rt.Count = 5
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.DeleteGroups:
+		req := kmsg.NewPtrDeleteGroupsRequest()
+		req.Groups = []string{group}
+		return req
+	case kmsg.ElectLeaders:
+		req := kmsg.NewPtrElectLeadersRequest()
+		rt := kmsg.NewElectLeadersRequestTopic()
+		rt.Topic = topic
+		rt.Partitions = []int32{0}
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.AlterPartitionAssignments:
+		req := kmsg.NewPtrAlterPartitionAssignmentsRequest()
+		rt := kmsg.NewAlterPartitionAssignmentsRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewAlterPartitionAssignmentsRequestTopicPartition()
+		rp.Replicas = []int32{0}
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.OffsetDelete:
+		req := kmsg.NewPtrOffsetDeleteRequest()
+		req.Group = group
+		rt := kmsg.NewOffsetDeleteRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewOffsetDeleteRequestTopicPartition()
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.AlterClientQuotas:
+		req := kmsg.NewPtrAlterClientQuotasRequest()
+		e := kmsg.NewAlterClientQuotasRequestEntry()
+		ent := kmsg.NewAlterClientQuotasRequestEntryEntity()
+		ent.Type = "client-id"
+		ent.Name = kmsg.StringPtr("coverage")
+		e.Entity = append(e.Entity, ent)
+		op := kmsg.NewAlterClientQuotasRequestEntryOp()
+		op.Key = "producer_byte_rate"
+		op.Value = 1000
+		e.Ops = append(e.Ops, op)
+		req.Entries = append(req.Entries, e)
+		return req
+	case kmsg.DescribeUserSCRAMCredentials:
+		req := kmsg.NewPtrDescribeUserSCRAMCredentialsRequest()
+		u := kmsg.NewDescribeUserSCRAMCredentialsRequestUser()
+		u.Name = "coverage"
+		req.Users = append(req.Users, u)
+		return req
+	case kmsg.AlterUserSCRAMCredentials:
+		req := kmsg.NewPtrAlterUserSCRAMCredentialsRequest()
+		u := kmsg.NewAlterUserSCRAMCredentialsRequestUpsertion()
+		u.Name = "coverage"
+		u.Mechanism = 2
+		u.Iterations = 4096
+		u.Salt = []byte("salt")
+		u.SaltedPassword = []byte("pass")
+		req.Upsertions = append(req.Upsertions, u)
+		return req
+	case kmsg.UpdateFeatures:
+		req := kmsg.NewPtrUpdateFeaturesRequest()
+		fu := kmsg.NewUpdateFeaturesRequestFeatureUpdate()
+		fu.Feature = "transaction.version"
+		fu.MaxVersionLevel = 2
+		req.FeatureUpdates = append(req.FeatureUpdates, fu)
+		return req
+	case kmsg.DescribeProducers:
+		req := kmsg.NewPtrDescribeProducersRequest()
+		rt := kmsg.NewDescribeProducersRequestTopic()
+		rt.Topic = topic
+		rt.Partitions = []int32{0}
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.DescribeTransactions:
+		req := kmsg.NewPtrDescribeTransactionsRequest()
+		req.TransactionalIDs = []string{txnID}
+		return req
+	case kmsg.ConsumerGroupHeartbeat:
+		req := kmsg.NewPtrConsumerGroupHeartbeatRequest()
+		req.Group = group
+		req.MemberID = "00000000-0000-0000-0000-000000000001"
+		req.MemberEpoch = 0
+		req.RebalanceTimeoutMillis = 10000
+		req.SubscribedTopicNames = []string{topic}
+		return req
+	case kmsg.ConsumerGroupDescribe:
+		req := kmsg.NewPtrConsumerGroupDescribeRequest()
+		req.Groups = []string{group}
+		return req
+	case kmsg.DescribeTopicPartitions:
+		req := kmsg.NewPtrDescribeTopicPartitionsRequest()
+		rt := kmsg.NewDescribeTopicPartitionsRequestTopic()
+		rt.Topic = topic
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.ShareGroupHeartbeat:
+		req := kmsg.NewPtrShareGroupHeartbeatRequest()
+		req.GroupID = group
+		req.MemberID = "00000000-0000-0000-0000-000000000002"
+		req.MemberEpoch = 0
+		req.SubscribedTopicNames = []string{topic}
+		return req
+	case kmsg.ShareGroupDescribe:
+		req := kmsg.NewPtrShareGroupDescribeRequest()
+		req.GroupIDs = []string{group}
+		return req
+	case kmsg.ShareFetch:
+		req := kmsg.NewPtrShareFetchRequest()
+		req.GroupID = kmsg.StringPtr(group)
+		req.MemberID = kmsg.StringPtr("00000000-0000-0000-0000-000000000003")
+		req.ShareSessionEpoch = 0
+		req.MaxWaitMillis = 100
+		req.MaxRecords = 100
+		rt := kmsg.NewShareFetchRequestTopic()
+		rt.TopicID = id
+		rp := kmsg.NewShareFetchRequestTopicPartition()
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.ShareAcknowledge:
+		req := kmsg.NewPtrShareAcknowledgeRequest()
+		req.GroupID = kmsg.StringPtr(group)
+		req.MemberID = kmsg.StringPtr("00000000-0000-0000-0000-000000000003")
+		req.ShareSessionEpoch = 1
+		rt := kmsg.NewShareAcknowledgeRequestTopic()
+		rt.TopicID = id
+		rp := kmsg.NewShareAcknowledgeRequestTopicPartition()
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.DescribeShareGroupOffsets:
+		req := kmsg.NewPtrDescribeShareGroupOffsetsRequest()
+		rg := kmsg.NewDescribeShareGroupOffsetsRequestGroup()
+		rg.GroupID = group
+		rt := kmsg.NewDescribeShareGroupOffsetsRequestGroupTopic()
+		rt.Topic = topic
+		rt.Partitions = []int32{0}
+		rg.Topics = append(rg.Topics, rt)
+		req.Groups = append(req.Groups, rg)
+		return req
+	case kmsg.AlterShareGroupOffsets:
+		req := kmsg.NewPtrAlterShareGroupOffsetsRequest()
+		req.GroupID = group
+		rt := kmsg.NewAlterShareGroupOffsetsRequestTopic()
+		rt.Topic = topic
+		rp := kmsg.NewAlterShareGroupOffsetsRequestTopicPartition()
+		rt.Partitions = append(rt.Partitions, rp)
+		req.Topics = append(req.Topics, rt)
+		return req
+	case kmsg.DeleteShareGroupOffsets:
+		req := kmsg.NewPtrDeleteShareGroupOffsetsRequest()
+		req.GroupID = group
+		rt := kmsg.NewDeleteShareGroupOffsetsRequestTopic()
+		rt.Topic = topic
+		req.Topics = append(req.Topics, rt)
+		return req
+	default:
+		// ApiVersions, SASL, telemetry, and the cluster and listing
+		// requests carry nothing to name.
+		return part()
+	}
+}
+
+// Every request we handle can be faulted.
+func TestFaultCoverage(t *testing.T) {
+	t.Parallel()
+	const topic, group, txnID = "t", "g", "x"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic, "coverage-deleted"))
+	cl := newPlainClient(t, c)
+	id := c.TopicInfo(topic).TopicID
+
+	// A join creates the group the later requests need.
+	join := coverageReq(int16(kmsg.JoinGroup), topic, id, group, txnID)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := cl.Broker(0).Request(ctx, join); err != nil {
+		t.Fatalf("seeding the group: %v", err)
+	}
+
+	keys := make([]int16, 0, len(apiVersionsKeys))
+	apiVersionsMu.Lock()
+	for k := range apiVersionsKeys {
+		keys = append(keys, k)
+	}
+	apiVersionsMu.Unlock()
+
+	for _, key := range keys {
+		t.Run(kmsg.NameForKey(key), func(t *testing.T) {
+			req := coverageReq(key, topic, id, group, txnID)
+			if req == nil {
+				t.Skip("no minimal request")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			// The client sends its own ApiVersions when it opens a
+			// connection. We open the connection before installing
+			// the fault.
+			if _, err := cl.Broker(0).Request(ctx, kmsg.NewPtrApiVersionsRequest()); err != nil {
+				t.Fatalf("opening the connection: %v", err)
+			}
+
+			h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.Key(key)}, Count: -1, Err: kerr.UnknownServerError})
+			defer h.Remove()
+
+			resp, err := cl.Broker(0).Request(ctx, req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			if n := h.Hits(); n == 0 {
+				t.Errorf("fault never fired")
+			}
+			// We answer AddPartitionsToTxn in its v3 shape while
+			// advertising v5, so a raw request negotiated at v5
+			// carries no partitions for us to answer.
+			if kmsg.Key(key) == kmsg.AddPartitionsToTxn {
+				return
+			}
+			if !hasErrorCode(resp, kerr.UnknownServerError.Code) {
+				t.Errorf("response carries no injected error code")
+			}
+		})
+	}
+}
+
+// faultReq sends req to a node and returns the response.
+func faultReq(t *testing.T, cl *kgo.Client, node int32, req kmsg.Request) kmsg.Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	resp, err := cl.Broker(int(node)).Request(ctx, req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	return resp
+}
+
+func listOffsetsReq(topic string, partitions ...int32) *kmsg.ListOffsetsRequest {
+	req := kmsg.NewPtrListOffsetsRequest()
+	req.ReplicaID = -1
+	rt := kmsg.NewListOffsetsRequestTopic()
+	rt.Topic = topic
+	for _, p := range partitions {
+		rp := kmsg.NewListOffsetsRequestTopicPartition()
+		rp.Partition = p
+		rp.Timestamp, rp.CurrentLeaderEpoch = -1, -1
+		rt.Partitions = append(rt.Partitions, rp)
+	}
+	req.Topics = append(req.Topics, rt)
+	return req
+}
+
+func listOffsetsCode(t *testing.T, cl *kgo.Client, node int32, topic string, p int32) int16 {
+	t.Helper()
+	resp := faultReq(t, cl, node, listOffsetsReq(topic, p)).(*kmsg.ListOffsetsResponse)
+	if len(resp.Topics) != 1 || len(resp.Topics[0].Partitions) != 1 {
+		t.Fatalf("list offsets answered %d topics", len(resp.Topics))
+	}
+	return resp.Topics[0].Partitions[0].ErrorCode
+}
+
+func joinGroup(t *testing.T, cl *kgo.Client, group string) {
+	t.Helper()
+	req := kmsg.NewPtrJoinGroupRequest()
+	req.Group = group
+	req.SessionTimeoutMillis = 10000
+	req.RebalanceTimeoutMillis = 10000
+	req.ProtocolType = "consumer"
+	p := kmsg.NewJoinGroupRequestProtocol()
+	p.Name = "range"
+	req.Protocols = append(req.Protocols, p)
+	faultReq(t, cl, 0, req)
+}
+
+// A partition selector fails that partition and leaves the rest alone.
+func TestFaultPartition(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(3, topic))
+	cl := newPlainClient(t, c, kgo.RecordPartitioner(kgo.ManualPartitioner()))
+
+	h := c.Fault(Fault{
+		Keys:       []kmsg.Key{kmsg.Produce},
+		Topic:      topic,
+		Partitions: []int32{2},
+		Err:        kerr.PolicyViolation,
+		Count:      -1,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for p := int32(0); p < 3; p++ {
+		r := &kgo.Record{Topic: topic, Partition: p, Value: []byte("v")}
+		err := cl.ProduceSync(ctx, r).FirstErr()
+		if p == 2 {
+			if !errors.Is(err, kerr.PolicyViolation) {
+				t.Errorf("partition 2: got %v, want policy violation", err)
+			}
+		} else if err != nil {
+			t.Errorf("partition %d: %v", p, err)
+		}
+	}
+	if n := h.Hits(); n == 0 {
+		t.Error("fault never fired")
+	}
+}
+
+// A group selector fails every partition of every topic the group commits.
+func TestFaultGroupCommits(t *testing.T) {
+	t.Parallel()
+	const topic, group, other = "t", "g", "other"
+	c := newCluster(t, NumBrokers(1), SeedTopics(3, topic))
+	cl := newPlainClient(t, c)
+	joinGroup(t, cl, group)
+	joinGroup(t, cl, other)
+
+	h := c.Fault(Fault{Group: group, Err: kerr.NotCoordinator, Count: -1})
+
+	commit := func(group string) *kmsg.OffsetCommitResponse {
+		req := kmsg.NewPtrOffsetCommitRequest()
+		req.Group = group
+		req.Generation = -1
+		rt := kmsg.NewOffsetCommitRequestTopic()
+		rt.Topic = topic
+		rt.TopicID = c.TopicInfo(topic).TopicID
+		for p := int32(0); p < 3; p++ {
+			rp := kmsg.NewOffsetCommitRequestTopicPartition()
+			rp.Partition, rp.Offset, rp.LeaderEpoch = p, 1, -1
+			rt.Partitions = append(rt.Partitions, rp)
+		}
+		req.Topics = append(req.Topics, rt)
+		return faultReq(t, cl, 0, req).(*kmsg.OffsetCommitResponse)
+	}
+
+	resp := commit(group)
+	for _, st := range resp.Topics {
+		for _, sp := range st.Partitions {
+			if sp.ErrorCode != kerr.NotCoordinator.Code {
+				t.Errorf("%s partition %d answered %d, want not coordinator", st.Topic, sp.Partition, sp.ErrorCode)
+			}
+		}
+	}
+	resp = commit(other)
+	for _, st := range resp.Topics {
+		for _, sp := range st.Partitions {
+			if sp.ErrorCode != 0 {
+				t.Errorf("other group partition %d answered %d", sp.Partition, sp.ErrorCode)
+			}
+		}
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+}
+
+// A group selector fails one group's heartbeats and not another's.
+func TestFaultGroupHeartbeat(t *testing.T) {
+	t.Parallel()
+	const group, other = "g", "other"
+	c := newCluster(t, NumBrokers(1))
+	cl := newPlainClient(t, c)
+	joinGroup(t, cl, group)
+	joinGroup(t, cl, other)
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.Heartbeat}, Group: group, Err: kerr.CoordinatorLoadInProgress, Count: -1})
+
+	beat := func(group string) int16 {
+		req := kmsg.NewPtrHeartbeatRequest()
+		req.Group = group
+		req.Generation = -1
+		return faultReq(t, cl, 0, req).(*kmsg.HeartbeatResponse).ErrorCode
+	}
+	if code := beat(group); code != kerr.CoordinatorLoadInProgress.Code {
+		t.Errorf("faulted group answered %d", code)
+	}
+	if code := beat(other); code == kerr.CoordinatorLoadInProgress.Code {
+		t.Error("the other group was faulted")
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+}
+
+// A group selector picks one group out of a describe.
+func TestFaultDescribeGroups(t *testing.T) {
+	t.Parallel()
+	const group, other = "g", "other"
+	c := newCluster(t, NumBrokers(1))
+	cl := newPlainClient(t, c)
+	joinGroup(t, cl, group)
+	joinGroup(t, cl, other)
+
+	c.Fault(Fault{Group: group, Err: kerr.GroupAuthorizationFailed, Count: -1})
+
+	req := kmsg.NewPtrDescribeGroupsRequest()
+	req.Groups = []string{group, other}
+	resp := faultReq(t, cl, 0, req).(*kmsg.DescribeGroupsResponse)
+	if len(resp.Groups) != 2 {
+		t.Fatalf("describe answered %d groups", len(resp.Groups))
+	}
+	for _, g := range resp.Groups {
+		switch g.Group {
+		case group:
+			if g.ErrorCode != kerr.GroupAuthorizationFailed.Code {
+				t.Errorf("faulted group answered %d", g.ErrorCode)
+			}
+		case other:
+			if g.ErrorCode != 0 {
+				t.Errorf("other group answered %d", g.ErrorCode)
+			}
+		}
+	}
+}
+
+// TopLevel fails the whole request and answers it at once.
+func TestFaultTopLevel(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	id := c.TopicInfo(topic).TopicID
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.Fetch}, TopLevel: true, Err: kerr.FetchSessionTopicIDError, Count: -1})
+
+	req := kmsg.NewPtrFetchRequest()
+	req.MaxWaitMillis = 30000
+	req.MinBytes = 1
+	req.SessionEpoch = -1
+	rt := kmsg.NewFetchRequestTopic()
+	rt.Topic, rt.TopicID = topic, id
+	rp := kmsg.NewFetchRequestTopicPartition()
+	rp.CurrentLeaderEpoch = -1
+	rp.PartitionMaxBytes = 1 << 20
+	rt.Partitions = append(rt.Partitions, rp)
+	req.Topics = append(req.Topics, rt)
+
+	start := time.Now()
+	resp := faultReq(t, cl, 0, req).(*kmsg.FetchResponse)
+	if took := time.Since(start); took > 5*time.Second {
+		t.Errorf("fetch took %s: a top-level fault must not wait out MaxWait", took)
+	}
+	if resp.ErrorCode != kerr.FetchSessionTopicIDError.Code {
+		t.Errorf("top-level code %d != %d", resp.ErrorCode, kerr.FetchSessionTopicIDError.Code)
+	}
+	if len(resp.Topics) != 0 {
+		t.Errorf("top-level fault answered %d topics", len(resp.Topics))
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+}
+
+// A transaction selector reaches every request that names the transaction.
+func TestFaultTxnID(t *testing.T) {
+	t.Parallel()
+	const topic, txnID, group = "t", "x", "g"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	h := c.Fault(Fault{TxnID: txnID, Err: kerr.ProducerFenced, Count: -1})
+
+	init := kmsg.NewPtrInitProducerIDRequest()
+	init.TransactionalID = kmsg.StringPtr(txnID)
+	init.TransactionTimeoutMillis = 10000
+	init.ProducerID, init.ProducerEpoch = -1, -1
+	if code := faultReq(t, cl, 0, init).(*kmsg.InitProducerIDResponse).ErrorCode; code != kerr.ProducerFenced.Code {
+		t.Errorf("init producer id answered %d", code)
+	}
+
+	end := kmsg.NewPtrEndTxnRequest()
+	end.TransactionalID = txnID
+	end.ProducerEpoch = -1
+	if code := faultReq(t, cl, 0, end).(*kmsg.EndTxnResponse).ErrorCode; code != kerr.ProducerFenced.Code {
+		t.Errorf("end txn answered %d", code)
+	}
+
+	tc := kmsg.NewPtrTxnOffsetCommitRequest()
+	tc.TransactionalID = txnID
+	tc.Group = group
+	tc.ProducerEpoch, tc.Generation = -1, -1
+	tct := kmsg.NewTxnOffsetCommitRequestTopic()
+	tct.Topic = topic
+	tcp := kmsg.NewTxnOffsetCommitRequestTopicPartition()
+	tcp.LeaderEpoch = -1
+	tct.Partitions = append(tct.Partitions, tcp)
+	tc.Topics = append(tc.Topics, tct)
+	tcr := faultReq(t, cl, 0, tc).(*kmsg.TxnOffsetCommitResponse)
+	if len(tcr.Topics) != 1 || len(tcr.Topics[0].Partitions) != 1 || tcr.Topics[0].Partitions[0].ErrorCode != kerr.ProducerFenced.Code {
+		t.Errorf("txn offset commit answered %v", tcr.Topics)
+	}
+
+	if n := h.Hits(); n != 3 {
+		t.Errorf("fault fired %d times != 3", n)
+	}
+}
+
+// A node selector fires only at that node.
+func TestFaultNode(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(2), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	if err := c.MoveTopicPartition(topic, 0, 1); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.ListOffsets}, Nodes: []int32{1}, Topic: topic, Err: kerr.PolicyViolation, Count: -1})
+	if code := listOffsetsCode(t, cl, 0, topic, 0); code == kerr.PolicyViolation.Code {
+		t.Error("a node 1 fault fired at node 0")
+	}
+	if code := listOffsetsCode(t, cl, 1, topic, 0); code != kerr.PolicyViolation.Code {
+		t.Errorf("node 1 answered %d", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+}
+
+// FindCoordinator matches a group key against Group and a transaction key
+// against TxnID.
+func TestFaultFindCoordinator(t *testing.T) {
+	t.Parallel()
+	c := newCluster(t, NumBrokers(1))
+	cl := newPlainClient(t, c)
+
+	c.Fault(
+		Fault{Group: "g", Err: kerr.CoordinatorNotAvailable, Count: -1},
+		Fault{TxnID: "x", Err: kerr.CoordinatorLoadInProgress, Count: -1},
+	)
+
+	find := func(typ int8, key string) int16 {
+		req := kmsg.NewPtrFindCoordinatorRequest()
+		req.CoordinatorType = typ
+		req.CoordinatorKey = key
+		req.CoordinatorKeys = []string{key}
+		resp := faultReq(t, cl, 0, req).(*kmsg.FindCoordinatorResponse)
+		if len(resp.Coordinators) == 1 {
+			return resp.Coordinators[0].ErrorCode
+		}
+		return resp.ErrorCode
+	}
+	if code := find(0, "g"); code != kerr.CoordinatorNotAvailable.Code {
+		t.Errorf("group key answered %d", code)
+	}
+	if code := find(1, "x"); code != kerr.CoordinatorLoadInProgress.Code {
+		t.Errorf("transaction key answered %d", code)
+	}
+	if code := find(0, "untouched"); code != 0 {
+		t.Errorf("unselected group key answered %d", code)
+	}
+	if code := find(1, "untouched"); code != 0 {
+		t.Errorf("unselected transaction key answered %d", code)
+	}
+}
+
+// Resource names a config resource.
+func TestFaultResourceConfigs(t *testing.T) {
+	t.Parallel()
+	const t1, t2 = "t1", "t2"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, t1, t2))
+	cl := newPlainClient(t, c)
+
+	c.Fault(Fault{Resource: t1, Err: kerr.InvalidConfig, Count: -1})
+
+	req := kmsg.NewPtrDescribeConfigsRequest()
+	for _, name := range []string{t1, t2} {
+		rr := kmsg.NewDescribeConfigsRequestResource()
+		rr.ResourceType = kmsg.ConfigResourceTypeTopic
+		rr.ResourceName = name
+		req.Resources = append(req.Resources, rr)
+	}
+	resp := faultReq(t, cl, 0, req).(*kmsg.DescribeConfigsResponse)
+	if len(resp.Resources) != 2 {
+		t.Fatalf("describe answered %d resources", len(resp.Resources))
+	}
+	for _, r := range resp.Resources {
+		switch r.ResourceName {
+		case t1:
+			if r.ErrorCode != kerr.InvalidConfig.Code {
+				t.Errorf("faulted resource answered %d", r.ErrorCode)
+			}
+		case t2:
+			if r.ErrorCode != 0 {
+				t.Errorf("other resource answered %d", r.ErrorCode)
+			}
+		}
+	}
+}
+
+// Resource names an ACL creation.
+func TestFaultResourceACLs(t *testing.T) {
+	t.Parallel()
+	c := newCluster(t, NumBrokers(1))
+	cl := newPlainClient(t, c)
+
+	c.Fault(Fault{Resource: "faulted", Err: kerr.InvalidRequest, Count: -1})
+
+	req := kmsg.NewPtrCreateACLsRequest()
+	for _, name := range []string{"faulted", "fine"} {
+		cr := kmsg.NewCreateACLsRequestCreation()
+		cr.ResourceType = kmsg.ACLResourceTypeTopic
+		cr.ResourceName = name
+		cr.ResourcePatternType = kmsg.ACLResourcePatternTypeLiteral
+		cr.Principal = "User:someone"
+		cr.Host = "*"
+		cr.Operation = kmsg.ACLOperationRead
+		cr.PermissionType = kmsg.ACLPermissionTypeAllow
+		req.Creations = append(req.Creations, cr)
+	}
+	resp := faultReq(t, cl, 0, req).(*kmsg.CreateACLsResponse)
+	if len(resp.Results) != 2 {
+		t.Fatalf("create answered %d results", len(resp.Results))
+	}
+	if resp.Results[0].ErrorCode != kerr.InvalidRequest.Code {
+		t.Errorf("faulted creation answered %d", resp.Results[0].ErrorCode)
+	}
+	if resp.Results[1].ErrorCode != 0 {
+		t.Errorf("other creation answered %d", resp.Results[1].ErrorCode)
+	}
+}
+
+// A selector a request does not carry never matches.
+func TestFaultSelectorNotCarried(t *testing.T) {
+	t.Parallel()
+	const topic, group = "t", "g"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	joinGroup(t, cl, group)
+
+	h := c.Fault(Fault{Topic: topic, Err: kerr.UnknownServerError, Count: -1})
+
+	req := kmsg.NewPtrHeartbeatRequest()
+	req.Group = group
+	req.Generation = -1
+	if code := faultReq(t, cl, 0, req).(*kmsg.HeartbeatResponse).ErrorCode; code == kerr.UnknownServerError.Code {
+		t.Error("a topic fault failed a heartbeat")
+	}
+	if n := h.Hits(); n != 0 {
+		t.Errorf("fault fired %d times on a request with no topic", n)
+	}
+}
+
+// Count budgets requests, and Remove ends a budgetless fault.
+func TestFaultCount(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	once := c.Fault(Fault{Keys: []kmsg.Key{kmsg.ListOffsets}, Topic: topic, Err: kerr.PolicyViolation})
+	if code := listOffsetsCode(t, cl, 0, topic, 0); code != kerr.PolicyViolation.Code {
+		t.Errorf("first request answered %d", code)
+	}
+	if code := listOffsetsCode(t, cl, 0, topic, 0); code != 0 {
+		t.Errorf("second request answered %d: Count 0 is one request", code)
+	}
+	if n := once.Hits(); n != 1 {
+		t.Errorf("one-shot fault fired %d times", n)
+	}
+	once.Remove() // removing an exhausted fault is fine
+
+	forever := c.Fault(Fault{Keys: []kmsg.Key{kmsg.ListOffsets}, Topic: topic, Err: kerr.PolicyViolation, Count: -1})
+	for i := range 3 {
+		if code := listOffsetsCode(t, cl, 0, topic, 0); code != kerr.PolicyViolation.Code {
+			t.Errorf("request %d answered %d", i, code)
+		}
+	}
+	forever.Remove()
+	forever.Remove() // twice is fine
+	if code := listOffsetsCode(t, cl, 0, topic, 0); code != 0 {
+		t.Errorf("request after removal answered %d", code)
+	}
+	if n := forever.Hits(); n != 3 {
+		t.Errorf("removed fault fired %d times != 3", n)
+	}
+}
+
+// One handle covers every fault it installed, and the earliest fault that
+// matches answers.
+func TestFaultBatch(t *testing.T) {
+	t.Parallel()
+	const t1, t2 = "t1", "t2"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, t1, t2))
+	cl := newPlainClient(t, c)
+
+	h := c.Fault(
+		Fault{Topic: t1, Err: kerr.PolicyViolation, Count: -1},
+		Fault{Topic: t1, Err: kerr.InvalidRequest, Count: -1},
+		Fault{Topic: t2, Err: kerr.NotEnoughReplicas, Count: -1},
+	)
+	if code := listOffsetsCode(t, cl, 0, t1, 0); code != kerr.PolicyViolation.Code {
+		t.Errorf("t1 answered %d, want the fault added first", code)
+	}
+	if code := listOffsetsCode(t, cl, 0, t2, 0); code != kerr.NotEnoughReplicas.Code {
+		t.Errorf("t2 answered %d", code)
+	}
+	if n := h.Hits(); n != 2 {
+		t.Errorf("handle counted %d hits != 2", n)
+	}
+	h.Remove()
+	if code := listOffsetsCode(t, cl, 0, t1, 0); code != 0 {
+		t.Errorf("t1 after removal answered %d", code)
+	}
+	if code := listOffsetsCode(t, cl, 0, t2, 0); code != 0 {
+		t.Errorf("t2 after removal answered %d", code)
+	}
+}
+
+// An idempotent producer retries a timed-out append. The record lands once.
+func TestFaultAfterApplyIdempotent(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c,
+		kgo.RetryBackoffFn(func(int) time.Duration { return 50 * time.Millisecond }),
+	)
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.Produce}, Topic: topic, Err: kerr.RequestTimedOut})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	r := &kgo.Record{Topic: topic, Value: []byte("v")}
+	if err := cl.ProduceSync(ctx, r).FirstErr(); err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+	if i := c.PartitionInfo(topic, 0); i.HighWatermark != 1 {
+		t.Errorf("high watermark %d != 1: the timed out append was not deduplicated", i.HighWatermark)
+	}
+	if r.Offset != 0 {
+		t.Errorf("record landed at offset %d != 0", r.Offset)
+	}
+}
+
+// A producer with no producer ID retries a timed-out append. The record
+// lands twice.
+func TestFaultAfterApplyDuplicates(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c,
+		kgo.DisableIdempotentWrite(),
+		kgo.RetryBackoffFn(func(int) time.Duration { return 50 * time.Millisecond }),
+	)
+
+	c.Fault(Fault{Keys: []kmsg.Key{kmsg.Produce}, Topic: topic, Err: kerr.RequestTimedOut})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("v")}).FirstErr(); err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+	if i := c.PartitionInfo(topic, 0); i.HighWatermark != 2 {
+		t.Errorf("high watermark %d != 2: the timed out append did not happen", i.HighWatermark)
+	}
+}
+
+// NOT_ENOUGH_REPLICAS_AFTER_APPEND is the produce error a broker answers
+// after appending.
+func TestFaultAfterApplyNotEnoughReplicas(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c,
+		kgo.RetryBackoffFn(func(int) time.Duration { return 50 * time.Millisecond }),
+	)
+
+	c.Fault(Fault{Keys: []kmsg.Key{kmsg.Produce}, Topic: topic, Err: kerr.NotEnoughReplicasAfterAppend})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("v")}).FirstErr(); err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+	if i := c.PartitionInfo(topic, 0); i.HighWatermark != 1 {
+		t.Errorf("high watermark %d != 1", i.HighWatermark)
+	}
+}
+
+// A timed-out commit is stored. The next fetch reads it.
+func TestFaultAfterApplyOffsetCommit(t *testing.T) {
+	t.Parallel()
+	const topic, group = "t", "g"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	id := c.TopicInfo(topic).TopicID
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.OffsetCommit}, Group: group, Err: kerr.RequestTimedOut})
+
+	commit := kmsg.NewPtrOffsetCommitRequest()
+	commit.Group = group
+	commit.Generation = -1
+	ct := kmsg.NewOffsetCommitRequestTopic()
+	ct.Topic, ct.TopicID = topic, id
+	cp := kmsg.NewOffsetCommitRequestTopicPartition()
+	cp.Offset, cp.LeaderEpoch = 7, -1
+	ct.Partitions = append(ct.Partitions, cp)
+	commit.Topics = append(commit.Topics, ct)
+	cresp := faultReq(t, cl, 0, commit).(*kmsg.OffsetCommitResponse)
+	if len(cresp.Topics) != 1 || len(cresp.Topics[0].Partitions) != 1 {
+		t.Fatalf("commit answered %d topics", len(cresp.Topics))
+	}
+	if code := cresp.Topics[0].Partitions[0].ErrorCode; code != kerr.RequestTimedOut.Code {
+		t.Errorf("commit answered %d, want request timed out", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+
+	fetch := kmsg.NewPtrOffsetFetchRequest()
+	fg := kmsg.NewOffsetFetchRequestGroup()
+	fg.Group = group
+	fg.MemberEpoch = -1
+	ft := kmsg.NewOffsetFetchRequestGroupTopic()
+	ft.Topic, ft.TopicID = topic, id
+	ft.Partitions = []int32{0}
+	fg.Topics = append(fg.Topics, ft)
+	fetch.Groups = append(fetch.Groups, fg)
+	fresp := faultReq(t, cl, 0, fetch).(*kmsg.OffsetFetchResponse)
+	if len(fresp.Groups) != 1 || len(fresp.Groups[0].Topics) != 1 || len(fresp.Groups[0].Topics[0].Partitions) != 1 {
+		t.Fatalf("fetch answered %v", fresp.Groups)
+	}
+	if offset := fresp.Groups[0].Topics[0].Partitions[0].Offset; offset != 7 {
+		t.Errorf("fetched offset %d != 7: the timed out commit was not stored", offset)
+	}
+}
+
+// Wait blocks until the faults have answered.
+func TestFaultWait(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.ListOffsets}, Topic: topic, Err: kerr.PolicyViolation, Count: 2})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Wait blocks until a request lands.
+	done := make(chan error, 1)
+	go func() { done <- h.Wait(ctx, 1) }()
+	select {
+	case err := <-done:
+		t.Fatalf("Wait returned %v before any request", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	listOffsetsCode(t, cl, 0, topic, 0)
+	if err := <-done; err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+
+	// A hit that already happened satisfies Wait at once.
+	if err := h.Wait(ctx, 1); err != nil {
+		t.Fatalf("Wait on a hit that already landed: %v", err)
+	}
+
+	// Waiting for the whole budget returns when the fault is used up.
+	listOffsetsCode(t, cl, 0, topic, 0)
+	if err := h.Wait(ctx, 2); err != nil {
+		t.Fatalf("Wait for the budget: %v", err)
+	}
+	if code := listOffsetsCode(t, cl, 0, topic, 0); code != 0 {
+		t.Errorf("request after the budget answered %d", code)
+	}
+
+	// A context that is done ends the wait.
+	dead, deadCancel := context.WithCancel(context.Background())
+	deadCancel()
+	if err := h.Wait(dead, 3); !errors.Is(err, context.Canceled) {
+		t.Errorf("Wait on a canceled context: %v", err)
+	}
+}
+
+// A timed-out delete still deletes the records.
+func TestFaultAfterApplyDeleteRecords(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for range 3 {
+		if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("v")}).FirstErr(); err != nil {
+			t.Fatalf("produce: %v", err)
+		}
+	}
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.DeleteRecords}, Topic: topic, Err: kerr.RequestTimedOut})
+
+	del := kmsg.NewPtrDeleteRecordsRequest()
+	dt := kmsg.NewDeleteRecordsRequestTopic()
+	dt.Topic = topic
+	dp := kmsg.NewDeleteRecordsRequestTopicPartition()
+	dp.Offset = 2
+	dt.Partitions = append(dt.Partitions, dp)
+	del.Topics = append(del.Topics, dt)
+	dresp := faultReq(t, cl, 0, del).(*kmsg.DeleteRecordsResponse)
+	if len(dresp.Topics) != 1 || len(dresp.Topics[0].Partitions) != 1 {
+		t.Fatalf("delete answered %v", dresp.Topics)
+	}
+	if code := dresp.Topics[0].Partitions[0].ErrorCode; code != kerr.RequestTimedOut.Code {
+		t.Errorf("delete answered %d, want request timed out", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+	if o := c.PartitionInfo(topic, 0).LogStartOffset; o != 2 {
+		t.Errorf("log start offset %d != 2: the timed out delete did not happen", o)
+	}
+}
+
+// A timed-out alter still sets the config.
+func TestFaultAfterApplyAlterConfigs(t *testing.T) {
+	t.Parallel()
+	const topic, name, value = "t", "max.message.bytes", "999999"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.IncrementalAlterConfigs}, Resource: topic, Err: kerr.RequestTimedOut})
+
+	alter := kmsg.NewPtrIncrementalAlterConfigsRequest()
+	ar := kmsg.NewIncrementalAlterConfigsRequestResource()
+	ar.ResourceType = kmsg.ConfigResourceTypeTopic
+	ar.ResourceName = topic
+	ac := kmsg.NewIncrementalAlterConfigsRequestResourceConfig()
+	ac.Name, ac.Value = name, kmsg.StringPtr(value)
+	ar.Configs = append(ar.Configs, ac)
+	alter.Resources = append(alter.Resources, ar)
+	aresp := faultReq(t, cl, 0, alter).(*kmsg.IncrementalAlterConfigsResponse)
+	if len(aresp.Resources) != 1 {
+		t.Fatalf("alter answered %d resources != 1", len(aresp.Resources))
+	}
+	if code := aresp.Resources[0].ErrorCode; code != kerr.RequestTimedOut.Code {
+		t.Errorf("alter answered %d, want request timed out", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+
+	describe := kmsg.NewPtrDescribeConfigsRequest()
+	dr := kmsg.NewDescribeConfigsRequestResource()
+	dr.ResourceType = kmsg.ConfigResourceTypeTopic
+	dr.ResourceName = topic
+	describe.Resources = append(describe.Resources, dr)
+	dresp := faultReq(t, cl, 0, describe).(*kmsg.DescribeConfigsResponse)
+	if len(dresp.Resources) != 1 {
+		t.Fatalf("describe answered %d resources != 1", len(dresp.Resources))
+	}
+	var got string
+	for _, cfg := range dresp.Resources[0].Configs {
+		if cfg.Name == name && cfg.Value != nil {
+			got = *cfg.Value
+		}
+	}
+	if got != value {
+		t.Errorf("%s is %q != %q: the timed out alter did not happen", name, got, value)
+	}
+}
+
+// initTxn starts a transactional producer and returns its ID and epoch.
+func initTxn(t *testing.T, cl *kgo.Client, txnID string) (int64, int16) {
+	t.Helper()
+	req := kmsg.NewPtrInitProducerIDRequest()
+	req.TransactionalID = kmsg.StringPtr(txnID)
+	req.TransactionTimeoutMillis = 10000
+	req.ProducerID, req.ProducerEpoch = -1, -1
+	resp := faultReq(t, cl, 0, req).(*kmsg.InitProducerIDResponse)
+	if resp.ErrorCode != 0 {
+		t.Fatalf("init producer id answered %d", resp.ErrorCode)
+	}
+	return resp.ProducerID, resp.ProducerEpoch
+}
+
+// A timed-out transactional commit still stores the offsets. Committing the
+// transaction makes them visible.
+func TestFaultAfterApplyTxnOffsetCommit(t *testing.T) {
+	t.Parallel()
+	const topic, txnID, group = "t", "x", "g"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+	id := c.TopicInfo(topic).TopicID
+
+	pid, epoch := initTxn(t, cl, txnID)
+
+	add := kmsg.NewPtrAddOffsetsToTxnRequest()
+	add.TransactionalID = txnID
+	add.ProducerID, add.ProducerEpoch = pid, epoch
+	add.Group = group
+	if code := faultReq(t, cl, 0, add).(*kmsg.AddOffsetsToTxnResponse).ErrorCode; code != 0 {
+		t.Fatalf("add offsets answered %d", code)
+	}
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.TxnOffsetCommit}, Group: group, Err: kerr.RequestTimedOut})
+
+	commit := kmsg.NewPtrTxnOffsetCommitRequest()
+	commit.TransactionalID = txnID
+	commit.Group = group
+	commit.ProducerID, commit.ProducerEpoch = pid, epoch
+	commit.Generation = -1
+	ct := kmsg.NewTxnOffsetCommitRequestTopic()
+	ct.Topic = topic
+	cp := kmsg.NewTxnOffsetCommitRequestTopicPartition()
+	cp.Offset, cp.LeaderEpoch = 7, -1
+	ct.Partitions = append(ct.Partitions, cp)
+	commit.Topics = append(commit.Topics, ct)
+	cresp := faultReq(t, cl, 0, commit).(*kmsg.TxnOffsetCommitResponse)
+	if len(cresp.Topics) != 1 || len(cresp.Topics[0].Partitions) != 1 {
+		t.Fatalf("txn offset commit answered %v", cresp.Topics)
+	}
+	if code := cresp.Topics[0].Partitions[0].ErrorCode; code != kerr.RequestTimedOut.Code {
+		t.Errorf("txn offset commit answered %d, want request timed out", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+
+	end := kmsg.NewPtrEndTxnRequest()
+	end.TransactionalID = txnID
+	end.ProducerID, end.ProducerEpoch = pid, epoch
+	end.Commit = true
+	if code := faultReq(t, cl, 0, end).(*kmsg.EndTxnResponse).ErrorCode; code != 0 {
+		t.Fatalf("end txn answered %d", code)
+	}
+
+	fetch := kmsg.NewPtrOffsetFetchRequest()
+	fg := kmsg.NewOffsetFetchRequestGroup()
+	fg.Group = group
+	fg.MemberEpoch = -1
+	ft := kmsg.NewOffsetFetchRequestGroupTopic()
+	ft.Topic, ft.TopicID = topic, id
+	ft.Partitions = []int32{0}
+	fg.Topics = append(fg.Topics, ft)
+	fetch.Groups = append(fetch.Groups, fg)
+	fresp := faultReq(t, cl, 0, fetch).(*kmsg.OffsetFetchResponse)
+	if len(fresp.Groups) != 1 || len(fresp.Groups[0].Topics) != 1 || len(fresp.Groups[0].Topics[0].Partitions) != 1 {
+		t.Fatalf("offset fetch answered %v", fresp.Groups)
+	}
+	if offset := fresp.Groups[0].Topics[0].Partitions[0].Offset; offset != 7 {
+		t.Errorf("fetched offset %d != 7: the timed out commit was not stored", offset)
+	}
+}
+
+// A control function can install a fault. It applies to the requests that
+// follow.
+func TestFaultFromControl(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	var (
+		seen atomic.Int64
+		h    atomic.Pointer[FaultHandle]
+	)
+	c.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+		if seen.Add(1) == 2 {
+			h.Store(c.Fault(Fault{Keys: []kmsg.Key{kmsg.Produce}, Topic: topic, Err: kerr.PolicyViolation, Count: -1}))
+		}
+		return nil, nil, false
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	produce := func() error {
+		return cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("v")}).FirstErr()
+	}
+	if err := produce(); err != nil {
+		t.Fatalf("produce before the fault: %v", err)
+	}
+	_ = produce() // the control installs the fault while handling this one
+	if err := produce(); !errors.Is(err, kerr.PolicyViolation) {
+		t.Errorf("produce after the fault: %v, want policy violation", err)
+	}
+	hh := h.Load()
+	if hh == nil {
+		t.Fatal("the control never installed the fault")
+	}
+	if n := hh.Hits(); n == 0 {
+		t.Error("the fault never fired")
+	}
+}
+
+// A control installs a fault while sleeping. It does not deadlock and the
+// fault applies.
+func TestFaultFromSleepingControl(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	var (
+		seen atomic.Int64
+		h    atomic.Pointer[FaultHandle]
+	)
+	c.ControlKey(int16(kmsg.ListOffsets), func(kmsg.Request) (kmsg.Response, error, bool) {
+		if seen.Add(1) == 1 {
+			c.SleepControl(func() {
+				h.Store(c.Fault(Fault{Keys: []kmsg.Key{kmsg.ListOffsets}, Topic: topic, Err: kerr.PolicyViolation, Count: -1}))
+			})
+		}
+		return nil, nil, false
+	})
+
+	listOffsetsCode(t, cl, 0, topic, 0) // the slept control answers rather than hanging
+	if code := listOffsetsCode(t, cl, 0, topic, 0); code != kerr.PolicyViolation.Code {
+		t.Errorf("list offsets after the fault answered %d", code)
+	}
+	hh := h.Load()
+	if hh == nil {
+		t.Fatal("the control never installed the fault")
+	}
+	if n := hh.Hits(); n == 0 {
+		t.Error("the fault never fired")
+	}
+}
+
+// A timed-out delete still deletes the group.
+func TestFaultAfterApplyDeleteGroups(t *testing.T) {
+	t.Parallel()
+	const group = "g"
+	c := newCluster(t, NumBrokers(1))
+	cl := newPlainClient(t, c)
+	joinGroup(t, cl, group)
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.DeleteGroups}, Group: group, Err: kerr.RequestTimedOut})
+
+	del := kmsg.NewPtrDeleteGroupsRequest()
+	del.Groups = []string{group}
+	dresp := faultReq(t, cl, 0, del).(*kmsg.DeleteGroupsResponse)
+	if len(dresp.Groups) != 1 {
+		t.Fatalf("delete answered %d groups", len(dresp.Groups))
+	}
+	if code := dresp.Groups[0].ErrorCode; code != kerr.RequestTimedOut.Code {
+		t.Errorf("delete answered %d, want request timed out", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+
+	list := faultReq(t, cl, 0, kmsg.NewPtrListGroupsRequest()).(*kmsg.ListGroupsResponse)
+	for _, g := range list.Groups {
+		if g.Group == group {
+			t.Error("the group still exists: the timed out delete did not happen")
+		}
+	}
+}
+
+// A timed-out create still creates the topic.
+func TestFaultAfterApplyCreateTopics(t *testing.T) {
+	t.Parallel()
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1))
+	cl := newPlainClient(t, c)
+
+	h := c.Fault(Fault{Keys: []kmsg.Key{kmsg.CreateTopics}, Topic: topic, Err: kerr.RequestTimedOut})
+
+	create := kmsg.NewPtrCreateTopicsRequest()
+	ct := kmsg.NewCreateTopicsRequestTopic()
+	ct.Topic = topic
+	ct.NumPartitions = 1
+	ct.ReplicationFactor = 1
+	create.Topics = append(create.Topics, ct)
+	cresp := faultReq(t, cl, 0, create).(*kmsg.CreateTopicsResponse)
+	if len(cresp.Topics) != 1 {
+		t.Fatalf("create answered %d topics", len(cresp.Topics))
+	}
+	if code := cresp.Topics[0].ErrorCode; code != kerr.RequestTimedOut.Code {
+		t.Errorf("create answered %d, want request timed out", code)
+	}
+	if n := h.Hits(); n != 1 {
+		t.Errorf("fault fired %d times != 1", n)
+	}
+	if c.TopicInfo(topic) == nil {
+		t.Error("the topic does not exist: the timed out create did not happen")
+	}
+}

--- a/pkg/kfake/faults.go
+++ b/pkg/kfake/faults.go
@@ -1,0 +1,401 @@
+package kfake
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// We check faults wherever we check authorization, and per partition in
+// every request that carries partitions.
+
+// Fault fails matching requests with Err in place of the real answer, with
+// every field being an AND filter of what the fault should apply to. Faults
+// are an easier way to inject targeted failures than Control.
+//
+// A selector that a request does not carry never matches: a fault with a
+// Topic does not fail a heartbeat. Requests with a top-level ErrorCode can
+// have that error code set by setting TopLevel to true (some requests set
+// either a top-level code OR a per-resource code).
+//
+// A faulted entity is rejected before the broker acts on it, except with
+// REQUEST_TIMED_OUT, on the requests a real broker can answer that way after
+// applying them, or NOT_ENOUGH_REPLICAS_AFTER_APPEND on produce: those are
+// answered and the work still happens. Faults are checked in the order added
+// and the first match answers; a ControlKey control that answers a request
+// bypasses them.
+type Fault struct {
+	Keys  []kmsg.Key // which requests this should apply to; nil means all
+	Nodes []int32    // which nodes this should apply to; nil means all
+
+	Topic      string   // "" means all
+	TopicID    [16]byte // zero means all
+	Partitions []int32  // which partitions this should apply to; nil means all
+	Group      string   // "" means all; a FindCoordinator group key matches this
+	TxnID      string   // "" means all; a FindCoordinator transaction key matches this
+	TopLevel   bool     // fail the request's top-level ErrorCode rather than its entities, ignored for requests without one
+
+	// Resource names an entity no selector above reaches: a config
+	// resource, a client quota entity, a SCRAM user, a log dir, a feature,
+	// a member in a LeaveGroup, or the resource name of an ACL creation or
+	// filter. "" means all.
+	Resource string
+
+	Err   *kerr.Error // nil defaults to UNKNOWN_SERVER_ERROR
+	Count int         // requests to fault; 0 means one, -1 means until Remove is called
+}
+
+// FaultHandle refers to the faults installed by one Fault call.
+type FaultHandle struct {
+	c  *Cluster
+	fs []*fault
+}
+
+type fault struct {
+	keys       []kmsg.Key
+	nodes      []int32
+	topic      string
+	topicID    uuid
+	partitions []int32
+	group      string
+	txnID      string
+	resource   string
+	topLevel   bool
+	err        *kerr.Error
+	hits       atomic.Int64
+
+	// left is the requests remaining, -1 for unlimited, and removed is
+	// set once we drop the fault. Both are guarded by c.faultsMu.
+	left    int
+	removed bool
+}
+
+// Fault installs faults and returns a handle to them. Fault may be called
+// from a control function.
+func (c *Cluster) Fault(faults ...Fault) *FaultHandle {
+	h := &FaultHandle{c: c}
+	c.faultsMu.Lock()
+	defer c.faultsMu.Unlock()
+	if c.faultCond == nil {
+		c.faultCond = sync.NewCond(&c.faultsMu)
+	}
+	for _, in := range faults {
+		f := &fault{
+			keys:       slices.Clone(in.Keys),
+			nodes:      slices.Clone(in.Nodes),
+			topic:      in.Topic,
+			topicID:    in.TopicID,
+			partitions: slices.Clone(in.Partitions),
+			group:      in.Group,
+			txnID:      in.TxnID,
+			resource:   in.Resource,
+			topLevel:   in.TopLevel,
+			err:        in.Err,
+			left:       in.Count,
+		}
+		if f.err == nil {
+			f.err = kerr.UnknownServerError
+		}
+		switch {
+		case in.Count == 0:
+			f.left = 1
+		case in.Count < 0:
+			f.left = -1
+		}
+		h.fs = append(h.fs, f)
+		c.faults = append(c.faults, f)
+	}
+	return h
+}
+
+// Wait blocks until the faults have answered at least n requests in total,
+// or until ctx is done, returning ctx's error.
+func (h *FaultHandle) Wait(ctx context.Context, n int) error {
+	quit := false
+	done := make(chan struct{})
+	go func() {
+		h.c.faultsMu.Lock()
+		defer h.c.faultsMu.Unlock()
+		defer close(done)
+
+		for !quit && h.Hits() < n {
+			h.c.faultCond.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		h.c.faultsMu.Lock()
+		quit = true
+		h.c.faultsMu.Unlock()
+		h.c.faultCond.Broadcast()
+		return ctx.Err()
+	}
+}
+
+// Hits is the count of requests the faults have answered so far.
+func (h *FaultHandle) Hits() int {
+	var n int64
+	for _, f := range h.fs {
+		n += f.hits.Load()
+	}
+	return int(n)
+}
+
+// Remove uninstalls faults associated with this handle.
+func (h *FaultHandle) Remove() {
+	h.c.faultsMu.Lock()
+	defer h.c.faultsMu.Unlock()
+	for _, f := range h.fs {
+		h.c.rmFaultLocked(f)
+	}
+}
+
+func (c *Cluster) rmFaultLocked(f *fault) {
+	if f.removed {
+		return
+	}
+	f.removed = true
+	c.faults = slices.DeleteFunc(c.faults, func(o *fault) bool { return o == f })
+}
+
+// faultKey is what a site knows about the entity it is answering for. A fault
+// that selects on something the key does not name never matches there.
+type faultKey struct {
+	topic     string
+	topicID   uuid
+	partition int32
+	hasPart   bool
+	group     string
+	txnID     string
+	resource  string
+}
+
+// part returns k naming a partition.
+func (k faultKey) part(p int32) faultKey {
+	k.partition, k.hasPart = p, true
+	return k
+}
+
+func (f *fault) matches(k faultKey) bool {
+	if f.topic != "" && f.topic != k.topic {
+		return false
+	}
+	if f.topicID != noID && f.topicID != k.topicID {
+		return false
+	}
+	if len(f.partitions) > 0 && (!k.hasPart || !slices.Contains(f.partitions, k.partition)) {
+		return false
+	}
+	if f.group != "" && f.group != k.group {
+		return false
+	}
+	if f.txnID != "" && f.txnID != k.txnID {
+		return false
+	}
+	if f.resource != "" && f.resource != k.resource {
+		return false
+	}
+	return true
+}
+
+// faultCheck is the faults that can match one request; hits records the ones
+// this request has already hit.
+type faultCheck struct {
+	c    *Cluster
+	key  int16
+	fs   []*fault
+	hits []*fault
+}
+
+// faultsFor returns the faults to consider for creq, or nil if none can match.
+func (c *Cluster) faultsFor(creq *clientReq) *faultCheck {
+	c.faultsMu.Lock()
+	defer c.faultsMu.Unlock()
+	if len(c.faults) == 0 {
+		return nil
+	}
+	key := creq.kreq.Key()
+	kkey := kmsg.Key(key)
+	var fs []*fault
+	for _, f := range c.faults {
+		if len(f.nodes) > 0 && !slices.Contains(f.nodes, creq.cc.b.node) {
+			continue
+		}
+		if len(f.keys) > 0 && !slices.Contains(f.keys, kkey) {
+			continue
+		}
+		fs = append(fs, f)
+	}
+	if len(fs) == 0 {
+		return nil
+	}
+	return &faultCheck{c: c, key: key, fs: fs}
+}
+
+// check returns the error to answer the entity named by k with, if a fault
+// matches it.
+func (fc *faultCheck) check(k faultKey) *kerr.Error {
+	if fc == nil {
+		return nil
+	}
+	for _, f := range fc.fs {
+		// A TopLevel fault answers only in topLevel.
+		if f.topLevel || !f.matches(k) {
+			continue
+		}
+		if !fc.hit(f) {
+			continue
+		}
+		return f.err
+	}
+	return nil
+}
+
+// afterApply is the requests a broker can answer REQUEST_TIMED_OUT after
+// applying them, and the codes it answers with.
+var afterApply = map[int16][]*kerr.Error{
+	int16(kmsg.Produce):                   {kerr.RequestTimedOut, kerr.NotEnoughReplicasAfterAppend},
+	int16(kmsg.WriteTxnMarkers):           {kerr.RequestTimedOut, kerr.NotEnoughReplicasAfterAppend},
+	int16(kmsg.DeleteRecords):             {kerr.RequestTimedOut},
+	int16(kmsg.OffsetCommit):              {kerr.RequestTimedOut},
+	int16(kmsg.TxnOffsetCommit):           {kerr.RequestTimedOut},
+	int16(kmsg.DeleteGroups):              {kerr.RequestTimedOut},
+	int16(kmsg.AlterShareGroupOffsets):    {kerr.RequestTimedOut},
+	int16(kmsg.DeleteShareGroupOffsets):   {kerr.RequestTimedOut},
+	int16(kmsg.CreateTopics):              {kerr.RequestTimedOut},
+	int16(kmsg.DeleteTopics):              {kerr.RequestTimedOut},
+	int16(kmsg.CreatePartitions):          {kerr.RequestTimedOut},
+	int16(kmsg.ElectLeaders):              {kerr.RequestTimedOut},
+	int16(kmsg.AlterPartitionAssignments): {kerr.RequestTimedOut},
+	int16(kmsg.AlterConfigs):              {kerr.RequestTimedOut},
+	int16(kmsg.IncrementalAlterConfigs):   {kerr.RequestTimedOut},
+	int16(kmsg.CreateACLs):                {kerr.RequestTimedOut},
+	int16(kmsg.DeleteACLs):                {kerr.RequestTimedOut},
+	int16(kmsg.AlterClientQuotas):         {kerr.RequestTimedOut},
+	int16(kmsg.AlterUserSCRAMCredentials): {kerr.RequestTimedOut},
+	int16(kmsg.UpdateFeatures):            {kerr.RequestTimedOut},
+}
+
+// skipsWork reports whether answering e skips the entity's work; the
+// afterApply codes do not.
+func (creq *clientReq) skipsWork(e *kerr.Error) bool {
+	return !slices.Contains(afterApply[creq.kreq.Key()], e)
+}
+
+// entityless is the requests that carry nothing a fault can select on.
+var entityless = map[int16]bool{
+	int16(kmsg.ApiVersions):               true,
+	int16(kmsg.SASLHandshake):             true,
+	int16(kmsg.SASLAuthenticate):          true,
+	int16(kmsg.GetTelemetrySubscriptions): true,
+	int16(kmsg.PushTelemetry):             true,
+	int16(kmsg.DescribeCluster):           true,
+	int16(kmsg.ListGroups):                true,
+	int16(kmsg.ListTransactions):          true,
+}
+
+// topLevel answers a request before its handler runs: a TopLevel fault sets
+// the top-level error code of any request that has one, and on a request with
+// nothing to select on (entityless) any fault with no entity selectors does
+// the same.
+func (fc *faultCheck) topLevel(kreq kmsg.Request) kmsg.Response {
+	if fc == nil {
+		return nil
+	}
+	for _, f := range fc.fs {
+		answers := f.topLevel || entityless[fc.key] && f.matches(faultKey{})
+		if !answers {
+			continue
+		}
+		resp := kreq.ResponseKind()
+		code, ok := topLevelCode(resp)
+		if !ok {
+			continue // this request has no top-level code
+		}
+		if !fc.hit(f) {
+			continue
+		}
+		code.SetInt(int64(f.err.Code))
+		return resp
+	}
+	return nil
+}
+
+// topLevelCode returns the response's top-level ErrorCode field, if it has
+// one.
+func topLevelCode(kresp kmsg.Response) (reflect.Value, bool) {
+	v := reflect.ValueOf(kresp)
+	if v.Kind() != reflect.Pointer || v.IsNil() {
+		return reflect.Value{}, false
+	}
+	code := v.Elem().FieldByName("ErrorCode")
+	if !code.IsValid() || code.Kind() != reflect.Int16 {
+		return reflect.Value{}, false
+	}
+	return code, true
+}
+
+// hit takes a unit of f's budget for this request. A request with several
+// matching entities hits the fault once: the first entity takes the unit,
+// later ones are still answered. A fault with nothing left removes itself.
+func (fc *faultCheck) hit(f *fault) bool {
+	if slices.Contains(fc.hits, f) {
+		return true
+	}
+	fc.c.faultsMu.Lock()
+	defer fc.c.faultsMu.Unlock()
+	if f.removed || f.left == 0 {
+		return false
+	}
+	if f.left > 0 {
+		f.left--
+		if f.left == 0 {
+			fc.c.rmFaultLocked(f)
+		}
+	}
+	f.hits.Add(1)
+	fc.hits = append(fc.hits, f)
+	fc.c.faultCond.Broadcast()
+	return true
+}
+
+// anyHit reports whether anything in this request was faulted.
+func (fc *faultCheck) anyHit() bool { return fc != nil && len(fc.hits) > 0 }
+
+// deny answers the error to fail the entity named by k with, either because
+// the user is not allowed the operation or because a fault matches.
+func (c *Cluster) deny(creq *clientReq, resource string, rt kmsg.ACLResourceType, op kmsg.ACLOperation, k faultKey) *kerr.Error {
+	if !c.allowedACL(creq, resource, rt, op) {
+		return aclDenied(rt)
+	}
+	return creq.faults.check(k)
+}
+
+// denyCluster is deny for an operation on the cluster itself.
+func (c *Cluster) denyCluster(creq *clientReq, op kmsg.ACLOperation) *kerr.Error {
+	if !c.allowedClusterACL(creq, op) {
+		return kerr.ClusterAuthorizationFailed
+	}
+	return creq.faults.check(faultKey{})
+}
+
+func aclDenied(rt kmsg.ACLResourceType) *kerr.Error {
+	switch rt {
+	case kmsg.ACLResourceTypeTopic:
+		return kerr.TopicAuthorizationFailed
+	case kmsg.ACLResourceTypeGroup:
+		return kerr.GroupAuthorizationFailed
+	case kmsg.ACLResourceTypeTransactionalId:
+		return kerr.TransactionalIDAuthorizationFailed
+	default:
+		return kerr.ClusterAuthorizationFailed
+	}
+}

--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -402,7 +402,7 @@ func (gs *groups) handleList(creq *clientReq) *kmsg.ListGroupsResponse {
 			continue
 		}
 		// ACL check: DESCRIBE on Group - filter out groups without permission
-		if !g.c.allowedACL(creq, g.name, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
+		if e := g.c.deny(creq, g.name, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: g.name}); e != nil {
 			continue
 		}
 		g.waitControl(func() {
@@ -437,8 +437,8 @@ func (gs *groups) handleDescribe(creq *clientReq) *kmsg.DescribeGroupsResponse {
 	for _, rg := range req.Groups {
 		sg := doneg(rg)
 		// ACL check: DESCRIBE on Group
-		if !gs.c.allowedACL(creq, rg, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
-			sg.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		if e := gs.c.deny(creq, rg, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: rg}); e != nil {
+			sg.ErrorCode = e.Code
 			continue
 		}
 		if kerr := gs.c.validateGroup(creq, rg); kerr != nil {
@@ -502,18 +502,26 @@ func (gs *groups) handleDelete(creq *clientReq) *kmsg.DeleteGroupsResponse {
 
 	for _, rg := range req.Groups {
 		sg := doneg(rg)
+		// setErr sets the code unless a fault already answered.
+		setErr := func(code int16) {
+			if sg.ErrorCode == 0 {
+				sg.ErrorCode = code
+			}
+		}
 		// ACL check: DELETE on Group
-		if !gs.c.allowedACL(creq, rg, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDelete) {
-			sg.ErrorCode = kerr.GroupAuthorizationFailed.Code
-			continue
+		if e := gs.c.deny(creq, rg, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDelete, faultKey{group: rg}); e != nil {
+			sg.ErrorCode = e.Code
+			if creq.skipsWork(e) { // a timed-out delete still deletes
+				continue
+			}
 		}
 		if kerr := gs.c.validateGroup(creq, rg); kerr != nil {
-			sg.ErrorCode = kerr.Code
+			setErr(kerr.Code)
 			continue
 		}
 		g, ok := gs.gs[rg]
 		if !ok {
-			sg.ErrorCode = kerr.GroupIDNotFound.Code
+			setErr(kerr.GroupIDNotFound.Code)
 			continue
 		}
 		if !g.waitControl(func() {
@@ -521,20 +529,20 @@ func (gs *groups) handleDelete(creq *clientReq) *kmsg.DeleteGroupsResponse {
 				if g.activeConsumerCount() == 0 {
 					g.quitOnce()
 				} else {
-					sg.ErrorCode = kerr.NonEmptyGroup.Code
+					setErr(kerr.NonEmptyGroup.Code)
 				}
 			} else {
 				switch g.state {
 				case groupDead:
-					sg.ErrorCode = kerr.GroupIDNotFound.Code
+					setErr(kerr.GroupIDNotFound.Code)
 				case groupEmpty:
 					g.quitOnce()
 				case groupPreparingRebalance, groupCompletingRebalance, groupStable, groupReconciling:
-					sg.ErrorCode = kerr.NonEmptyGroup.Code
+					setErr(kerr.NonEmptyGroup.Code)
 				}
 			}
 		}) {
-			sg.ErrorCode = kerr.GroupIDNotFound.Code
+			setErr(kerr.GroupIDNotFound.Code)
 		}
 		// Delete from gs.gs in the Cluster.run() goroutine, not
 		// inside the waitControl callback. The callback runs in the
@@ -599,8 +607,8 @@ func (gs *groups) handleOffsetFetch(creq *clientReq) *kmsg.OffsetFetchResponse {
 	for _, rg := range req.Groups {
 		sg := doneg(rg.Group)
 		// ACL check: DESCRIBE on Group
-		if !gs.c.allowedACL(creq, rg.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
-			sg.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		if e := gs.c.deny(creq, rg.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: rg.Group}); e != nil {
+			sg.ErrorCode = e.Code
 			continue
 		}
 		if kerr := gs.c.validateGroup(creq, rg.Group); kerr != nil {
@@ -680,6 +688,13 @@ func (gs *groups) handleOffsetFetch(creq *clientReq) *kmsg.OffsetFetchResponse {
 					for _, p := range t.Partitions {
 						sp := kmsg.NewOffsetFetchResponseGroupTopicPartition()
 						sp.Partition = p
+						if e := creq.faults.check(faultKey{group: rg.Group, topic: t.Topic, topicID: t.TopicID}.part(p)); e != nil {
+							sp.ErrorCode = e.Code
+							sp.Offset = -1
+							sp.LeaderEpoch = -1
+							st.Partitions = append(st.Partitions, sp)
+							continue
+						}
 						if unstable {
 							sp.ErrorCode = kerr.UnstableOffsetCommit.Code
 							sp.Offset = -1
@@ -712,8 +727,8 @@ func (g *group) handleOffsetDelete(creq *clientReq) *kmsg.OffsetDeleteResponse {
 	resp := req.ResponseKind().(*kmsg.OffsetDeleteResponse)
 
 	// ACL check: DELETE on Group
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDelete) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDelete, faultKey{group: req.Group}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp
 	}
 
@@ -761,6 +776,10 @@ func (g *group) handleOffsetDelete(creq *clientReq) *kmsg.OffsetDeleteResponse {
 
 	for _, t := range req.Topics {
 		for _, p := range t.Partitions {
+			if e := creq.faults.check(faultKey{group: req.Group, topic: t.Topic}.part(p.Partition)); e != nil {
+				donep(t.Topic, p.Partition, e.Code)
+				continue
+			}
 			if _, ok := subTopics[t.Topic]; ok {
 				donep(t.Topic, p.Partition, kerr.GroupSubscribedToTopic.Code)
 				continue
@@ -960,8 +979,8 @@ func (g *group) handleJoin(creq *clientReq) (kmsg.Response, bool) {
 		resp.ErrorCode = kerr.Code
 		return resp, false
 	}
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp, false
 	}
 	if st := req.SessionTimeoutMillis; st < g.c.groupMinSessionTimeoutMs() || st > g.c.groupMaxSessionTimeoutMs() {
@@ -1154,8 +1173,8 @@ func (g *group) handleSync(creq *clientReq) kmsg.Response {
 		resp.ErrorCode = kerr.Code
 		return resp
 	}
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp
 	}
 	if err := g.validateInstanceID(req.InstanceID, req.MemberID); err != nil {
@@ -1210,8 +1229,8 @@ func (g *group) handleHeartbeat(creq *clientReq) kmsg.Response {
 		resp.ErrorCode = kerr.Code
 		return resp
 	}
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp
 	}
 	if err := g.validateInstanceID(req.InstanceID, req.MemberID); err != nil {
@@ -1250,8 +1269,8 @@ func (g *group) handleLeave(creq *clientReq) kmsg.Response {
 		resp.ErrorCode = kerr.Code
 		return resp
 	}
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp
 	}
 	if req.Version < 3 {
@@ -1268,6 +1287,11 @@ func (g *group) handleLeave(creq *clientReq) kmsg.Response {
 		resp.Members = append(resp.Members, mresp)
 
 		r := &resp.Members[len(resp.Members)-1]
+
+		if e := creq.faults.check(faultKey{group: req.Group, resource: rm.MemberID}); e != nil {
+			r.ErrorCode = e.Code
+			continue
+		}
 
 		// Resolve memberID from instanceID for static members.
 		if rm.InstanceID != nil {
@@ -1335,11 +1359,12 @@ func (g *group) fillOffsetCommitWithACL(creq *clientReq, req *kmsg.OffsetCommitR
 		st := kmsg.NewOffsetCommitResponseTopic()
 		st.Topic = t.Topic
 		st.TopicID = t.TopicID
-		if !g.c.allowedACL(creq, t.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
+		tk := faultKey{group: g.name, topic: t.Topic, topicID: t.TopicID}
+		if e := g.c.deny(creq, t.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, tk); e != nil && creq.skipsWork(e) { // a timed-out commit falls through to the per-partition checks
 			for _, p := range t.Partitions {
 				sp := kmsg.NewOffsetCommitResponseTopicPartition()
 				sp.Partition = p.Partition
-				sp.ErrorCode = kerr.TopicAuthorizationFailed.Code
+				sp.ErrorCode = e.Code
 				st.Partitions = append(st.Partitions, sp)
 			}
 		} else {
@@ -1349,9 +1374,16 @@ func (g *group) fillOffsetCommitWithACL(creq *clientReq, req *kmsg.OffsetCommitR
 			for _, p := range t.Partitions {
 				sp := kmsg.NewOffsetCommitResponseTopicPartition()
 				sp.Partition = p.Partition
-				if creq.topicMeta != nil && (!topicExists || p.Partition < 0 || p.Partition >= meta.partitions) {
+				e := creq.faults.check(tk.part(p.Partition))
+				switch {
+				case e != nil && creq.skipsWork(e): // a timed-out commit is still stored
+					sp.ErrorCode = e.Code
+				case creq.topicMeta != nil && (!topicExists || p.Partition < 0 || p.Partition >= meta.partitions):
 					sp.ErrorCode = kerr.UnknownTopicOrPartition.Code
-				} else {
+				default:
+					if e != nil {
+						sp.ErrorCode = e.Code
+					}
 					at.Partitions = append(at.Partitions, p)
 				}
 				st.Partitions = append(st.Partitions, sp)
@@ -1376,8 +1408,8 @@ func (g *group) handleOffsetCommit(creq *clientReq) (*kmsg.OffsetCommitResponse,
 	}
 
 	// ACL check: READ on GROUP (if denied, fail all topics)
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		fillOffsetCommit(req, resp, kerr.GroupAuthorizationFailed.Code)
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil && creq.skipsWork(e) {
+		fillOffsetCommit(req, resp, e.Code)
 		return resp, false
 	}
 
@@ -1875,8 +1907,8 @@ func (gs *groups) handleConsumerGroupDescribe(creq *clientReq) *kmsg.ConsumerGro
 
 	for _, rg := range req.Groups {
 		sg := doneg(rg)
-		if !gs.c.allowedACL(creq, rg, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe) {
-			sg.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		if e := gs.c.deny(creq, rg, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationDescribe, faultKey{group: rg}); e != nil {
+			sg.ErrorCode = e.Code
 			continue
 		}
 		if kerr := gs.c.validateGroup(creq, rg); kerr != nil {
@@ -1961,8 +1993,8 @@ func (g *group) handleConsumerHeartbeat(creq *clientReq) kmsg.Response {
 		resp.ErrorCode = kerr.Code
 		return resp
 	}
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil {
+		resp.ErrorCode = e.Code
 		return resp
 	}
 
@@ -3301,8 +3333,8 @@ func (g *group) handleConsumerOffsetCommit(creq *clientReq) *kmsg.OffsetCommitRe
 		fillOffsetCommit(req, resp, kerr.Code)
 		return resp
 	}
-	if !g.c.allowedACL(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead) {
-		fillOffsetCommit(req, resp, kerr.GroupAuthorizationFailed.Code)
+	if e := g.c.deny(creq, req.Group, kmsg.ACLResourceTypeGroup, kmsg.ACLOperationRead, faultKey{group: req.Group}); e != nil && creq.skipsWork(e) {
+		fillOffsetCommit(req, resp, e.Code)
 		return resp
 	}
 

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2348,23 +2348,13 @@ func TestRequestCachedMetadata(t *testing.T) {
 		}
 		countAfterCache := metadataRequests.Load()
 
-		// Step 2: intercept ListOffsets to return NotLeaderForPartition,
+		// Step 2: fail one ListOffsets with NotLeaderForPartition,
 		// which triggers maybeDeleteCachedMeta for the topic.
-		c.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-			lor := kreq.(*kmsg.ListOffsetsRequest)
-			resp := lor.ResponseKind().(*kmsg.ListOffsetsResponse)
-			for _, rt := range lor.Topics {
-				st := kmsg.NewListOffsetsResponseTopic()
-				st.Topic = rt.Topic
-				for _, rp := range rt.Partitions {
-					sp := kmsg.NewListOffsetsResponseTopicPartition()
-					sp.Partition = rp.Partition
-					sp.ErrorCode = kerr.NotLeaderForPartition.Code
-					st.Partitions = append(st.Partitions, sp)
-				}
-				resp.Topics = append(resp.Topics, st)
-			}
-			return resp, nil, true
+		c.Fault(Fault{
+			Keys:  []kmsg.Key{kmsg.ListOffsets},
+			Topic: "topic1",
+			Err:   kerr.NotLeaderForPartition,
+			Count: 1,
 		})
 		adm.ListStartOffsets(ctx, "topic1")
 
@@ -4126,22 +4116,11 @@ func TestOnDataLossCallbackReentrancy(t *testing.T) {
 	// One-shot: the first produce gets OUT_OF_ORDER_SEQUENCE_NUMBER,
 	// which for a non-transactional producer (stopOnDataLoss unset)
 	// fires the data-loss callback and reloads the producer id.
-	c.ControlKey(0, func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		req := kreq.(*kmsg.ProduceRequest)
-		resp := req.ResponseKind().(*kmsg.ProduceResponse)
-		for _, rt := range req.Topics {
-			respt := kmsg.NewProduceResponseTopic()
-			respt.Topic = rt.Topic
-			respt.TopicID = rt.TopicID
-			for _, rp := range rt.Partitions {
-				respp := kmsg.NewProduceResponseTopicPartition()
-				respp.Partition = rp.Partition
-				respp.ErrorCode = kerr.OutOfOrderSequenceNumber.Code
-				respt.Partitions = append(respt.Partitions, respp)
-			}
-			resp.Topics = append(resp.Topics, respt)
-		}
-		return resp, nil, true
+	c.Fault(Fault{
+		Keys:  []kmsg.Key{kmsg.Produce},
+		Topic: testTopic,
+		Err:   kerr.OutOfOrderSequenceNumber,
+		Count: 1,
 	})
 
 	var cl *kgo.Client

--- a/pkg/kfake/share_churn_test.go
+++ b/pkg/kfake/share_churn_test.go
@@ -105,30 +105,6 @@ func TestShareFetchLeaderMoveNoHintHeals(t *testing.T) {
 	oldLeader := c.LeaderFor(topic, 0)
 	newLeader := (oldLeader + 1) % 2
 
-	// Once moved is set, every ShareFetch served by the old leader gets
-	// a manual NOT_LEADER response with CurrentLeader=-1/-1 (no hint)
-	// and no NodeEndpoints. Requests to the new leader pass through.
-	var moved atomic.Bool
-	c.ControlKey(int16(kmsg.ShareFetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		c.KeepControl()
-		if !moved.Load() || c.CurrentNode() != oldLeader {
-			return nil, nil, false
-		}
-		req := kreq.(*kmsg.ShareFetchRequest)
-		resp := req.ResponseKind().(*kmsg.ShareFetchResponse)
-		resp.AcquisitionLockTimeoutMillis = 30000
-		rt := kmsg.NewShareFetchResponseTopic()
-		rt.TopicID = ti.TopicID
-		rp := kmsg.NewShareFetchResponseTopicPartition()
-		rp.Partition = 0
-		rp.ErrorCode = kerr.NotLeaderForPartition.Code
-		rp.CurrentLeader.LeaderID = -1 // leaderless window: no hint
-		rp.CurrentLeader.LeaderEpoch = -1
-		rt.Partitions = append(rt.Partitions, rp)
-		resp.Topics = append(resp.Topics, rt)
-		return resp, nil, true
-	})
-
 	cl := shareChurnConsumer(t, c, topic, group)
 
 	if got, _ := pollShareUntil(t, cl, pre, 10*time.Second, nil); got < pre {
@@ -138,7 +114,16 @@ func TestShareFetchLeaderMoveNoHintHeals(t *testing.T) {
 	if err := c.MoveTopicPartition(topic, 0, newLeader); err != nil {
 		t.Fatal(err)
 	}
-	moved.Store(true)
+	// Every ShareFetch the old leader serves now fails with NOT_LEADER and
+	// no CurrentLeader hint. The client heals with a metadata refresh.
+	c.Fault(Fault{
+		Keys:       []kmsg.Key{kmsg.ShareFetch},
+		Nodes:      []int32{oldLeader},
+		TopicID:    ti.TopicID,
+		Partitions: []int32{0},
+		Err:        kerr.NotLeaderForPartition,
+		Count:      -1,
+	})
 	produceN(t, c, topic, post)
 
 	// Post-fix: the stripped NOT_LEADER triggers a metadata refresh, the
@@ -285,16 +270,18 @@ func TestShareFetchTopLevelErrorBackoff(t *testing.T) {
 		mu    sync.Mutex
 		times []time.Time
 	)
-	c.ControlKey(int16(kmsg.ShareFetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+	c.Fault(Fault{
+		Keys:     []kmsg.Key{kmsg.ShareFetch},
+		TopLevel: true,
+		Err:      kerr.GroupAuthorizationFailed,
+		Count:    -1,
+	})
+	c.ControlKey(int16(kmsg.ShareFetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 		c.KeepControl()
 		mu.Lock()
 		times = append(times, time.Now())
 		mu.Unlock()
-		req := kreq.(*kmsg.ShareFetchRequest)
-		resp := req.ResponseKind().(*kmsg.ShareFetchResponse)
-		resp.AcquisitionLockTimeoutMillis = 30000
-		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
-		return resp, nil, true
+		return nil, nil, false
 	})
 
 	cl := shareChurnConsumer(t, c, topic, group)

--- a/pkg/kfake/share_groups.go
+++ b/pkg/kfake/share_groups.go
@@ -1162,13 +1162,18 @@ func (g *shareGroup) processShareAcks(
 			}
 			continue
 		}
-		if !g.c.allowedACL(creq, topicName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
+		tk := faultKey{topic: topicName, topicID: at.topicID}
+		if e := g.c.deny(creq, topicName, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, tk); e != nil {
 			for _, ap := range at.partitions {
-				onPartition(at.topicID, ap.partition, kerr.TopicAuthorizationFailed.Code)
+				onPartition(at.topicID, ap.partition, e.Code)
 			}
 			continue
 		}
 		for _, ap := range at.partitions {
+			if e := creq.faults.check(tk.part(ap.partition)); e != nil {
+				onPartition(at.topicID, ap.partition, e.Code)
+				continue
+			}
 			errCode := int16(0)
 			prevEnd := int64(-1)
 			for _, batch := range ap.batches {

--- a/pkg/kfake/sink_sweep_test.go
+++ b/pkg/kfake/sink_sweep_test.go
@@ -255,22 +255,11 @@ func TestAuditTxnAbortRetryAfterOperationNotAttempted(t *testing.T) {
 	// producers and is neither retriable nor recoverable under KIP-890p2,
 	// so the abort below cannot take the recovered-early-return and must
 	// reach the broker via EndTxn.
-	c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
-		preq := req.(*kmsg.ProduceRequest)
-		resp := preq.ResponseKind().(*kmsg.ProduceResponse)
-		for _, rt := range preq.Topics {
-			st := kmsg.NewProduceResponseTopic()
-			st.Topic = rt.Topic
-			st.TopicID = rt.TopicID
-			for _, rp := range rt.Partitions {
-				sp := kmsg.NewProduceResponseTopicPartition()
-				sp.Partition = rp.Partition
-				sp.ErrorCode = kerr.InvalidProducerIDMapping.Code
-				st.Partitions = append(st.Partitions, sp)
-			}
-			resp.Topics = append(resp.Topics, st)
-		}
-		return resp, nil, true
+	c.Fault(Fault{
+		Keys:  []kmsg.Key{kmsg.Produce},
+		Topic: topic,
+		Err:   kerr.InvalidProducerIDMapping,
+		Count: 1,
 	})
 	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("r2")}).FirstErr(); err == nil {
 		t.Fatal("expected the injected produce failure, got success")

--- a/pkg/kfake/source_resweep_test.go
+++ b/pkg/kfake/source_resweep_test.go
@@ -145,17 +145,20 @@ func TestAuditFetchTopLevelErrorBackoff(t *testing.T) {
 		mu    sync.Mutex
 		times []time.Time
 	)
-	c.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+	// An unexpected top-level code (not a fetch-session code) routes to the
+	// default arm.
+	c.Fault(Fault{
+		Keys:     []kmsg.Key{kmsg.Fetch},
+		TopLevel: true,
+		Err:      kerr.UnknownServerError,
+		Count:    -1,
+	})
+	c.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
 		c.KeepControl()
-		req := kreq.(*kmsg.FetchRequest)
 		mu.Lock()
 		times = append(times, time.Now())
 		mu.Unlock()
-		resp := req.ResponseKind().(*kmsg.FetchResponse)
-		// An unexpected top-level code (not a fetch-session code) routes to
-		// the default arm.
-		resp.ErrorCode = kerr.UnknownServerError.Code
-		return resp, nil, true
+		return nil, nil, false
 	})
 
 	cl := newPlainClient(t, c,

--- a/pkg/kfake/txn_churn_test.go
+++ b/pkg/kfake/txn_churn_test.go
@@ -87,26 +87,15 @@ func TestAuditTxnInitPidRetriableLoadFailure(t *testing.T) {
 	}
 }
 
-// failAllProduces installs a control that fails every partition of the next
-// produce request with MESSAGE_TOO_LARGE: terminal for the batch, but not a
-// producer-id-failing error, mirroring a broker-side append rejection.
-func failAllProduces(c *Cluster) {
-	c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
-		preq := req.(*kmsg.ProduceRequest)
-		resp := preq.ResponseKind().(*kmsg.ProduceResponse)
-		for _, rt := range preq.Topics {
-			st := kmsg.NewProduceResponseTopic()
-			st.Topic = rt.Topic
-			st.TopicID = rt.TopicID
-			for _, rp := range rt.Partitions {
-				sp := kmsg.NewProduceResponseTopicPartition()
-				sp.Partition = rp.Partition
-				sp.ErrorCode = kerr.MessageTooLarge.Code
-				st.Partitions = append(st.Partitions, sp)
-			}
-			resp.Topics = append(resp.Topics, st)
-		}
-		return resp, nil, true
+// failAllProduces fails every partition of the topic in the next produce
+// request with MESSAGE_TOO_LARGE. The batch is terminal and the producer ID
+// survives, as with a broker-side append rejection.
+func failAllProduces(c *Cluster, topic string) {
+	c.Fault(Fault{
+		Keys:  []kmsg.Key{kmsg.Produce},
+		Topic: topic,
+		Err:   kerr.MessageTooLarge,
+		Count: 1,
 	})
 }
 
@@ -135,7 +124,7 @@ func TestAuditTxnV2AbortAfterFailedProduces(t *testing.T) {
 	c := newCluster(t, NumBrokers(1), SeedTopics(1, "audit-v2-abort"))
 
 	endTxns := observeEndTxns(c)
-	failAllProduces(c)
+	failAllProduces(c, "audit-v2-abort")
 
 	cl := newPlainClient(t, c, kgo.TransactionalID("audit-v2-abort"))
 	if err := cl.BeginTransaction(); err != nil {
@@ -184,7 +173,7 @@ func TestAuditTxnV1AbortAfterFailedProducesControl(t *testing.T) {
 	}
 
 	endTxns := observeEndTxns(c)
-	failAllProduces(c)
+	failAllProduces(c, "audit-v1-abort")
 
 	cl := newPlainClient(t, c, kgo.TransactionalID("audit-v1-abort"))
 	if err := cl.BeginTransaction(); err != nil {

--- a/pkg/kfake/txns.go
+++ b/pkg/kfake/txns.go
@@ -310,8 +310,18 @@ func (pids *pids) doAddPartitions(creq *clientReq) kmsg.Response {
 		}
 	}
 
-	// Check if all topics/partitions exist.
+	// A faulted partition is not added, and the rest of the transaction
+	// is not attempted, as with a partition that does not exist.
+	faulted := make(map[tpKey]*kerr.Error)
 	var noAttempt bool
+	for _, rt := range req.Topics {
+		for _, rp := range rt.Partitions {
+			if e := creq.faults.check(faultKey{txnID: req.TransactionalID, topic: rt.Topic}.part(rp)); e != nil {
+				faulted[tpKey{rt.Topic, rp}] = e
+				noAttempt = true
+			}
+		}
+	}
 	for _, rt := range req.Topics {
 		for _, rp := range rt.Partitions {
 			if pdMap[tpKey{rt.Topic, rp}] == nil {
@@ -326,9 +336,12 @@ func (pids *pids) doAddPartitions(creq *clientReq) kmsg.Response {
 	if noAttempt {
 		for _, rt := range req.Topics {
 			for _, rp := range rt.Partitions {
-				if pdMap[tpKey{rt.Topic, rp}] == nil {
+				switch e := faulted[tpKey{rt.Topic, rp}]; {
+				case e != nil:
+					donep(rt.Topic, rp, e.Code)
+				case pdMap[tpKey{rt.Topic, rp}] == nil:
 					donep(rt.Topic, rp, kerr.UnknownTopicOrPartition.Code)
-				} else {
+				default:
 					donep(rt.Topic, rp, kerr.OperationNotAttempted.Code)
 				}
 			}
@@ -492,9 +505,15 @@ func (pids *pids) doTxnOffsetCommit(creq *clientReq) kmsg.Response {
 		for _, rp := range rt.Partitions {
 			sp := kmsg.NewTxnOffsetCommitResponseTopicPartition()
 			sp.Partition = rp.Partition
-			if !pids.c.data.tps.checkp(rt.Topic, rp.Partition) {
+			e := creq.faults.check(faultKey{txnID: req.TransactionalID, group: req.Group, topic: rt.Topic}.part(rp.Partition))
+			if e != nil {
+				sp.ErrorCode = e.Code
+			}
+			switch {
+			case e != nil && creq.skipsWork(e): // a timed-out commit is still stored
+			case !pids.c.data.tps.checkp(rt.Topic, rp.Partition):
 				sp.ErrorCode = kerr.UnknownTopicOrPartition.Code
-			} else {
+			default:
 				groupOffsets.set(rt.Topic, rp.Partition, offsetCommit{
 					offset:      rp.Offset,
 					leaderEpoch: rp.LeaderEpoch,
@@ -900,8 +919,8 @@ func (pids *pids) doDescribeTransactions(creq *clientReq) kmsg.Response {
 		st := kmsg.NewDescribeTransactionsResponseTransactionState()
 		st.TransactionalID = txnID
 
-		if !pids.c.allowedACL(creq, txnID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationDescribe) {
-			st.ErrorCode = kerr.TransactionalIDAuthorizationFailed.Code
+		if e := pids.c.deny(creq, txnID, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationDescribe, faultKey{txnID: txnID}); e != nil {
+			st.ErrorCode = e.Code
 			resp.TransactionStates = append(resp.TransactionStates, st)
 			continue
 		}
@@ -928,7 +947,7 @@ func (pids *pids) doDescribeTransactions(creq *clientReq) kmsg.Response {
 			st.State = "Ongoing"
 			st.StartTimestamp = pidinf.txStart.UnixMilli()
 			pidinf.txParts.each(func(topic string, partition int32, _ *partData) {
-				if !pids.c.allowedACL(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe) {
+				if e := pids.c.deny(creq, topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationDescribe, faultKey{topic: topic}.part(partition)); e != nil {
 					return
 				}
 				var topicEntry *kmsg.DescribeTransactionsResponseTransactionStateTopic
@@ -983,7 +1002,7 @@ func (pids *pids) doListTransactions(creq *clientReq) kmsg.Response {
 		if pidinf.txid == "" {
 			continue
 		}
-		if !pids.c.allowedACL(creq, pidinf.txid, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationDescribe) {
+		if e := pids.c.deny(creq, pidinf.txid, kmsg.ACLResourceTypeTransactionalId, kmsg.ACLOperationDescribe, faultKey{txnID: pidinf.txid}); e != nil {
 			continue
 		}
 		state := "Empty"
@@ -1029,14 +1048,18 @@ func (pids *pids) doDescribeProducers(creq *clientReq) kmsg.Response {
 	}
 	var checks []partState
 	for _, rt := range req.Topics {
-		if !pids.c.allowedACL(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead) {
+		if e := pids.c.deny(creq, rt.Topic, kmsg.ACLResourceTypeTopic, kmsg.ACLOperationRead, faultKey{topic: rt.Topic}); e != nil {
 			for _, p := range rt.Partitions {
-				checks = append(checks, partState{rt.Topic, p, kerr.TopicAuthorizationFailed.Code})
+				checks = append(checks, partState{rt.Topic, p, e.Code})
 			}
 			continue
 		}
 		for _, p := range rt.Partitions {
-			checks = append(checks, partState{rt.Topic, p, 0})
+			var code int16
+			if e := creq.faults.check(faultKey{topic: rt.Topic}.part(p)); e != nil {
+				code = e.Code
+			}
+			checks = append(checks, partState{rt.Topic, p, code})
 		}
 	}
 


### PR DESCRIPTION
## Fault

`c.Fault(faults...)` installs faults and returns one handle for the batch. Every field of a `Fault` is an AND filter over what it applies to: `Keys` (request kinds), `Nodes`, `Topic` or `TopicID`, `Partitions`, `Group`, `TxnID`, `Resource` (a config resource, quota entity, SCRAM user, log dir, feature, LeaveGroup member, or ACL resource name), and `TopLevel` to fail the request's top-level error code instead of its entities. Every zero value means "all", so node 0 and partition 0 are named the same way as any other, and a selector a request does not carry never matches: a fault with a `Topic` does not fail a heartbeat, and one with `Partitions` does not match an entity that has no partition. `Fault` may be called from a control function.

`Count` is a budget of requests: 0 is one, -1 is until `Remove`, N is N. Faults are checked in the order added and the first match answers an entity; a `ControlKey` control that answers a request bypasses them. The handle has `Hits`, `Wait(ctx, n)`, and `Remove`.

`REQUEST_TIMED_OUT` is answered after the work rather than in place of it on exactly the requests a real broker can answer that way, and `NOT_ENOUGH_REPLICAS_AFTER_APPEND` on Produce and WriteTxnMarkers. A table in faults.go holds the set, all per entity: Produce, WriteTxnMarkers, DeleteRecords, OffsetCommit, TxnOffsetCommit, DeleteGroups, AlterShareGroupOffsets, DeleteShareGroupOffsets, and the forwarded admin requests whose controller work can finish after the broker's forwarding budget expires (CreateTopics, DeleteTopics, CreatePartitions, ElectLeaders, AlterPartitionAssignments, AlterConfigs, IncrementalAlterConfigs, CreateACLs, DeleteACLs, AlterClientQuotas, AlterUserSCRAMCredentials, UpdateFeatures). Everywhere else -- the group protocol, the transaction coordinator, the share requests, every read -- the code is an ordinary rejection. So a faulted produce still appends, a timed out delete still deletes, a timed out commit is still stored, and a timed out create still creates, each with a test.

**Coverage.** Faults are checked wherever authorization is (one helper beside every ACL check, in the numbered handlers and in groups.go, share_groups.go and txns.go), plus per partition inside every request that carries partitions, and at dispatch for the eight requests that carry nothing to select on (the entityless set in faults.go). A table test walks every request key kfake registers, sends a minimal request of that kind, and asserts the response carries the injected code and that the fault fired -- so no kind can silently miss.

Why: matching by topic ID, group, or transaction. After a delete and recreate a client can keep addressing the stale ID, and a test has to fail only the requests that use it; until now the only way to fail one partition was a control function rebuilding the whole response by hand.

## Converting existing tests

Nine controls in the kfake tests existed only to answer a request with an error code; they are now faults. That removes 216 lines and adds 120, and 97 of the removed lines were building kmsg response entries. Five become per-partition faults (produce, fetch, list offsets, offset for leader epoch, share fetch), two become `TopLevel` faults with the control kept only for its timestamps, and two that blocked on a channel the control closed now wait on the handle with `Wait`. The controls left alone are not error injection: preferred read replicas, a negative offset, the KIP-320 undefined-epoch sentinel, a duplicated partition entry, a closed connection, an error code that alternates per request, a request held in flight, and pure observers.

## Tested

The coverage table over every registered key; a partition selector that fails one partition and leaves the rest; a group selector across commits, heartbeats, and a describe; `TopLevel` failing a fetch at once with no partitions; a transaction selector across InitProducerID, EndTxn, and TxnOffsetCommit; a node selector on a two node cluster; FindCoordinator matching a group key against `Group` and a transaction key against `TxnID`; `Resource` on DescribeConfigs and on CreateACLs; a topic fault that does not touch a heartbeat; the `Count` budget and `Remove`; a batch handle summing hits and removing both faults; the earliest fault winning; the after-apply cases (produce three ways, delete records, offset and transactional commits, delete groups, create topics, alter configs); faults installed from inside a control function, plain and sleeping; and `Wait` before, during, at exhaustion, and on a canceled context.

`gofmt -l pkg/kfake` clean, `go vet`, the fault tests and every converted test with `-race -count=10`, the persist tests with `-race`, and the full package with `-race -skip ETL`.

## Maintenance

pkg/kfake/CLAUDE.md gains a section on adding a request handler: where the deny and check calls go, what the fault key names, the answer-then-skipsWork emission shape, the after-apply table, and the tests that must pass. nilerr is excluded for the numbered handlers: they answer an error code inside the response and return nil to the connection, which the linter reads as a swallowed error.
