### PR TITLE
kgo: ignore KIP-951 leader hints that do not move us

### DIFF
--- a/pkg/kfake/sink_sweep_test.go
+++ b/pkg/kfake/sink_sweep_test.go
@@ -7,6 +7,8 @@ package kfake
 import (
 	"context"
 	"errors"
+	"net"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -358,5 +360,78 @@ func TestProduceTimedOutRetriesOnBackoff(t *testing.T) {
 	// The timed-out append still landed, so the retry deduplicates.
 	if hwm := c.PartitionInfo(topic, 0).HighWatermark; hwm != 1 {
 		t.Fatalf("high watermark %d; want 1", hwm)
+	}
+}
+
+// A broker can answer NOT_LEADER_OR_FOLLOWER with a KIP-951 CurrentLeader
+// that names the leader we are already producing to at the epoch we already
+// have. That hint moves nothing, and staging it as a move skipped both the
+// retry wait and the metadata update, so every retry went out at round trip
+// speed until the record budget was gone.
+func TestProduceStaleLeaderHintBacksOff(t *testing.T) {
+	t.Parallel()
+
+	const topic = "stale-hint"
+	const retries = 3
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+
+	var backoffs atomic.Int32
+	cl := newPlainClient(t, c,
+		kgo.RetryBackoffFn(func(int) time.Duration { backoffs.Add(1); return 10 * time.Millisecond }),
+		kgo.DisableIdempotentWrite(),
+		kgo.MaxProduceRequestsInflightPerBroker(1),
+		kgo.RecordRetries(retries),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("warmup")}).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hint back exactly the leader and epoch the client just produced to.
+	mreq := kmsg.NewPtrMetadataRequest()
+	mt := kmsg.NewMetadataRequestTopic()
+	mt.Topic = kmsg.StringPtr(topic)
+	mreq.Topics = append(mreq.Topics, mt)
+	mresp, err := mreq.RequestWith(ctx, cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leader := mresp.Topics[0].Partitions[0].Leader
+	epoch := mresp.Topics[0].Partitions[0].LeaderEpoch
+	host, portStr, _ := net.SplitHostPort(c.ListenAddrs()[0])
+	port, _ := strconv.Atoi(portStr)
+
+	var produces atomic.Int32
+	c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		produces.Add(1)
+		r := req.ResponseKind().(*kmsg.ProduceResponse)
+		rt := kmsg.NewProduceResponseTopic()
+		rt.Topic = topic
+		rt.TopicID = req.(*kmsg.ProduceRequest).Topics[0].TopicID
+		rp := kmsg.NewProduceResponseTopicPartition()
+		rp.ErrorCode = kerr.NotLeaderForPartition.Code
+		rp.CurrentLeader.LeaderID = leader
+		rp.CurrentLeader.LeaderEpoch = epoch
+		rt.Partitions = append(rt.Partitions, rp)
+		r.Topics = append(r.Topics, rt)
+		r.Brokers = []kmsg.ProduceResponseBroker{{NodeID: leader, Host: host, Port: int32(port)}}
+		return r, nil, true
+	})
+
+	err = cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("probe")}).FirstErr()
+	if !errors.Is(err, kerr.NotLeaderForPartition) {
+		t.Errorf("got err %v, want NOT_LEADER_OR_FOLLOWER", err)
+	}
+	if got := produces.Load(); got != retries+1 {
+		t.Errorf("got %d produce requests, want %d", got, retries+1)
+	}
+	// Every retry waits exactly once: the guard sends the stale hint down
+	// the backoff path, and drain checks that backoff after taking its
+	// inflight slot rather than before.
+	if got := backoffs.Load(); got != retries {
+		t.Errorf("got %d backoffs, want %d", got, retries)
 	}
 }

--- a/pkg/kfake/sink_sweep_test.go
+++ b/pkg/kfake/sink_sweep_test.go
@@ -365,22 +365,105 @@ func TestProduceTimedOutRetriesOnBackoff(t *testing.T) {
 
 // A broker can answer NOT_LEADER_OR_FOLLOWER with a KIP-951 CurrentLeader
 // that names the leader we are already producing to at the epoch we already
-// have. That hint moves nothing, and staging it as a move skipped both the
-// retry wait and the metadata update, so every retry went out at round trip
-// speed until the record budget was gone.
+// have, or at an older epoch. That hint moves nothing, and staging it as a
+// move skipped both the retry wait and the metadata update, so every retry
+// went out at round trip speed until the record budget was gone.
 func TestProduceStaleLeaderHintBacksOff(t *testing.T) {
 	t.Parallel()
+	for _, idempotent := range []bool{false, true} {
+		for _, test := range []struct {
+			name        string
+			epochDelta  int32 // hinted epoch, relative to the one the client has
+			leaderDelta int32 // hinted leader, relative to the real one
+			immediate   int32 // retries that go out at once because the hint moved us
+		}{
+			{name: "same_epoch"},
+			{name: "older_epoch", epochDelta: -1},
+			{name: "same_epoch_other_leader", leaderDelta: 1},
+			{name: "newer_epoch_then_repeated", epochDelta: 1, immediate: 1},
+		} {
+			t.Run(test.name+"/idempotent="+strconv.FormatBool(idempotent), func(t *testing.T) {
+				t.Parallel()
 
-	const topic = "stale-hint"
-	const retries = 3
-	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+				const topic = "stale-hint"
+				const retries = 3
+				c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+				// Start at epoch 1 so that an older hint is still a valid epoch.
+				if err := c.MoveTopicPartition(topic, 0, 0); err != nil {
+					t.Fatal(err)
+				}
 
+				var backoffs atomic.Int32
+				opts := []kgo.Opt{
+					// Any request answered with a retryable error waits on
+					// RetryBackoffFn; leave produce as the only one that can.
+					kgo.DisableClientMetrics(),
+					kgo.RetryBackoffFn(func(int) time.Duration { backoffs.Add(1); return 10 * time.Millisecond }),
+					kgo.RecordRetries(retries),
+				}
+				if !idempotent {
+					opts = append(opts, kgo.DisableIdempotentWrite(), kgo.MaxProduceRequestsInflightPerBroker(1))
+				}
+				cl := newPlainClient(t, c, opts...)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("warmup")}).FirstErr(); err != nil {
+					t.Fatal(err)
+				}
+				backoffs.Store(0)
+
+				pi := c.PartitionInfo(topic, 0)
+				host, portStr, _ := net.SplitHostPort(c.ListenAddrs()[0])
+				port, _ := strconv.Atoi(portStr)
+
+				var produces atomic.Int32
+				c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
+					c.KeepControl()
+					produces.Add(1)
+					r := req.ResponseKind().(*kmsg.ProduceResponse)
+					rt := kmsg.NewProduceResponseTopic()
+					rt.Topic = topic
+					rt.TopicID = req.(*kmsg.ProduceRequest).Topics[0].TopicID
+					rp := kmsg.NewProduceResponseTopicPartition()
+					rp.ErrorCode = kerr.NotLeaderForPartition.Code
+					rp.CurrentLeader.LeaderID = pi.Leader + test.leaderDelta
+					rp.CurrentLeader.LeaderEpoch = pi.Epoch + test.epochDelta
+					rt.Partitions = append(rt.Partitions, rp)
+					r.Topics = append(r.Topics, rt)
+					r.Brokers = []kmsg.ProduceResponseBroker{{NodeID: pi.Leader, Host: host, Port: int32(port)}}
+					return r, nil, true
+				})
+
+				err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("probe")}).FirstErr()
+				if !errors.Is(err, kerr.NotLeaderForPartition) {
+					t.Errorf("got err %v, want NOT_LEADER_OR_FOLLOWER", err)
+				}
+				if got := produces.Load(); got != retries+1 {
+					t.Errorf("got %d produce requests, want %d", got, retries+1)
+				}
+				// A hint that moves us retries at once; every other retry,
+				// including one for a same-epoch hint at another leader,
+				// waits exactly once. Exactly once also pins drain checking
+				// its backoff after taking an inflight slot, not before.
+				if want := int32(retries) - test.immediate; backoffs.Load() != want {
+					t.Errorf("got %d backoffs, want %d", backoffs.Load(), want)
+				}
+			})
+		}
+	}
+}
+
+// A hint that names a new leader still moves us and retries there at once.
+func TestProduceLeaderHintMovesWithoutBackoff(t *testing.T) {
+	t.Parallel()
+
+	const topic = "hint-move"
+	c := newCluster(t, NumBrokers(2), SeedTopics(1, topic))
 	var backoffs atomic.Int32
 	cl := newPlainClient(t, c,
-		kgo.RetryBackoffFn(func(int) time.Duration { backoffs.Add(1); return 10 * time.Millisecond }),
-		kgo.DisableIdempotentWrite(),
-		kgo.MaxProduceRequestsInflightPerBroker(1),
-		kgo.RecordRetries(retries),
+		kgo.DisableClientMetrics(),
+		kgo.RetryBackoffFn(func(int) time.Duration { backoffs.Add(1); return time.Second }),
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -388,50 +471,26 @@ func TestProduceStaleLeaderHintBacksOff(t *testing.T) {
 	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("warmup")}).FirstErr(); err != nil {
 		t.Fatal(err)
 	}
+	backoffs.Store(0)
 
-	// Hint back exactly the leader and epoch the client just produced to.
-	mreq := kmsg.NewPtrMetadataRequest()
-	mt := kmsg.NewMetadataRequestTopic()
-	mt.Topic = kmsg.StringPtr(topic)
-	mreq.Topics = append(mreq.Topics, mt)
-	mresp, err := mreq.RequestWith(ctx, cl)
-	if err != nil {
+	old := c.PartitionInfo(topic, 0)
+	if err := c.MoveTopicPartition(topic, 0, (old.Leader+1)%2); err != nil {
 		t.Fatal(err)
 	}
-	leader := mresp.Topics[0].Partitions[0].Leader
-	epoch := mresp.Topics[0].Partitions[0].LeaderEpoch
-	host, portStr, _ := net.SplitHostPort(c.ListenAddrs()[0])
-	port, _ := strconv.Atoi(portStr)
-
 	var produces atomic.Int32
-	c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
+	c.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
 		c.KeepControl()
 		produces.Add(1)
-		r := req.ResponseKind().(*kmsg.ProduceResponse)
-		rt := kmsg.NewProduceResponseTopic()
-		rt.Topic = topic
-		rt.TopicID = req.(*kmsg.ProduceRequest).Topics[0].TopicID
-		rp := kmsg.NewProduceResponseTopicPartition()
-		rp.ErrorCode = kerr.NotLeaderForPartition.Code
-		rp.CurrentLeader.LeaderID = leader
-		rp.CurrentLeader.LeaderEpoch = epoch
-		rt.Partitions = append(rt.Partitions, rp)
-		r.Topics = append(r.Topics, rt)
-		r.Brokers = []kmsg.ProduceResponseBroker{{NodeID: leader, Host: host, Port: int32(port)}}
-		return r, nil, true
+		return nil, nil, false
 	})
 
-	err = cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("probe")}).FirstErr()
-	if !errors.Is(err, kerr.NotLeaderForPartition) {
-		t.Errorf("got err %v, want NOT_LEADER_OR_FOLLOWER", err)
+	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("probe")}).FirstErr(); err != nil {
+		t.Fatal(err)
 	}
-	if got := produces.Load(); got != retries+1 {
-		t.Errorf("got %d produce requests, want %d", got, retries+1)
+	if got := produces.Load(); got != 2 {
+		t.Errorf("got %d produce requests, want the rejected attempt and its retry", got)
 	}
-	// Every retry waits exactly once: the guard sends the stale hint down
-	// the backoff path, and drain checks that backoff after taking its
-	// inflight slot rather than before.
-	if got := backoffs.Load(); got != retries {
-		t.Errorf("got %d backoffs, want %d", got, retries)
+	if got := backoffs.Load(); got != 0 {
+		t.Errorf("got %d backoffs, want 0", got)
 	}
 }

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -946,10 +946,10 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 
 	if len(req.batches.bs) > 0 {
 		s.cl.cfg.logger.Log(LogLevelError, "broker did not reply to all topics / partitions in the produce request! reenqueuing missing partitions", "broker", logID(s.nodeID))
-		s.handleRetryBatches(req.batches, nil, 0, true, false, "broker did not reply to all topics in produce request")
+		s.handleRetryBatches(req.batches, nil, req.backoffSeq, true, false, "broker did not reply to all topics in produce request")
 	}
 	if len(reqRetry.bs) > 0 {
-		s.handleRetryBatches(reqRetry, &kmove, 0, true, true, "produce request had retry batches")
+		s.handleRetryBatches(reqRetry, &kmove, req.backoffSeq, true, true, "produce request had retry batches")
 	}
 	if len(reqBackoff.bs) > 0 {
 		s.handleRetryBatches(reqBackoff, nil, req.backoffSeq, false, true, "produce request had timed out batches")

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -270,8 +270,6 @@ func (s *sink) clearBackoff() {
 func (s *sink) drain() {
 	again := true
 	for again {
-		s.maybeBackoff()
-
 		sem := s.inflightSem.Load().(chan struct{})
 		select {
 		case sem <- struct{}{}:
@@ -279,6 +277,13 @@ func (s *sink) drain() {
 			s.drainState.hardFinish()
 			return
 		}
+
+		// We back off after taking our inflight slot, not before. A
+		// response arrives, triggers a backoff, and only then frees the
+		// slot we are waiting on, so a backoff checked before the wait
+		// is always one request out of date. Only one goroutine is ever
+		// in this loop, so holding the slot while we wait costs nothing.
+		s.maybeBackoff()
 
 		again = s.drainState.maybeFinish(s.produce(sem))
 	}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -1352,6 +1352,14 @@ func (s *sink) handleRetryBatches(
 			return
 		}
 
+		// The broker hinted a leader we are already using. We retry on
+		// the same sink, but we wait first: without this we resend as
+		// fast as the broker can reject us.
+		if kmove.hasStaleRecBuf(batch.owner) {
+			shouldBackoff = true
+			return
+		}
+
 		// If our first batch (seq == 0) fails with unknown topic, we
 		// retry immediately. Kafka can reply with valid metadata
 		// immediately after a topic was created, before the leaders

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -739,6 +739,7 @@ func (tp *topicPartition) migrateShareCursorTo(cl *Client, new *topicPartition) 
 type kip951move struct {
 	recBufs map[*recBuf]topicPartitionData
 	cursors map[*cursor]topicPartitionData
+	stale   map[*recBuf]struct{}
 	brokers []BrokerMetadata
 }
 
@@ -754,12 +755,35 @@ func (k *kip951move) hasRecBuf(rb *recBuf) bool {
 	return ok
 }
 
+// hasStaleRecBuf returns whether the broker sent a CurrentLeader hint for this
+// buffer that does not move us. We still want the normal retry wait, we just
+// do not want to block the retry on a metadata update that can only tell us
+// what we already know.
+func (k *kip951move) hasStaleRecBuf(rb *recBuf) bool {
+	if k == nil {
+		return false
+	}
+	_, ok := k.stale[rb]
+	return ok
+}
+
 func (k *kip951move) maybeAddProducePartition(resp *kmsg.ProduceResponse, p *kmsg.ProduceResponseTopicPartition, rb *recBuf) bool {
 	if resp.GetVersion() < 10 ||
 		p.ErrorCode != kerr.NotLeaderForPartition.Code ||
 		len(resp.Brokers) == 0 ||
 		p.CurrentLeader.LeaderID < 0 ||
 		p.CurrentLeader.LeaderEpoch < 0 {
+		return false
+	}
+	// Only a newer epoch moves us. An equal or older epoch, whatever leader
+	// it names, retries after the normal backoff; doMove says why. The
+	// endpoints in the response are as stale as the epoch, so we only
+	// record them for a hint we act on.
+	if p.CurrentLeader.LeaderEpoch <= rb.leaderEpoch {
+		if k.stale == nil {
+			k.stale = make(map[*recBuf]struct{})
+		}
+		k.stale[rb] = struct{}{}
 		return false
 	}
 	if len(k.brokers) == 0 {
@@ -792,6 +816,9 @@ func (k *kip951move) maybeAddFetchPartition(resp *kmsg.FetchResponse, p *kmsg.Fe
 		return false
 	}
 
+	if p.CurrentLeader.LeaderEpoch <= c.leaderEpoch { // as in maybeAddProducePartition
+		return false
+	}
 	if len(k.brokers) == 0 {
 		for _, rb := range resp.Brokers {
 			b := BrokerMetadata{
@@ -957,11 +984,16 @@ func (k *kip951move) doMove(cl *Client) {
 	// mutex. The actual migration is done in the migrate function (see
 	// below).
 	//
-	// A migration is not needed if the old value has a higher leader
-	// epoch.  If the leader epoch is equal, we check if the leader is the
-	// same (this allows easier injection of failures in local testing).  A
-	// higher epoch can come from a concurrent metadata update that
-	// actually performed the move first.
+	// A migration is only needed if the hint carries a newer leader
+	// epoch. An equal or older epoch can come from a concurrent metadata
+	// update that already performed the move, or from a broker whose
+	// answer is behind: the not_leader error and the CurrentLeader hint
+	// are two separate reads inside the broker and nothing keeps them
+	// consistent, so a broker can name the leader we already use. An equal
+	// epoch at a different leader is refused too: two brokers naming each
+	// other at one epoch would otherwise move us back and forth with no
+	// wait between attempts. The staging checks make the same comparison,
+	// as does the Java client.
 	//
 	// The hint was staged from a produce/fetch response and we are applied
 	// asynchronously: between staging and now, the user can purge the
@@ -983,10 +1015,7 @@ func (k *kip951move) doMove(cl *Client) {
 		if !owns(old) {
 			return nil, nil, false
 		}
-		if old.leaderEpoch > td.leaderEpoch {
-			return nil, nil, false
-		}
-		if old.leaderEpoch == td.leaderEpoch && old.leader == td.leader {
+		if old.leaderEpoch >= td.leaderEpoch {
 			return nil, nil, false
 		}
 


### PR DESCRIPTION
A broker can answer NOT_LEADER_OR_FOLLOWER with a `CurrentLeader` that names the leader we already produce to at the epoch we already have, or an older epoch: the error and the hint are two separate reads inside the broker, and its metadata cache is updated before its replica state. We staged any non-negative hint as a move, which skipped both the retry wait and the metadata update, and then `doMove` found nothing to move and re-drained at once. With default settings that loops at round trip speed for as long as the broker keeps answering the same way (475 requests in 5s, zero metadata refreshes); with `RecordRetries` bounded, the budget was gone in 55ms and the record failed during a routine leader change. A hint now has to carry a newer epoch to count as a move, and `doMove` makes the same comparison; a same-epoch hint at a different leader is refused too, since two brokers naming each other at one epoch would otherwise move us back and forth with no wait between attempts, and the endpoints in such a response are as stale as its epoch, so they are recorded only for a hint we act on (the Java client applies the same rules). Otherwise the produce retries after the normal backoff and the fetch takes the normal metadata path.

Routing the stale hint through the backoff path exposed two bugs in that path, fixed in the first two commits. The retry and missing-reply batches passed a literal `0` as the backoff seq, so they could back off until the sink's first backoff of any kind and then never again. And `drain` checked the backoff before waiting on the inflight semaphore, which a response releases only after triggering the backoff, so with one request in flight per broker every produce backoff let one extra request through.

Tested with kfake answering every produce with the client's own leader and epoch, an older epoch, the same epoch at another leader, or a newer epoch that then repeats, for idempotent and non-idempotent producers: each retry waits exactly once, a real leader move retries at once with no wait, and exhaustion surfaces `NOT_LEADER_OR_FOLLOWER` rather than `ErrRecordRetries`. Against master, the reporter's reproduction made 6 requests in 55ms with no backoff call and no metadata refresh. Whole kfake package green under `-race`, kgo suite green against a 3-broker `kcl fake` under `-race`, lint clean. The test matrix and the real-move test come from #1414.

Closes #1412.