### PR TITLE
kgo: rack aware assignment for topics we do not consume; evict cached metadata less

### DIFF
--- a/pkg/kgo/client.go
+++ b/pkg/kgo/client.go
@@ -1067,7 +1067,7 @@ func (cl *Client) fetchBrokerMetadata(ctx context.Context) error {
 			}()
 			req := kmsg.NewPtrMetadataRequest()
 			req.Topics = []kmsg.MetadataRequestTopic{}
-			_, _, wait.err = cl.fetchMetadata(cl.ctx, req, true, nil)
+			_, _, wait.err = cl.fetchMetadata(cl.ctx, req, true, false, nil) // prune: no; brokers only, no opinion on topics
 		}()
 	}
 	cl.fetchingBrokersMu.Unlock()
@@ -1080,7 +1080,7 @@ func (cl *Client) fetchBrokerMetadata(ctx context.Context) error {
 	}
 }
 
-func (cl *Client) fetchMetadataByName(ctx context.Context, all bool, topics []string, results map[string]cachedMetaTopic) (*broker, *kmsg.MetadataResponse, error) {
+func (cl *Client) fetchMetadataByName(ctx context.Context, all bool, topics []string, prune bool, results map[string]cachedMetaTopic) (*broker, *kmsg.MetadataResponse, error) {
 	req := kmsg.NewPtrMetadataRequest()
 	req.AllowAutoTopicCreation = cl.cfg.allowAutoTopicCreation
 	if all {
@@ -1094,7 +1094,7 @@ func (cl *Client) fetchMetadataByName(ctx context.Context, all bool, topics []st
 			req.Topics = append(req.Topics, reqTopic)
 		}
 	}
-	return cl.fetchMetadata(ctx, req, true, results)
+	return cl.fetchMetadata(ctx, req, true, prune, results)
 }
 
 // resolveTopicMetaByID fetches metadata by TopicID and caches the results.
@@ -1121,11 +1121,11 @@ func (cl *Client) resolveTopicMetaByID(ctx context.Context, ids [][16]byte) (map
 		req.Topics = append(req.Topics, reqTopic)
 	}
 	results := make(map[string]cachedMetaTopic)
-	_, _, err := cl.fetchMetadata(ctx, req, true, results)
+	_, _, err := cl.fetchMetadata(ctx, req, true, false, results) // prune: no; only the ids we could not resolve
 	return results, err
 }
 
-func (cl *Client) fetchMetadata(ctx context.Context, req *kmsg.MetadataRequest, limitRetries bool, results map[string]cachedMetaTopic) (*broker, *kmsg.MetadataResponse, error) {
+func (cl *Client) fetchMetadata(ctx context.Context, req *kmsg.MetadataRequest, limitRetries, prune bool, results map[string]cachedMetaTopic) (*broker, *kmsg.MetadataResponse, error) {
 	r := cl.retryable()
 
 	var rebootstrapped bool
@@ -1160,7 +1160,7 @@ start:
 		cl.updateMetadataBrokers(meta)
 
 		// Cache the metadata, and potentially store each topic in the results.
-		cl.storeCachedMeta(meta, req.Topics == nil, results)
+		cl.storeCachedMeta(req, meta, prune, results)
 	}
 	return r.last, meta, err
 }
@@ -1563,7 +1563,7 @@ func (cl *Client) RequestCachedMetadata(ctx context.Context, req *kmsg.MetadataR
 			rt.TopicID = id
 			idReq.Topics = append(idReq.Topics, rt)
 		}
-		_, meta, err := cl.fetchMetadata(ctx, idReq, true, nil)
+		_, meta, err := cl.fetchMetadata(ctx, idReq, true, false, nil) // prune: no; only the ids we could not resolve
 		if err != nil {
 			return nil, err
 		}
@@ -1881,7 +1881,7 @@ func (cl *Client) shardedRequest(ctx context.Context, req kmsg.Request) ([]Respo
 	case *kmsg.MetadataRequest:
 		// We hijack any metadata request so as to populate our
 		// own brokers and controller ID.
-		br, resp, err := cl.fetchMetadata(ctx, t, false, nil)
+		br, resp, err := cl.fetchMetadata(ctx, t, false, true, nil) // prune: yes; the user says what they want cached
 		return shards(shard(br, req, resp, err)), nil
 
 	case kmsg.AdminRequest:
@@ -3158,19 +3158,35 @@ func (cl *Client) resolveTopicMeta(ctx context.Context, topics []string, useCach
 	if results == nil {
 		results = make(map[string]cachedMetaTopic)
 	}
-	_, _, err := cl.fetchMetadataByName(ctx, all, needed, results)
+	_, _, err := cl.fetchMetadataByName(ctx, all, needed, true, results) // prune: yes; our caller wants only these cached
 	return results, err
 }
 
 // storeCachedMeta caches the fetched metadata in the Client, and
-// optionally stores each topic in results. If all is true, this was an
-// all-topics fetch and stale entries not in the response are evicted.
+// optionally stores each topic in results. If the request was for all
+// topics, stale entries not in the response are evicted.
+//
+// If prune is true, we also evict entries older than MetadataMinAge that the
+// response does not contain. Only requests that say something about what we
+// want cached prune: the metadata loop, a user's own metadata request, and
+// RequestCachedMetadata. Internal targeted fetches say nothing about the
+// topics they did not ask for, so loading brokers, resolving topic IDs,
+// creating unknown produce topics, and loading the group's topics to balance
+// all leave the rest of the cache alone.
+//
+// A request for no topics is a broker only request: the response cannot
+// contain topics and says nothing about the ones we have, so we neither
+// store nor evict.
 //
 // Topics with a nil name are skipped. Per the Kafka protocol, the broker
 // always populates the topic name for successfully resolved topics, even
 // for TopicID-only requests. A nil name only occurs for error responses
 // (e.g. UnknownTopicID), which cannot be meaningfully cached by name.
-func (cl *Client) storeCachedMeta(meta *kmsg.MetadataResponse, all bool, results map[string]cachedMetaTopic) {
+func (cl *Client) storeCachedMeta(req *kmsg.MetadataRequest, meta *kmsg.MetadataResponse, prune bool, results map[string]cachedMetaTopic) {
+	if req.Topics != nil && len(req.Topics) == 0 {
+		return
+	}
+	all := req.Topics == nil
 	cl.metaCache.mu.Lock()
 	defer cl.metaCache.mu.Unlock()
 	if cl.metaCache.topics == nil {
@@ -3242,7 +3258,7 @@ func (cl *Client) storeCachedMeta(meta *kmsg.MetadataResponse, all bool, results
 	// Prune entries older than metadataMinAge. If the number of
 	// topics we just stored equals the map size, every entry is
 	// fresh and there is nothing to prune.
-	if stored < len(cl.metaCache.topics) {
+	if prune && stored < len(cl.metaCache.topics) {
 		for topic, ct := range cl.metaCache.topics {
 			if ct.when.Equal(when) {
 				continue

--- a/pkg/kgo/client_resweep_test.go
+++ b/pkg/kgo/client_resweep_test.go
@@ -31,7 +31,7 @@ func TestAuditWriteTxnMarkersPreservesCoordinatorEpoch(t *testing.T) {
 	rp.Leader = 1
 	rt.Partitions = append(rt.Partitions, rp)
 	meta.Topics = append(meta.Topics, rt)
-	cl.storeCachedMeta(meta, false, nil)
+	cl.storeCachedMeta(mkreq("foo"), meta, true, nil)
 
 	req := kmsg.NewPtrWriteTxnMarkersRequest()
 	m := kmsg.NewWriteTxnMarkersRequestMarker()

--- a/pkg/kgo/client_sweep_test.go
+++ b/pkg/kgo/client_sweep_test.go
@@ -2,6 +2,7 @@ package kgo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
@@ -22,8 +23,8 @@ func TestStoreCachedMetaTopicIDChange(t *testing.T) {
 		resp.Topics = append(resp.Topics, rt)
 		return resp
 	}
-	cl.storeCachedMeta(mkmeta(1), false, nil)
-	cl.storeCachedMeta(mkmeta(2), false, nil)
+	cl.storeCachedMeta(mkreq("foo"), mkmeta(1), true, nil)
+	cl.storeCachedMeta(mkreq("foo"), mkmeta(2), true, nil)
 
 	cl.metaCache.mu.Lock()
 	defer cl.metaCache.mu.Unlock()
@@ -81,5 +82,70 @@ func TestOptValuesTxnIDAndShare(t *testing.T) {
 	}
 	if vs := shcl.OptValues(ShareAckCallback); vs == nil {
 		t.Errorf("OptValues(ShareAckCallback) = nil; the option exists and must be returned")
+	}
+}
+
+// mkreq returns a metadata request for the given topics.
+func mkreq(topics ...string) *kmsg.MetadataRequest {
+	req := kmsg.NewPtrMetadataRequest()
+	req.Topics = []kmsg.MetadataRequestTopic{}
+	for _, topic := range topics {
+		rt := kmsg.NewMetadataRequestTopic()
+		rt.Topic = kmsg.StringPtr(topic)
+		req.Topics = append(req.Topics, rt)
+	}
+	return req
+}
+
+// We evict cached topics only from a request that says something about what
+// we want cached. A broker only request asks for no topics, and internal
+// targeted fetches (topic IDs, unknown produce topics, the group's topics)
+// ask only about their own, so neither can drop what else we have.
+func TestStoreCachedMetaEviction(t *testing.T) {
+	t.Parallel()
+
+	foo := func() *kmsg.MetadataResponse {
+		resp := kmsg.NewPtrMetadataResponse()
+		rt := kmsg.NewMetadataResponseTopic()
+		rt.Topic = kmsg.StringPtr("foo")
+		resp.Topics = append(resp.Topics, rt)
+		return resp
+	}
+
+	for _, test := range []struct {
+		name  string
+		req   *kmsg.MetadataRequest
+		prune bool
+		exp   bool // whether foo survives
+	}{
+		{"broker only request", mkreq(), true, true},
+		{"targeted fetch of another topic", mkreq("bar"), false, true},
+		{"interested request for another topic", mkreq("bar"), true, false},
+	} {
+		cl := &Client{cfg: defaultCfg()}
+		cl.storeCachedMeta(mkreq("foo"), foo(), true, nil)
+
+		// Age the entry past metadataMinAge; a fresh entry is never
+		// pruned.
+		cl.metaCache.mu.Lock()
+		ct := cl.metaCache.topics["foo"]
+		ct.when = time.Now().Add(-time.Hour)
+		cl.metaCache.topics["foo"] = ct
+		cl.metaCache.mu.Unlock()
+
+		bar := kmsg.NewPtrMetadataResponse()
+		if len(test.req.Topics) > 0 {
+			rt := kmsg.NewMetadataResponseTopic()
+			rt.Topic = kmsg.StringPtr("bar")
+			bar.Topics = append(bar.Topics, rt)
+		}
+		cl.storeCachedMeta(test.req, bar, test.prune, nil)
+
+		cl.metaCache.mu.Lock()
+		_, got := cl.metaCache.topics["foo"]
+		cl.metaCache.mu.Unlock()
+		if got != test.exp {
+			t.Errorf("%s: foo cached = %v, expected %v", test.name, got, test.exp)
+		}
 	}
 }

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -437,7 +437,7 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 			metaTopics = append(metaTopics, topic)
 		}
 
-		_, resp, err := g.cl.fetchMetadataByName(g.ctx, false, metaTopics, nil)
+		_, resp, err := g.cl.fetchMetadataByName(g.ctx, false, metaTopics, false, nil) // prune: no; the group's topics are not all we cache
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch metadata for group topics: %v", err)
 		}

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -430,8 +430,17 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 		})
 	}
 
+	// KIP-881: we build rack info below from the metadata cache, which
+	// can evict a topic when it stores a response that is missing it.
+	rackMeta := !needMeta && g.needRackMeta(memberBalancer, topics)
+	needMeta = needMeta || rackMeta
+
 	if needMeta {
-		g.cl.cfg.logger.Log(LogLevelInfo, "group members indicated interest in topics the leader is not assigned, fetching metadata for all group topics")
+		why := "group members indicated interest in topics the leader is not assigned"
+		if rackMeta {
+			why = "our metadata cache no longer has all group topics and we balance by rack"
+		}
+		g.cl.cfg.logger.Log(LogLevelInfo, "fetching metadata for all group topics", "why", why)
 		var metaTopics []string
 		for topic := range topics {
 			metaTopics = append(metaTopics, topic)
@@ -459,7 +468,7 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 
 	// KIP-881: build partition rack info for rack-aware assignment.
 	// We use cached broker racks and partition leaders from local
-	// metadata. This requires no extra fetches.
+	// metadata, which we refreshed above if we had to.
 	if cb, ok := memberBalancer.(*ConsumerBalancer); ok {
 		cb.partitionRacks = g.buildPartitionRacks(cb, topicPartitionCount)
 	}
@@ -534,20 +543,47 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 	return into.IntoSyncAssignment(), nil
 }
 
+// anyMemberRack returns whether any member reported a rack.
+func (b *ConsumerBalancer) anyMemberRack() bool {
+	for i := range b.metadatas {
+		if b.metadatas[i].Rack != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// needRackMeta returns whether we need to load metadata before we can rack
+// balance topics that other group members consume. We always have racks for
+// the topics we consume ourselves; for the rest, we load metadata through
+// groupExternal, which populates the metadata cache. Our own metadata
+// updates keep those topics cached, since we ask for them, but a user's
+// metadata request for other topics evicts them (see storeCachedMeta).
+func (g *groupConsumer) needRackMeta(memberBalancer GroupMemberBalancer, topics map[string]struct{}) bool {
+	cb, ok := memberBalancer.(*ConsumerBalancer)
+	if !ok || !cb.anyMemberRack() {
+		return false
+	}
+	myTopics := g.tps.load()
+	g.cl.metaCache.mu.Lock()
+	defer g.cl.metaCache.mu.Unlock()
+	for topic := range topics {
+		if _, ok := myTopics[topic]; ok {
+			continue
+		}
+		if _, ok := g.cl.metaCache.topics[topic]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
 // buildPartitionRacks builds a topic => partition => rack map for rack-aware
 // assignment (KIP-881). It uses cached broker racks and partition leaders from
 // the metadata cache, falling back to our own topics. Returns nil if no rack
 // info is available.
 func (g *groupConsumer) buildPartitionRacks(b *ConsumerBalancer, topicPartitionCount map[string]int32) map[string][]string {
-	// Check if any member has a rack.
-	var hasRack bool
-	for i := range b.metadatas {
-		if b.metadatas[i].Rack != nil {
-			hasRack = true
-			break
-		}
-	}
-	if !hasRack {
+	if !b.anyMemberRack() {
 		return nil
 	}
 

--- a/pkg/kgo/group_balancer.go
+++ b/pkg/kgo/group_balancer.go
@@ -535,8 +535,9 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 }
 
 // buildPartitionRacks builds a topic => partition => rack map for rack-aware
-// assignment (KIP-881). It uses cached broker racks and partition leader info
-// from local metadata. Returns nil if no rack info is available.
+// assignment (KIP-881). It uses cached broker racks and partition leaders from
+// the metadata cache, falling back to our own topics. Returns nil if no rack
+// info is available.
 func (g *groupConsumer) buildPartitionRacks(b *ConsumerBalancer, topicPartitionCount map[string]int32) map[string][]string {
 	// Check if any member has a rack.
 	var hasRack bool
@@ -556,13 +557,35 @@ func (g *groupConsumer) buildPartitionRacks(b *ConsumerBalancer, topicPartitionC
 		return nil
 	}
 
-	// Build partition racks from local topic metadata. Each
-	// partition's rack is determined by its leader broker's rack.
+	// Each partition's rack is its leader broker's rack. We prefer the
+	// metadata cache: it has every topic the group is interested in,
+	// including topics we do not consume and so never have in tps. The
+	// cache prunes entries whenever a request that does not cover them
+	// stores its response, so for our own topics we fall back to tps.
+	cached := make(map[string]cachedMetaTopic, len(topicPartitionCount))
+	g.cl.metaCache.mu.Lock()
+	for topic := range topicPartitionCount {
+		if ct, ok := g.cl.metaCache.topics[topic]; ok {
+			cached[topic] = ct
+		}
+	}
+	g.cl.metaCache.mu.Unlock()
+
 	partitionRacks := make(map[string][]string, len(topicPartitionCount))
 	myTopics := g.tps.load()
 	for topic, numPartitions := range topicPartitionCount {
 		racks := make([]string, numPartitions)
-		if data, ok := myTopics[topic]; ok {
+		if ps := cached[topic].t.Partitions; len(ps) > 0 {
+			// The cache keeps the broker's partition order.
+			for _, p := range ps {
+				if p.Partition < 0 || p.Partition >= numPartitions {
+					continue
+				}
+				if rack, ok := brokerRacks[p.Leader]; ok {
+					racks[p.Partition] = rack
+				}
+			}
+		} else if data, ok := myTopics[topic]; ok {
 			tpd := data.load()
 			for i, p := range tpd.partitions {
 				if p == nil || int32(i) >= numPartitions {

--- a/pkg/kgo/group_balancer_test.go
+++ b/pkg/kgo/group_balancer_test.go
@@ -460,3 +460,56 @@ func TestNewConsumerBalancerDuplicateMemberIDs(t *testing.T) {
 		t.Errorf("expected 2 partitions assigned, got %d (plan %v)", total, plan)
 	}
 }
+
+// TestBuildPartitionRacks checks that partition racks come from the metadata
+// cache, which has every topic the group is interested in, including topics
+// we do not ourselves consume, and that our own topics still get racks when
+// the cache has been pruned.
+func TestBuildPartitionRacks(t *testing.T) {
+	t.Parallel()
+
+	rackA := "rackA"
+	cl := new(Client)
+	cl.brokers = []*broker{
+		{meta: BrokerMetadata{NodeID: 1, Rack: &rackA}},
+		{meta: BrokerMetadata{NodeID: 2}},
+	}
+	cl.metaCache.topics = map[string]cachedMetaTopic{
+		"t1": {t: kmsg.MetadataResponseTopic{Partitions: []kmsg.MetadataResponseTopicPartition{
+			{Partition: 0, Leader: 1},
+		}}},
+		// A topic another member is interested in: the cache keeps the
+		// broker's response order, and can know of more partitions than
+		// the group is balancing.
+		"t2": {t: kmsg.MetadataResponseTopic{Partitions: []kmsg.MetadataResponseTopicPartition{
+			{Partition: 1, Leader: 1},
+			{Partition: 0, Leader: 2},
+			{Partition: 2, Leader: 1},
+		}}},
+	}
+
+	// t4 is ours and has been pruned from the cache.
+	tps := newTopicsPartitions()
+	tps.storeTopics([]string{"t4"})
+	tps.load()["t4"].v.Store(&topicPartitionsData{partitions: []*topicPartition{
+		{topicPartitionData: topicPartitionData{leader: 1}},
+	}})
+
+	g := &groupConsumer{cl: cl, tps: tps}
+	b := &ConsumerBalancer{
+		metadatas: []kmsg.ConsumerMemberMetadata{{Topics: []string{"t1"}, Rack: &rackA}},
+	}
+
+	// Broker 2 has no rack, and t3 is in neither the cache nor tps: both
+	// are rackless rather than missing.
+	got := g.buildPartitionRacks(b, map[string]int32{"t1": 1, "t2": 2, "t3": 1, "t4": 1})
+	exp := map[string][]string{
+		"t1": {"rackA"},
+		"t2": {"", "rackA"},
+		"t3": {""},
+		"t4": {"rackA"},
+	}
+	if !reflect.DeepEqual(got, exp) {
+		t.Errorf("got racks != exp\ngot: %#v\nexp: %#v\n", got, exp)
+	}
+}

--- a/pkg/kgo/group_balancer_test.go
+++ b/pkg/kgo/group_balancer_test.go
@@ -513,3 +513,40 @@ func TestBuildPartitionRacks(t *testing.T) {
 		t.Errorf("got racks != exp\ngot: %#v\nexp: %#v\n", got, exp)
 	}
 }
+
+func TestNeedRackMeta(t *testing.T) {
+	t.Parallel()
+
+	rack := "rack"
+	// t1 is ours, t2 is a topic only another member consumes.
+	topics := map[string]struct{}{"t1": {}, "t2": {}}
+	rackB := &ConsumerBalancer{metadatas: []kmsg.ConsumerMemberMetadata{{Topics: []string{"t1"}, Rack: &rack}}}
+	norackB := &ConsumerBalancer{metadatas: []kmsg.ConsumerMemberMetadata{{Topics: []string{"t1"}}}}
+
+	newG := func(cached ...string) *groupConsumer {
+		cl := new(Client)
+		cl.metaCache.topics = make(map[string]cachedMetaTopic)
+		for _, topic := range cached {
+			cl.metaCache.topics[topic] = cachedMetaTopic{}
+		}
+		tps := newTopicsPartitions()
+		tps.storeTopics([]string{"t1"})
+		return &groupConsumer{cl: cl, cfg: &cl.cfg, tps: tps}
+	}
+
+	for _, test := range []struct {
+		name string
+		g    *groupConsumer
+		b    GroupMemberBalancer
+		exp  bool
+	}{
+		{"cache is missing a topic that is not ours", newG("t1"), rackB, true},
+		{"cache has every topic", newG("t1", "t2"), rackB, false},
+		{"cache is missing only our own topic", newG("t2"), rackB, false},
+		{"no member has a rack", newG("t1"), norackB, false},
+	} {
+		if got := test.g.needRackMeta(test.b, topics); got != test.exp {
+			t.Errorf("%s: got %v, expected %v", test.name, got, test.exp)
+		}
+	}
+}

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -369,7 +369,7 @@ func (cl *Client) updateMetadata() (retryWhy multiUpdateWhy, err error) {
 				unknownTopics = append(unknownTopics, unknown)
 			}
 			var err error
-			unknownCreateResp, err = cl.fetchTopicMetadata(false, unknownTopics)
+			unknownCreateResp, err = cl.fetchTopicMetadata(false, unknownTopics, false) // prune: no; unknown produce topics only, the fetch below covers the rest
 			if err != nil {
 				// We bump all produce topics even though we
 				// only explicitly requested unknown ones; this
@@ -384,7 +384,7 @@ func (cl *Client) updateMetadata() (retryWhy multiUpdateWhy, err error) {
 		cl.producer.unknownTopicsMu.Unlock()
 	}
 
-	latest, err := cl.fetchTopicMetadata(all, reqTopics)
+	latest, err := cl.fetchTopicMetadata(all, reqTopics, true) // prune: yes; everything we track, so anything else is unwanted
 	if err != nil {
 		cl.bumpMetadataFailForTopics( // bump load failures for all topics
 			tpsProducerLoad,
@@ -663,8 +663,8 @@ func (mp metadataPartition) newPartition(cl *Client, kind partitionKind) *topicP
 
 // fetchTopicMetadata fetches metadata for all reqTopics and returns new
 // topicPartitionsData for each topic.
-func (cl *Client) fetchTopicMetadata(all bool, reqTopics []string) (map[string]*metadataTopic, error) {
-	_, meta, err := cl.fetchMetadataByName(cl.ctx, all, reqTopics, nil)
+func (cl *Client) fetchTopicMetadata(all bool, reqTopics []string, prune bool) (map[string]*metadataTopic, error) {
+	_, meta, err := cl.fetchMetadataByName(cl.ctx, all, reqTopics, prune, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two things, the second noticed while writing the first.

**Rack aware assignment skipped the topics the leader does not consume.** `buildPartitionRacks` looked each topic up in `tps`, which only holds the topics this client consumes. A group can be interested in topics its leader does not, and those came back with no rack at all, so range, sticky, and cooperative sticky matched nothing for them: the leader assigned them without regard to rack, silently. Partition leaders now come from the metadata cache, which the metadata loop keeps for the group's whole topic set, with `tps` as the fallback for our own. A topic in neither still yields empty racks, so today's behavior is the floor.

Balancing also refetches when the cache cannot answer rack placement, but only when a member reported a rack and only for topics we do not consume ourselves. A group with no racks never pays, and neither does one whose topics are all cached.

**The metadata cache was evicting topics for requests that say nothing about topics.** `storeCachedMeta` evicts every cached topic older than `MetadataMinAge` that the response it stores does not contain. Loading brokers asks for *no* topics, so it dropped everything; resolving topic IDs, creating unknown produce topics, and loading a group's topics to balance each ask only about their own. We load brokers whenever we want a broker we do not know, whenever we want the controller and do not know it, and on every request that fans out to all brokers, so a client that also does admin work was throwing its topic cache away regularly.

Eviction now happens only for requests that say something about what we want cached: the metadata loop, a user's own metadata request, and `RequestCachedMetadata`. The loop still bounds the cache, since it asks only for the topics we produce to, consume, or balance.

No API change. #1379 stacks on this and gates rack aware balancing behind `BalanceRacks`.
