### PR TITLE
kgo: retry a timed-out produce after backoff, not after metadata

### DIFF
--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -2575,19 +2575,25 @@ func TestIssue1217(t *testing.T) {
 		host, portStr, _ := net.SplitHostPort(c.ListenAddrs()[0])
 		port, _ := strconv.Atoi(portStr)
 
+		// The poison retries on the produce backoff without touching
+		// metadata; the NOT_LEADER on the next attempt sends the
+		// poisoned batch through metadata.
 		var produceAttempt atomic.Int32
 		c.ControlKey(int16(kmsg.Produce), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			c.KeepControl()
-			if produceAttempt.Add(1) == 1 {
+			switch produceAttempt.Add(1) {
+			case 1:
 				return produceErr(kreq, kerr.RequestTimedOut.Code)
+			case 2:
+				return produceErr(kreq, kerr.NotLeaderForPartition.Code)
+			default:
+				return nil, nil, false
 			}
-			return nil, nil, false
 		})
 
-		// After the poison, return LEADER_NOT_AVAILABLE on metadata
-		// to trigger bumpRepeatedLoadErr. We keep returning the error
-		// more times than RecordRetries(1) to verify the limit is
-		// bypassed.
+		// Metadata then returns LEADER_NOT_AVAILABLE to trigger
+		// bumpRepeatedLoadErr, more times than RecordRetries(1), to
+		// verify the limit is bypassed.
 		var metadataErrors atomic.Int32
 		c.ControlKey(int16(kmsg.Metadata), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			c.KeepControl()

--- a/pkg/kfake/sink_sweep_test.go
+++ b/pkg/kfake/sink_sweep_test.go
@@ -324,3 +324,39 @@ func TestAuditProduceDuplicateResponseEntryKeepsHook(t *testing.T) {
 		t.Fatalf("BUG REPRODUCED: OnProduceBatchWritten fired %d times for one successfully produced batch; a duplicated produce response topic entry deleted the batch's metrics before the deferred hook ran", got)
 	}
 }
+
+// A produce answered REQUEST_TIMED_OUT retries after the produce backoff,
+// not after the next metadata update, which MetadataMinAge holds off.
+func TestProduceTimedOutRetriesOnBackoff(t *testing.T) {
+	t.Parallel()
+
+	const topic = "t"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	h := c.Fault(Fault{
+		Keys:  []kmsg.Key{kmsg.Produce},
+		Topic: topic,
+		Err:   kerr.RequestTimedOut,
+	})
+	cl := newPlainClient(t, c,
+		kgo.DefaultProduceTopic(topic),
+		kgo.MetadataMinAge(30*time.Second),
+		kgo.RetryBackoffFn(func(int) time.Duration { return 50 * time.Millisecond }),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := time.Now()
+	if err := cl.ProduceSync(ctx, kgo.StringRecord("p0")).FirstErr(); err != nil {
+		t.Fatalf("produce did not heal past the timed-out append: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("retry took %v; want the produce backoff, not a metadata update", elapsed)
+	}
+	if h.Hits() != 1 {
+		t.Fatalf("fault hit %d times; want 1", h.Hits())
+	}
+	// The timed-out append still landed, so the retry deduplicates.
+	if hwm := c.PartitionInfo(topic, 0).HighWatermark; hwm != 1 {
+		t.Fatalf("high watermark %d; want 1", hwm)
+	}
+}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -859,7 +859,8 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 	}
 
 	var kmove kip951move
-	var reqRetry seqRecBatches // handled at the end
+	var reqRetry seqRecBatches   // handled at the end
+	var reqBackoff seqRecBatches // retried after the produce backoff, no metadata update
 
 	kresp := resp.(*kmsg.ProduceResponse)
 	for i := range kresp.Topics {
@@ -916,7 +917,15 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 				tmetrics[partition],
 			)
 			if retry {
-				reqRetry.addSeqBatch(topic, tid, partition, batch)
+				// A timed-out append, or one short of replicas,
+				// comes from a leader that is still the leader:
+				// metadata has nothing to say, so we retry after
+				// the produce backoff.
+				if rp.ErrorCode == kerr.RequestTimedOut.Code || rp.ErrorCode == kerr.NotEnoughReplicasAfterAppend.Code {
+					reqBackoff.addSeqBatch(topic, tid, partition, batch)
+				} else {
+					reqRetry.addSeqBatch(topic, tid, partition, batch)
+				}
 			}
 			if !didProduce {
 				delete(tmetrics, partition)
@@ -941,6 +950,9 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 	}
 	if len(reqRetry.bs) > 0 {
 		s.handleRetryBatches(reqRetry, &kmove, 0, true, true, "produce request had retry batches")
+	}
+	if len(reqBackoff.bs) > 0 {
+		s.handleRetryBatches(reqBackoff, nil, req.backoffSeq, false, true, "produce request had timed out batches")
 	}
 }
 


### PR DESCRIPTION
A produce batch answered `REQUEST_TIMED_OUT` or `NOT_ENOUGH_REPLICAS_AFTER_APPEND` was retried like every other retryable error: marked failing until the next metadata update, which `MetadataMinAge` holds off for up to five seconds by default. Both codes come from a leader that is still the leader and has already appended locally, so metadata has nothing to say. The batch now retries after the produce backoff, the same path a request that died on the wire takes. Everything else (NOT_LEADER, unknown topic, and the rest) still refreshes metadata first.

Found while driving `kcl fake` faults from the real-broker tests: a produce answered with a timeout after the append took five seconds to land its retry.

Tested with a kfake fault answering one produce `REQUEST_TIMED_OUT` after the append: the idempotent retry lands the record once, in under two seconds against a 30s `MetadataMinAge`; without the change the same test waits the full 30s. The `TestIssue1217` load-errors subtest now answers the second attempt `NOT_LEADER` so its poisoned batch still reaches the metadata path it exercises. Whole kfake package green under `-race`, lint clean.
