### PR TITLE
kgo: never regex-match internal topics; align 848 regex with the broker

### DIFF
--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -2120,7 +2120,7 @@ func (g *group) consumerJoin(creq *clientReq, req *kmsg.ConsumerGroupHeartbeatRe
 		slices.Sort(m.subscribedTopics)
 	}
 	if req.SubscribedTopicRegex != nil {
-		re, err := regexp.Compile(*req.SubscribedTopicRegex)
+		re, err := compileSubscribedTopicRegex(*req.SubscribedTopicRegex)
 		if err != nil {
 			resp.ErrorCode = kerr.InvalidRequest.Code
 			return resp
@@ -2194,7 +2194,7 @@ func (g *group) updateMemberSubscriptions(m *consumerMember, req *kmsg.ConsumerG
 		}
 	}
 	if req.SubscribedTopicRegex != nil && *req.SubscribedTopicRegex != m.subscribedRegexSource {
-		re, err := regexp.Compile(*req.SubscribedTopicRegex)
+		re, err := compileSubscribedTopicRegex(*req.SubscribedTopicRegex)
 		if err != nil {
 			return false, kerr.InvalidRequest.Code
 		}
@@ -3730,4 +3730,10 @@ func (g *group) atConsumerSessionTimeoutIn(m *consumerMember, d time.Duration) {
 			g.evictConsumerMember(m)
 		}
 	})
+}
+
+// compileSubscribedTopicRegex compiles a KIP-848 subscription regex. Kafka
+// matches the regex against the entire topic name, so we anchor it.
+func compileSubscribedTopicRegex(pattern string) (*regexp.Regexp, error) {
+	return regexp.Compile("^(?:" + pattern + ")$")
 }

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1725,6 +1725,16 @@ func ConsumePartitions(partitions map[string]map[int32]Offset) ConsumerOpt {
 // regular expressions. You can further use ConsumeExcludeTopics to exclude
 // topics that would match any ConsumeTopics regex.
 //
+// A regular expression matches anywhere in a topic name, the same as Go's
+// MatchString: "foo" matches "foo", "foobar", and "barfoo". Anchor with ^ and
+// $ to match an entire name. A regex client never consumes internal topics
+// such as __consumer_offsets; consume those from a client without
+// ConsumeRegex. The one exception to this is the next-gen consumer group
+// protocol, where if you don't use ConsumeExcludeTopics, the broker resolves
+// the regex and may include internal topics. ConsumeExcludeTopics forces
+// client-side regex evaluation because the next-gen protocol does not yet
+// support exclude regexes.
+//
 // When consuming via regex, every metadata request loads *all* topics, so that
 // all topics can be passed to any regular expressions. Every topic is
 // evaluated only once ever across all regular expressions; either it

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"slices"
 	"sort"
@@ -1355,13 +1356,18 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 }
 
 // filterMetadataAllTopics, called BEFORE doOnMetadataUpdate, evaluates
-// all topics received against the user provided regex.
-func (c *consumer) filterMetadataAllTopics(topics []string) []string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+// all topics received against the user provided regex and returns the
+// topics we will consume.
+//
+// We never match internal topics. The broker can still assign one to us
+// when it resolves the regex itself (KIP-848 with no excludes); see
+// adoptAssignedTopic.
+func (c *consumer) filterMetadataAllTopics(latest map[string]*metadataTopic) []string {
 	var rns reNews
 	defer rns.log(&c.cl.cfg)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	var reSeen map[string]bool
 	if c.g != nil {
@@ -1372,32 +1378,47 @@ func (c *consumer) filterMetadataAllTopics(topics []string) []string {
 		reSeen = c.d.reSeen
 	}
 
-	keep := topics[:0]
-	for _, topic := range topics {
+	// We evaluate regexes in sorted order so that the log is deterministic
+	// when a topic matches multiple regexes.
+	var includes []string
+	keep := make([]string, 0, len(latest))
+	for topic, mt := range latest {
+		// loadErr should only be non-nil when requesting all topics
+		// if this is with auto-topic-creation && the creation failed.
+		// That is, we should not consume the topic since we just
+		// tried creating it and creating it failed.
+		if mt.loadErr != nil {
+			continue
+		}
 		want, seen := reSeen[topic]
 		if !seen {
+			if includes == nil {
+				includes = slices.Sorted(maps.Keys(c.cl.cfg.topics))
+			}
 			var matchedRe string
-			for rawRe, re := range c.cl.cfg.topics {
-				if want = re.MatchString(topic); want {
+			for _, rawRe := range includes {
+				if want = c.cl.cfg.topics[rawRe].MatchString(topic); want {
 					matchedRe = rawRe
 					break
 				}
 			}
-			if want {
-				for _, re := range c.cl.cfg.excludeTopics {
+			switch {
+			case !want:
+				rns.skip(topic)
+			case mt.isInternal:
+				want = false
+				rns.skipInternal(topic)
+			default:
+				for rawEx, re := range c.cl.cfg.excludeTopics {
 					if re.MatchString(topic) {
 						want = false
+						rns.exclude(rawEx, topic)
 						break
 					}
 				}
-			}
-			// A topic is only added once it also passes the exclude
-			// regexes; logging it as added on the include match alone
-			// would report an excluded topic as both added and skipped.
-			if want {
-				rns.add(matchedRe, topic)
-			} else {
-				rns.skip(topic)
+				if want {
+					rns.add(matchedRe, topic)
+				}
 			}
 			reSeen[topic] = want
 		}

--- a/pkg/kgo/consumer_direct.go
+++ b/pkg/kgo/consumer_direct.go
@@ -76,14 +76,11 @@ func (d *directConsumer) findNewAssignments() map[string]map[int32]Offset {
 
 		// If the above detected that we want to keep this topic, we
 		// set all partitions as usable.
-		//
-		// For internal partitions, we only allow consuming them if
-		// the topic is explicitly specified.
 		if !useTopic {
 			continue
 		}
 		partitions := topicPartitions.load()
-		if d.cfg.regex && partitions.isInternal || len(partitions.partitions) == 0 {
+		if len(partitions.partitions) == 0 {
 			continue
 		}
 		toUseTopic := make(map[int32]Offset, len(partitions.partitions))

--- a/pkg/kgo/consumer_group.go
+++ b/pkg/kgo/consumer_group.go
@@ -2412,9 +2412,6 @@ func (g *groupConsumer) findNewAssignments() {
 		// want to load the metadata", but the topic was not returned
 		// in the metadata (or it was returned with an error).
 		if useTopic && numPartitions > 0 {
-			if g.cfg.regex && parts.isInternal {
-				continue
-			}
 			toChange[topic] = change{isNew: true, delta: numPartitions}
 			numNewTopics++
 		}
@@ -3827,8 +3824,10 @@ func commitHasFatalMemberError(resp *kmsg.OffsetCommitResponse) error {
 }
 
 type reNews struct {
-	added   map[string][]string
-	skipped []string
+	added    map[string][]string
+	excluded map[string][]string
+	internal []string
+	skipped  []string
 }
 
 func (r *reNews) add(re, match string) {
@@ -3838,20 +3837,43 @@ func (r *reNews) add(re, match string) {
 	r.added[re] = append(r.added[re], match)
 }
 
+func (r *reNews) exclude(re, match string) {
+	if r.excluded == nil {
+		r.excluded = make(map[string][]string)
+	}
+	r.excluded[re] = append(r.excluded[re], match)
+}
+
+func (r *reNews) skipInternal(topic string) {
+	r.internal = append(r.internal, topic)
+}
+
 func (r *reNews) skip(topic string) {
 	r.skipped = append(r.skipped, topic)
 }
 
 func (r *reNews) log(cfg *cfg) {
-	if len(r.added) == 0 && len(r.skipped) == 0 {
+	if cfg.logger.Level() < LogLevelInfo {
 		return
 	}
-	var addeds []string
-	for re, matches := range r.added {
-		sort.Strings(matches)
-		addeds = append(addeds, fmt.Sprintf("%s[%s]", re, strings.Join(matches, " ")))
+	if len(r.added) == 0 && len(r.excluded) == 0 && len(r.internal) == 0 && len(r.skipped) == 0 {
+		return
 	}
-	added := strings.Join(addeds, " ")
+	fmtMatches := func(m map[string][]string) string {
+		var all []string
+		for re, matches := range m {
+			sort.Strings(matches)
+			all = append(all, fmt.Sprintf("%s[%s]", re, strings.Join(matches, " ")))
+		}
+		sort.Strings(all)
+		return strings.Join(all, " ")
+	}
+	sort.Strings(r.internal)
 	sort.Strings(r.skipped)
-	cfg.logger.Log(LogLevelInfo, "consumer regular expressions evaluated on new topics", "added", added, "evaluated_and_skipped", r.skipped)
+	cfg.logger.Log(LogLevelInfo, "consumer regular expressions evaluated on new topics",
+		"added", fmtMatches(r.added),
+		"excluded", fmtMatches(r.excluded),
+		"skipped_internal", r.internal,
+		"evaluated_and_skipped", r.skipped,
+	)
 }

--- a/pkg/kgo/consumer_group_848.go
+++ b/pkg/kgo/consumer_group_848.go
@@ -18,6 +18,18 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
+// adoptAssignedTopic adds a topic the broker assigned us that our regex
+// filter skipped, so that the next metadata update loads it and we can
+// fetch from it.
+func (g *groupConsumer) adoptAssignedTopic(topic string) {
+	g.cfg.logger.Log(LogLevelInfo, "adopting a topic the broker assigned that our regex filter skipped", "group", g.cfg.group, "topic", topic)
+	g.c.mu.Lock()
+	defer g.c.mu.Unlock()
+	g.reSeen[topic] = true
+	g.tps.storeTopics([]string{topic})
+	g.cl.triggerUpdateMetadataNow("consumer group heartbeat assigned a topic we have not loaded")
+}
+
 func (g *groupConsumer) should848() bool {
 	if wantBeta := g.cl.ctx.Value("opt_in_kafka_next_gen_balancer_beta"); wantBeta == nil { // !!! TODO REMOVE ONCE BROKER IMPROVES
 		return false
@@ -578,7 +590,30 @@ func (g *g848) handleResp(req *kmsg.ConsumerGroupHeartbeatRequest, resp *kmsg.Co
 	}
 
 	id2t := g.g.cl.id2tMap()
+	tps := g.g.tps.load()
 	newAssigned := make(map[string][]int32)
+
+	// resolve maps an assigned topic ID to a name we can fetch from,
+	// returning empty if we cannot yet. When the broker resolves our
+	// regex (no excludes), it can assign a topic that is not in tps: we
+	// never match internal topics, but the broker does. We adopt such a
+	// topic and wait for metadata to load it before assigning it.
+	resolve := func(id [16]byte) string {
+		name := id2t[id]
+		if name == "" || !g.g.cl.cfg.regex {
+			return name
+		}
+		tp, ok := tps[name]
+		if !ok {
+			g.g.adoptAssignedTopic(name)
+			tps = g.g.tps.load() // so we adopt once per response
+			return ""
+		}
+		if len(tp.load().partitions) == 0 {
+			return ""
+		}
+		return name
+	}
 
 	// Only update the last-sent fields when Topics was actually
 	// included in the request. When the request was a keepalive
@@ -601,7 +636,7 @@ func (g *g848) handleResp(req *kmsg.ConsumerGroupHeartbeatRequest, resp *kmsg.Co
 		g.unresolvedAssigned = nil
 		for _, t := range resp.Assignment.Topics {
 			ps := sanitizePartitions(t.Partitions)
-			name := id2t[t.TopicID]
+			name := resolve(t.TopicID)
 			if name == "" {
 				if g.unresolvedAssigned == nil {
 					g.unresolvedAssigned = make(map[topicID][]int32)
@@ -619,7 +654,7 @@ func (g *g848) handleResp(req *kmsg.ConsumerGroupHeartbeatRequest, resp *kmsg.Co
 	// resolve immediately - waiting for the next heartbeat is
 	// simpler and only costs one heartbeat interval (~5s).
 	for id, ps := range g.unresolvedAssigned {
-		if name := id2t[[16]byte(id)]; name != "" {
+		if name := resolve([16]byte(id)); name != "" {
 			newAssigned[name] = ps
 			delete(g.unresolvedAssigned, id)
 		}
@@ -712,39 +747,28 @@ func (g *g848) mkreq() *kmsg.ConsumerGroupHeartbeatRequest {
 	req.ServerAssignor = &g.serverAssignor
 
 	tps := g.g.tps.load()
-	if g.g.cl.cfg.regex && len(g.g.cl.cfg.excludeTopics) > 0 {
-		// KIP-848's SubscribedTopicRegex is include-only with no exclude
-		// counterpart. When excludes are configured, fall back to sending
-		// the already-resolved topic names from g.tps (which
-		// filterMetadataAllTopics populates with excludes applied).
-		// New topics are picked up on the next metadata refresh.
-		//
-		// Skip internal topics: classic regex consuming never uses them
-		// (findNewAssignments skips isInternal), and the broker honors
-		// explicit name subscriptions to internal topics, so emulating
-		// the regex with names would otherwise consume e.g.
-		// __consumer_offsets whenever the regex matches it.
-		subscribedTopics := make([]string, 0, len(tps))
-		for t, tp := range tps {
-			if tp.load().isInternal {
-				continue
-			}
-			subscribedTopics = append(subscribedTopics, t)
-		}
-		slices.Sort(subscribedTopics)
-		req.SubscribedTopicNames = subscribedTopics
-	} else if g.g.cl.cfg.regex {
+	if g.g.cl.cfg.regex && len(g.g.cl.cfg.excludeTopics) == 0 {
+		// The broker matches the regex against the entire topic name,
+		// while we match anywhere in the name (Go's MatchString). We
+		// wrap the regex in .* on both sides so that the broker
+		// resolves the same topics we would.
 		topics := g.g.cl.cfg.topics
 		patterns := make([]string, 0, len(topics))
 		for topic := range topics {
 			patterns = append(patterns, "(?:"+topic+")")
 		}
 		slices.Sort(patterns)
-		pattern := strings.Join(patterns, "|")
+		pattern := ".*(?:" + strings.Join(patterns, "|") + ").*"
 		req.SubscribedTopicRegex = &pattern
 	} else {
 		// SubscribedTopics must always exist when epoch == 0.
 		// We specifically 'make' the slice to ensure it is non-nil.
+		//
+		// KIP-848's SubscribedTopicRegex is include-only with no exclude
+		// counterpart. When excludes are configured, we send the
+		// already-resolved topic names from g.tps (which
+		// filterMetadataAllTopics populates with excludes applied).
+		// New topics are picked up on the next metadata refresh.
 		subscribedTopics := make([]string, 0, len(tps))
 		for t := range tps {
 			subscribedTopics = append(subscribedTopics, t)

--- a/pkg/kgo/consumer_test.go
+++ b/pkg/kgo/consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -89,6 +90,9 @@ func TestConsumeRegex(t *testing.T) {
 
 	pfx := randsha()[:16] + "-"
 
+	internal, _, internalCleanup := internalTopic(t, pfx+"internal")
+	defer internalCleanup()
+
 	// Create test topics
 	var cleanup []func()
 	for _, name := range []string{
@@ -106,11 +110,13 @@ func TestConsumeRegex(t *testing.T) {
 		}
 	}()
 
+	logs := newRingLogger(testLogger(), 4096)
 	cl, _ := newTestClient(
-		ConsumeTopics(pfx+".*"),                // Match all pfx-* topics
-		ConsumeExcludeTopics(pfx+"exclude-.*"), // Exclude pfx-exclude-* topics
+		ConsumeTopics(pfx+".*", regexp.QuoteMeta(internal)), // Match all pfx-* topics and the internal topic
+		ConsumeExcludeTopics(pfx+"exclude-.*"),              // Exclude pfx-exclude-* topics
 		ConsumeRegex(),
 		MetadataMinAge(100*time.Millisecond),
+		WithLogger(logs),
 	)
 	defer cl.Close()
 	var topics []string
@@ -127,6 +133,167 @@ func TestConsumeRegex(t *testing.T) {
 			t.Fatalf("expected to see %sinclude-*, got %v", pfx, topic)
 		}
 	}
+
+	// Every evaluated topic is logged under the decision we made for it.
+	wait(t, 15*time.Second, func() error {
+		added, excluded, skippedInternal := regexLogs(logs)
+		for _, want := range []string{pfx + "include-1", pfx + "include-2"} {
+			if !strings.Contains(added, want) {
+				return fmt.Errorf("added %q is missing %s", added, want)
+			}
+		}
+		if strings.Contains(added, pfx+"exclude-") {
+			return fmt.Errorf("added %q contains an excluded topic", added)
+		}
+		for _, want := range []string{pfx + "exclude-.*[", pfx + "exclude-1", pfx + "exclude-2"} {
+			if !strings.Contains(excluded, want) {
+				return fmt.Errorf("excluded %q is missing %s", excluded, want)
+			}
+		}
+		if !slices.Contains(skippedInternal, internal) {
+			return fmt.Errorf("skipped_internal %v is missing %s", skippedInternal, internal)
+		}
+		return nil
+	})
+}
+
+// regexLogs returns what the regex filter logged across all metadata updates.
+func regexLogs(r *ringLogger) (added, excluded string, skippedInternal []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range r.buf {
+		if e.msg != "consumer regular expressions evaluated on new topics" {
+			continue
+		}
+		for i := 0; i+1 < len(e.keyvals); i += 2 {
+			switch e.keyvals[i] {
+			case "added":
+				added += " " + e.keyvals[i+1].(string)
+			case "excluded":
+				excluded += " " + e.keyvals[i+1].(string)
+			case "skipped_internal":
+				skippedInternal = append(skippedInternal, e.keyvals[i+1].([]string)...)
+			}
+		}
+	}
+	return added, excluded, skippedInternal
+}
+
+// A share consumer subscribes by the names our regex filter resolved, so the
+// filter must skip internal topics for it as well.
+func TestConsumeRegexShareSkipsInternal(t *testing.T) {
+	t.Parallel()
+	adm() // ensure allowShare is initialized
+	if !allowShare {
+		t.Skip("broker does not support share groups (requires ShareFetch v2 and ShareAcknowledge v2, Kafka 4.2+)")
+	}
+
+	pfx := randsha()[:16] + "-"
+	internal, _, internalCleanup := internalTopic(t, pfx+"internal")
+	defer internalCleanup()
+	topic, topicCleanup := tmpNamedTopicPartitions(t, pfx+"regular", 1)
+	defer topicCleanup()
+	group, groupCleanup := tmpShareGroup(t)
+	defer groupCleanup()
+
+	cl, _ := newTestClient(
+		ConsumeTopics(pfx+".*", regexp.QuoteMeta(internal)),
+		ConsumeRegex(),
+		ShareGroup(group),
+		MetadataMinAge(100*time.Millisecond),
+	)
+	defer cl.Close()
+	wait(t, 15*time.Second, func() error {
+		cl.triggerUpdateMetadataNow("querying metadata for consumer initialization")
+		if topics := cl.GetConsumeTopics(); len(topics) != 1 || topics[0] != topic {
+			return fmt.Errorf("expected to consume only %s, got %v", topic, topics)
+		}
+		return nil
+	})
+}
+
+// When the broker resolves our regex (KIP-848 with no excludes), it matches
+// the entire topic name and it does not skip internal topics. We wrap the
+// regex so that the broker matches anywhere in the name like we do, and we
+// adopt an internal topic the broker assigns.
+func Test848RegexBrokerResolves(t *testing.T) {
+	t.Parallel()
+	adm() // ensure allow848 is initialized
+	if !allow848 {
+		t.Skip("broker does not support KIP-848 (requires ConsumerGroupHeartbeat v1, Kafka 4+)")
+	}
+
+	pfx := randsha()[:16] + "-"
+	internal, producible, internalCleanup := internalTopic(t, pfx+"internal")
+	defer internalCleanup()
+	regular := []string{pfx + "orders", pfx + "orders-v2"}
+	var cleanup []func()
+	for _, name := range regular {
+		_, c := tmpNamedTopicPartitions(t, name, 1)
+		cleanup = append(cleanup, c)
+	}
+	defer func() {
+		for _, c := range cleanup {
+			c()
+		}
+	}()
+	group, groupCleanup := tmpGroup(t)
+	defer groupCleanup()
+
+	want := regular
+	if producible {
+		want = append(want, internal)
+	}
+	producer, _ := newTestClient()
+	defer producer.Close()
+	for _, topic := range want {
+		if err := producer.ProduceSync(context.Background(), &Record{Topic: topic, Value: []byte("v")}).FirstErr(); err != nil {
+			t.Fatalf("produce to %s: %v", topic, err)
+		}
+	}
+
+	ctx848 := context.WithValue(context.Background(), "opt_in_kafka_next_gen_balancer_beta", true)
+	cl, _ := newTestClient(
+		WithContext(ctx848),
+		ConsumerGroup(group),
+		ConsumeRegex(),
+		// A bare name: matched by the broker alone, only pfx-orders
+		// would be consumed.
+		ConsumeTopics(pfx+"orders", regexp.QuoteMeta(internal)),
+		ConsumeResetOffset(NewOffset().AtStart()),
+		DisableAutoCommit(),
+		MetadataMinAge(100*time.Millisecond),
+		FetchMaxWait(250*time.Millisecond),
+	)
+	defer cl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	seen := make(map[string]bool)
+	for len(seen) < len(want) && ctx.Err() == nil {
+		fs := cl.PollFetches(ctx)
+		fs.EachTopic(func(ft FetchTopic) {
+			if len(ft.Records()) > 0 {
+				seen[ft.Topic] = true
+			}
+		})
+	}
+	for _, topic := range want {
+		if !seen[topic] {
+			t.Errorf("did not consume from %s", topic)
+		}
+	}
+
+	// The broker assigned the internal topic to us and we adopted it.
+	wait(t, 15*time.Second, func() error {
+		if _, ok := cl.consumer.g.nowAssigned.read()[internal]; !ok {
+			return fmt.Errorf("%s is not assigned", internal)
+		}
+		if !slices.Contains(cl.GetConsumeTopics(), internal) {
+			return fmt.Errorf("%s is not consumed", internal)
+		}
+		return nil
+	})
 }
 
 // Ensure we only consume one partition if we only ask for one partition.

--- a/pkg/kgo/helpers_test.go
+++ b/pkg/kgo/helpers_test.go
@@ -954,3 +954,78 @@ out:
 		}
 	}
 }
+
+// internalTopic returns an internal topic and whether we can produce to it.
+// kfake marks a topic internal through a topic config. A real broker either
+// rejects that config or ignores it, so we instead look up a group
+// coordinator, which creates __consumer_offsets.
+func internalTopic(tb testing.TB, name string) (string, bool, func()) {
+	tb.Helper()
+
+	deleteTopic := func(topic string) {
+		req := kmsg.NewPtrDeleteTopicsRequest()
+		req.TopicNames = []string{topic}
+		reqTopic := kmsg.NewDeleteTopicsRequestTopic()
+		reqTopic.Topic = kmsg.StringPtr(topic)
+		req.Topics = append(req.Topics, reqTopic)
+		req.RequestWith(context.Background(), adm())
+	}
+	isInternal := func(topic string) (bool, error) {
+		req := kmsg.NewPtrMetadataRequest()
+		reqTopic := kmsg.NewMetadataRequestTopic()
+		reqTopic.Topic = kmsg.StringPtr(topic)
+		req.Topics = append(req.Topics, reqTopic)
+		resp, err := req.RequestWith(context.Background(), adm())
+		if err != nil {
+			return false, err
+		}
+		for _, t := range resp.Topics {
+			if t.ErrorCode == 0 && t.Topic != nil && *t.Topic == topic {
+				return t.IsInternal, nil
+			}
+		}
+		return false, fmt.Errorf("topic %s is not in metadata", topic)
+	}
+
+	req := kmsg.NewPtrCreateTopicsRequest()
+	reqTopic := kmsg.NewCreateTopicsRequestTopic()
+	reqTopic.Topic = name
+	reqTopic.NumPartitions = 1
+	reqTopic.ReplicationFactor = int16(testrf)
+	cfg := kmsg.NewCreateTopicsRequestTopicConfig()
+	cfg.Name = "kfake.is_internal"
+	cfg.Value = kmsg.StringPtr("true")
+	reqTopic.Configs = append(reqTopic.Configs, cfg)
+	req.Topics = append(req.Topics, reqTopic)
+	resp, err := req.RequestWith(context.Background(), adm())
+	if err != nil {
+		tb.Fatalf("unable to create internal topic %q: %v", name, err)
+	}
+	if resp.Topics[0].ErrorCode == 0 {
+		internal, err := isInternal(name)
+		if err != nil {
+			tb.Fatalf("unable to describe %q: %v", name, err)
+		}
+		if internal {
+			return name, true, func() { deleteTopic(name) }
+		}
+		deleteTopic(name)
+	}
+
+	freq := kmsg.NewPtrFindCoordinatorRequest()
+	freq.CoordinatorKey = name
+	freq.CoordinatorKeys = []string{name}
+	freq.RequestWith(context.Background(), adm())
+	const offsets = "__consumer_offsets"
+	wait(tb, 30*time.Second, func() error {
+		internal, err := isInternal(offsets)
+		if err != nil {
+			return err
+		}
+		if !internal {
+			return errors.New(offsets + " is not internal")
+		}
+		return nil
+	})
+	return offsets, false, func() {}
+}

--- a/pkg/kgo/metadata.go
+++ b/pkg/kgo/metadata.go
@@ -450,24 +450,12 @@ func (cl *Client) updateMetadata() (retryWhy multiUpdateWhy, err error) {
 	// that we will store the topics at the end of our metadata update.
 	tpsConsumerLoad := tpsConsumer.load()
 	if all {
-		allTopics := make([]string, 0, len(latest))
-		for topic, mt := range latest {
-			// loadErr should only be non-nil when requesting all
-			// topics if this is with auto-topic-creation && the
-			// creation failed. That is, we should not consume the
-			// topic since we just tried creating it and creating
-			// it failed.
-			if mt.loadErr == nil {
-				allTopics = append(allTopics, topic)
-			}
-		}
-
 		// We filter out topics will not match any of our regex's.
 		// This ensures that the `tps` field does not contain topics
 		// we will never use (the client works with misc. topics in
 		// there, but it's better to avoid it -- and allows us to use
 		// `tps` in GetConsumeTopics).
-		allTopics = c.filterMetadataAllTopics(allTopics)
+		allTopics := c.filterMetadataAllTopics(latest)
 
 		tpsConsumerLoad = tpsConsumer.ensureTopics(allTopics)
 		defer tpsConsumer.storeData(tpsConsumerLoad)


### PR DESCRIPTION
Follow-up to #1409. Reviewing that change surfaced three pre-existing divergences in regex consuming, all in or around `filterMetadataAllTopics`.

## Internal topics

Classic and direct regex consumers have skipped internal topics since 2019, but the skip lived at the assignment points, not in the filter. So:

- a share consumer in regex mode sent internal topics by name in `SubscribedTopicNames` and consumed them;
- a classic consumer logged a matching internal topic as `added` and returned it from `GetConsumeTopics` while never assigning it.

The filter now skips internal topics itself, so every path that subscribes from `tps` agrees, and the three per-path checks are gone.

## KIP-848 regex

The broker resolves `SubscribedTopicRegex` against the entire topic name (re2j `matches()`), while kgo matches anywhere in the name (`MatchString`) on every other path. `ConsumeTopics("orders")` therefore consumed `orders` alone on 848 but `orders`, `orders-v2`, and `reorders` everywhere else, including 848 the moment any `ConsumeExcludeTopics` was set. We now wrap the regex sent to the broker in `.*` so it resolves the same names we would. Anchoring with `^` and `$` still gives an exact match.

The broker also does not skip internal topics when resolving a regex (only a DESCRIBE ACL filter applies). With the filter change above, a broker-assigned internal topic would be missing from `tps`. The heartbeat now adopts such a topic into `tps` and parks the assignment until metadata has loaded it, reusing the unresolved-ID mechanism. The same wait covers an assigned topic whose ID resolved via `id2t` before its partitions were stored.

Verified against Kafka 4.2.0 with an 848 consumer on `.*`:

```
[INFO] adopting a topic the broker assigned that our regex filter skipped; group: verify848-regex, topic: __consumer_offsets
[INFO] consumer group heartbeat detected an updated assignment; ... now_assigned: map[__consumer_offsets:[0 1 2 3 4] verify848-topic:[0]]
FETCHED topic=__consumer_offsets records=11
```

## Log

`consumer regular expressions evaluated on new topics` now carries `excluded` (keyed by the exclude regex that matched) and `skipped_internal` alongside `added` and `evaluated_and_skipped`, so an excluded topic is distinguishable from one that matched nothing. Include regexes are evaluated in sorted order so attribution is stable. The log runs after the consumer lock is released and is skipped below Info.

## kfake

kfake now anchors the 848 regex the way Kafka does, so the kgo tests exercise the wrap.

## Tests

- `TestConsumeRegex` asserts the log buckets and that an internal topic is neither added nor returned.
- `TestConsumeRegexShareSkipsInternal` covers the share path.
- `Test848RegexBrokerResolves` covers a bare-name include matching a longer topic name and adoption of a broker-assigned internal topic.

The internal-topic helper creates one on kfake through `kfake.is_internal` and, on a real broker, nudges a coordinator lookup so `__consumer_offsets` exists. All three pass 30x under `-race` against Kafka 4.2.0 and run unchanged on kfake.
