### PR TITLE
kfake: delete group commits when a topic is deleted

### DIFF
--- a/pkg/kfake/20_delete_topics.go
+++ b/pkg/kfake/20_delete_topics.go
@@ -163,6 +163,9 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 	}
 
 	if len(toDeletes) > 0 {
+		for _, td := range toDeletes {
+			c.dropGroupCommits(td.topic)
+		}
 		c.notifyTopicChange()
 		c.refreshCompactTicker()
 		c.persistTopicsState()

--- a/pkg/kfake/groups.go
+++ b/pkg/kfake/groups.go
@@ -196,6 +196,24 @@ func (c *Cluster) snapshotTopicMeta() topicMetaSnap {
 	return snap
 }
 
+// dropGroupCommits removes every group's committed offsets for a deleted
+// topic, as Kafka and Redpanda do. Each group mutates its commits on its own
+// manage goroutine; this runs after the topic is gone from c.data, so a
+// commit racing the delete on that goroutine is dropped too.
+func (c *Cluster) dropGroupCommits(topic string) {
+	for _, g := range c.groups.gs {
+		select {
+		case g.controlCh <- func() {
+			for part := range g.commits[topic] {
+				g.deleteCommitAndPersist(topic, part)
+			}
+		}:
+		case <-g.quitCh:
+		case <-g.c.die:
+		}
+	}
+}
+
 // notifyTopicChange recomputes target assignments for all consumer and
 // share groups after a topic is created, deleted, or has partitions
 // added. We capture a fresh metadata snapshot here (in the cluster run

--- a/pkg/kfake/issues_test.go
+++ b/pkg/kfake/issues_test.go
@@ -4464,3 +4464,68 @@ func TestEndTxnUnconfirmedCommitRetryRefused(t *testing.T) {
 		t.Fatalf("commit after heal: %v", err)
 	}
 }
+
+// Deleting a topic deletes every group's committed offsets for it, as Kafka
+// and Redpanda do, so a recreated topic starts with no committed offset.
+func TestDeleteTopicDropsGroupCommits(t *testing.T) {
+	t.Parallel()
+
+	const topic, group = "t", "g"
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	cl := newPlainClient(t, c)
+
+	commit := kmsg.NewPtrOffsetCommitRequest()
+	commit.Group = group
+	commit.Generation = -1
+	ct := kmsg.NewOffsetCommitRequestTopic()
+	ct.Topic, ct.TopicID = topic, c.TopicInfo(topic).TopicID
+	cp := kmsg.NewOffsetCommitRequestTopicPartition()
+	cp.Partition = 0
+	cp.Offset = 7
+	ct.Partitions = append(ct.Partitions, cp)
+	commit.Topics = append(commit.Topics, ct)
+	cresp := faultReq(t, cl, 0, commit).(*kmsg.OffsetCommitResponse)
+	if code := cresp.Topics[0].Partitions[0].ErrorCode; code != 0 {
+		t.Fatalf("commit answered %d", code)
+	}
+
+	fetched := func() int64 {
+		fetch := kmsg.NewPtrOffsetFetchRequest()
+		fg := kmsg.NewOffsetFetchRequestGroup()
+		fg.Group = group
+		fg.MemberEpoch = -1
+		ft := kmsg.NewOffsetFetchRequestGroupTopic()
+		ft.Topic, ft.TopicID = topic, c.TopicInfo(topic).TopicID
+		ft.Partitions = []int32{0}
+		fg.Topics = append(fg.Topics, ft)
+		fetch.Groups = append(fetch.Groups, fg)
+		fresp := faultReq(t, cl, 0, fetch).(*kmsg.OffsetFetchResponse)
+		return fresp.Groups[0].Topics[0].Partitions[0].Offset
+	}
+	if got := fetched(); got != 7 {
+		t.Fatalf("fetched %d before the delete, want 7", got)
+	}
+
+	del := kmsg.NewPtrDeleteTopicsRequest()
+	dt := kmsg.NewDeleteTopicsRequestTopic()
+	dt.Topic = kmsg.StringPtr(topic)
+	del.Topics = append(del.Topics, dt)
+	dresp := faultReq(t, cl, 0, del).(*kmsg.DeleteTopicsResponse)
+	if code := dresp.Topics[0].ErrorCode; code != 0 {
+		t.Fatalf("delete answered %d", code)
+	}
+	create := kmsg.NewPtrCreateTopicsRequest()
+	crt := kmsg.NewCreateTopicsRequestTopic()
+	crt.Topic = topic
+	crt.NumPartitions = 1
+	crt.ReplicationFactor = 1
+	create.Topics = append(create.Topics, crt)
+	crresp := faultReq(t, cl, 0, create).(*kmsg.CreateTopicsResponse)
+	if code := crresp.Topics[0].ErrorCode; code != 0 {
+		t.Fatalf("create answered %d", code)
+	}
+
+	if got := fetched(); got != -1 {
+		t.Fatalf("fetched %d after the recreate, want -1 (the commit should have been deleted with the topic)", got)
+	}
+}


### PR DESCRIPTION
Kafka's group coordinator deletes a group's committed offsets for a deleted topic's partitions (the classic coordinator since before 2.8, and the KRaft coordinator via offset tombstones), and Redpanda does the same. kfake kept them, so a recreated topic started with the old topic's committed offset and a member joining after the recreation was positioned by it. That difference is what the topic-recreation branch's commit fence and seed were built against; with kfake matching real brokers, that machinery goes.

DeleteTopics now drops every group's commits for the topic on each group's manage goroutine, before the topic-change notification. The test commits an offset, deletes and recreates the topic, and fetches: the commit is gone. It fails without the change (fetches 7).
