### PR TITLE
kgo: only log regex-consumed topics as added if not excluded

### DIFF
--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1376,9 +1376,10 @@ func (c *consumer) filterMetadataAllTopics(topics []string) []string {
 	for _, topic := range topics {
 		want, seen := reSeen[topic]
 		if !seen {
+			var matchedRe string
 			for rawRe, re := range c.cl.cfg.topics {
 				if want = re.MatchString(topic); want {
-					rns.add(rawRe, topic)
+					matchedRe = rawRe
 					break
 				}
 			}
@@ -1390,7 +1391,12 @@ func (c *consumer) filterMetadataAllTopics(topics []string) []string {
 					}
 				}
 			}
-			if !want {
+			// A topic is only added once it also passes the exclude
+			// regexes; logging it as added on the include match alone
+			// would report an excluded topic as both added and skipped.
+			if want {
+				rns.add(matchedRe, topic)
+			} else {
 				rns.skip(topic)
 			}
 			reSeen[topic] = want


### PR DESCRIPTION
filterMetadataAllTopics logged a topic as "added" as soon as an include
regex matched, before the exclude regexes were evaluated. An excluded
topic therefore appeared in both the "added" and "evaluated_and_skipped"
fields of the "consumer regular expressions evaluated on new topics"
log line, implying it would be consumed even though it never is.

Log the topic as added only after it also passes the exclude regexes.