### PR TITLE
kgo: respect produce retry backoff for repeated leader hints

### DIFF
--- a/pkg/kfake/issue_1412_test.go
+++ b/pkg/kfake/issue_1412_test.go
@@ -1,0 +1,162 @@
+package kfake
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// Repeated KIP-951 hints for the current leader must not bypass the produce
+// retry backoff and exhaust the retry budget in a tight loop.
+func TestIssue1412ProduceRetryBackoff(t *testing.T) {
+	t.Parallel()
+	for _, idempotent := range []bool{false, true} {
+		for _, test := range []struct {
+			name       string
+			epochDelta int32
+			timeout    bool
+			immediate  int32
+		}{
+			{name: "same_epoch"},
+			{name: "stale_epoch", epochDelta: -1},
+			{name: "new_epoch_then_repeated", epochDelta: 1, immediate: 1},
+			{name: "request_timeout", timeout: true},
+		} {
+			// An idempotent producer intentionally keeps retrying a timed-out
+			// append whose outcome is unknown, even beyond RecordRetries.
+			if test.timeout && idempotent {
+				continue
+			}
+			t.Run(test.name+"/idempotent="+strconv.FormatBool(idempotent), func(t *testing.T) {
+				t.Parallel()
+				const topic = "retry-backoff"
+				const retries = 5
+				const backoff = 50 * time.Millisecond
+				c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+				// Start at epoch 1 so the stale hint still has a valid epoch.
+				if err := c.MoveTopicPartition(topic, 0, 0); err != nil {
+					t.Fatal(err)
+				}
+				var backoffs atomic.Int32
+				var produces atomic.Int32
+				opts := []kgo.Opt{
+					// Telemetry requests share RetryBackoffFn; count only produce retries.
+					kgo.DisableClientMetrics(),
+					kgo.RecordRetries(retries),
+					kgo.RetryBackoffFn(func(int) time.Duration {
+						backoffs.Add(1)
+						return backoff
+					}),
+				}
+				if !idempotent {
+					opts = append(opts, kgo.DisableIdempotentWrite(), kgo.MaxProduceRequestsInflightPerBroker(1))
+				}
+				cl := newPlainClient(t, c, opts...)
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("warmup")}).FirstErr(); err != nil {
+					t.Fatal(err)
+				}
+				backoffs.Store(0)
+				pi := c.PartitionInfo(topic, 0)
+				host, portText, err := net.SplitHostPort(c.ListenAddrs()[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+				port, err := strconv.Atoi(portText)
+				if err != nil {
+					t.Fatal(err)
+				}
+				c.ControlKey(int16(kmsg.Produce), func(req kmsg.Request) (kmsg.Response, error, bool) {
+					c.KeepControl()
+					n := produces.Add(1)
+					if n > retries+1 {
+						// Allow recovery so a retry-limit regression cannot hang.
+						return nil, nil, false
+					}
+					if want := n - 1 - test.immediate; backoffs.Load() < want {
+						t.Errorf("produce %d: backoff calls = %d, want at least %d", n, backoffs.Load(), want)
+					}
+					if n == 2 && test.immediate != 0 && backoffs.Load() != 0 {
+						t.Error("advancing leader epoch did not retry immediately")
+					}
+					resp := req.ResponseKind().(*kmsg.ProduceResponse)
+					rt := kmsg.NewProduceResponseTopic()
+					rt.Topic = topic
+					rt.TopicID = req.(*kmsg.ProduceRequest).Topics[0].TopicID
+					rp := kmsg.NewProduceResponseTopicPartition()
+					rp.Partition = 0
+					rp.ErrorCode = kerr.NotLeaderForPartition.Code
+					if test.timeout {
+						rp.ErrorCode = kerr.RequestTimedOut.Code
+					}
+					rp.CurrentLeader.LeaderID = pi.Leader
+					rp.CurrentLeader.LeaderEpoch = pi.Epoch + test.epochDelta
+					rt.Partitions = append(rt.Partitions, rp)
+					resp.Topics = append(resp.Topics, rt)
+					if !test.timeout {
+						resp.Brokers = []kmsg.ProduceResponseBroker{{NodeID: pi.Leader, Host: host, Port: int32(port)}}
+					}
+					return resp, nil, true
+				})
+				start := time.Now()
+				err = cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("probe")}).FirstErr()
+				elapsed := time.Since(start)
+				if !errors.Is(err, kgo.ErrRecordRetries) {
+					t.Fatalf("expected retry exhaustion, got %v", err)
+				}
+				if got := produces.Load(); got != retries+1 {
+					t.Errorf("produce requests = %d, want %d", got, retries+1)
+				}
+				if want := time.Duration(retries-test.immediate) * backoff; elapsed < want {
+					t.Errorf("retries took %v, want at least %v of backoff", elapsed, want)
+				}
+			})
+		}
+	}
+}
+
+// A real leader change must still retry on the new broker without backoff.
+func TestIssue1412ProduceNewLeader(t *testing.T) {
+	t.Parallel()
+	const topic = "new-leader"
+	c := newCluster(t, NumBrokers(2), SeedTopics(1, topic))
+	var backoffs atomic.Int32
+	cl := newPlainClient(t, c, kgo.DisableClientMetrics(), kgo.RetryBackoffFn(func(int) time.Duration {
+		backoffs.Add(1)
+		return time.Second
+	}))
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("warmup")}).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	backoffs.Store(0)
+	old := c.PartitionInfo(topic, 0)
+	if err := c.MoveTopicPartition(topic, 0, (old.Leader+1)%2); err != nil {
+		t.Fatal(err)
+	}
+	var produces atomic.Int32
+	c.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		produces.Add(1)
+		return nil, nil, false
+	})
+	if err := cl.ProduceSync(ctx, &kgo.Record{Topic: topic, Value: []byte("probe")}).FirstErr(); err != nil {
+		t.Fatal(err)
+	}
+	if got := produces.Load(); got != 2 {
+		t.Errorf("produce requests = %d, want failed attempt and successful retry", got)
+	}
+	if got := backoffs.Load(); got != 0 {
+		t.Errorf("new leader backoff calls = %d, want 0", got)
+	}
+}

--- a/pkg/kgo/sink.go
+++ b/pkg/kgo/sink.go
@@ -270,8 +270,6 @@ func (s *sink) clearBackoff() {
 func (s *sink) drain() {
 	again := true
 	for again {
-		s.maybeBackoff()
-
 		sem := s.inflightSem.Load().(chan struct{})
 		select {
 		case sem <- struct{}{}:
@@ -280,6 +278,9 @@ func (s *sink) drain() {
 			return
 		}
 
+		// A response can request backoff while we wait for an inflight slot.
+		// Check after acquiring it so the next send observes that backoff.
+		s.maybeBackoff()
 		again = s.drainState.maybeFinish(s.produce(sem))
 	}
 }
@@ -920,8 +921,9 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 				// A timed-out append, or one short of replicas,
 				// comes from a leader that is still the leader:
 				// metadata has nothing to say, so we retry after
-				// the produce backoff.
-				if rp.ErrorCode == kerr.RequestTimedOut.Code || rp.ErrorCode == kerr.NotEnoughReplicasAfterAppend.Code {
+				// the produce backoff. A repeated leader hint also
+				// needs backoff, with an asynchronous metadata refresh.
+				if rp.ErrorCode == kerr.RequestTimedOut.Code || rp.ErrorCode == kerr.NotEnoughReplicasAfterAppend.Code || kmove.backoffs[batch.owner] {
 					reqBackoff.addSeqBatch(topic, tid, partition, batch)
 				} else {
 					reqRetry.addSeqBatch(topic, tid, partition, batch)
@@ -952,7 +954,11 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 		s.handleRetryBatches(reqRetry, &kmove, 0, true, true, "produce request had retry batches")
 	}
 	if len(reqBackoff.bs) > 0 {
-		s.handleRetryBatches(reqBackoff, nil, req.backoffSeq, false, true, "produce request had timed out batches")
+		if len(kmove.backoffs) > 0 {
+			// Refresh asynchronously without making retries wait for metadata.
+			s.cl.triggerUpdateMetadata(true, "produce response had stale leader hints")
+		}
+		s.handleRetryBatches(reqBackoff, nil, req.backoffSeq, false, true, "produce request had batches requiring backoff")
 	}
 }
 
@@ -1028,6 +1034,12 @@ func (s *sink) handleReqRespBatch(
 			fmt.Fprintf(b, "move:%d:%d@%d,%d}, ", rp.CurrentLeader.LeaderID, rp.CurrentLeader.LeaderEpoch, rp.BaseOffset, nrec)
 		}
 		batch.owner.failing = true
+		return true, false
+	}
+	if kmove.backoffs[batch.owner] {
+		if debug {
+			fmt.Fprintf(b, "retrying@%d,%d(%s)}, ", rp.BaseOffset, nrec, kerr.NotLeaderForPartition)
+		}
 		return true, false
 	}
 

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -737,9 +737,10 @@ func (tp *topicPartition) migrateShareCursorTo(cl *Client, new *topicPartition) 
 }
 
 type kip951move struct {
-	recBufs map[*recBuf]topicPartitionData
-	cursors map[*cursor]topicPartitionData
-	brokers []BrokerMetadata
+	recBufs  map[*recBuf]topicPartitionData
+	cursors  map[*cursor]topicPartitionData
+	brokers  []BrokerMetadata
+	backoffs map[*recBuf]bool
 }
 
 func (k *kip951move) empty() bool {
@@ -760,6 +761,16 @@ func (k *kip951move) maybeAddProducePartition(resp *kmsg.ProduceResponse, p *kms
 		len(resp.Brokers) == 0 ||
 		p.CurrentLeader.LeaderID < 0 ||
 		p.CurrentLeader.LeaderEpoch < 0 {
+		return false
+	}
+	// KIP-951 only permits an immediate retry when the hint advances our
+	// leader epoch. Repeated or stale hints must respect the produce backoff.
+	// The caller holds rb.mu, which guards rb.leaderEpoch.
+	if p.CurrentLeader.LeaderEpoch <= rb.leaderEpoch {
+		if k.backoffs == nil {
+			k.backoffs = make(map[*recBuf]bool)
+		}
+		k.backoffs[rb] = true
 		return false
 	}
 	if len(k.brokers) == 0 {


### PR DESCRIPTION
Repeated `NOT_LEADER_OR_FOLLOWER` responses with an unchanged leader epoch currently take the KIP-951 immediate retry path and can exhaust `RecordRetries` without calling `RetryBackoffFn`.

Related: #1413 was opened while this patch was being prepared. This is an independently prepared alternative for #1412, and the core fix overlaps. The additional kfake cases here may also be useful for that PR, particularly idempotent producers, older epochs, and an advancing epoch followed by repeated hints.

Only use that path when the hinted epoch advances the record buffer's known epoch. Route repeated or stale hints through the existing produce backoff path, refresh metadata asynchronously, and retain retry-limit handling. A higher epoch, including a move to another broker, still retries immediately.

Also check sink backoff after acquiring an inflight slot. A failure response can request backoff while the drain loop is waiting for that slot; checking before the wait lets the next send miss it.

Add kfake regressions for equal and stale epochs, an advancing epoch followed by repeated hints, ordinary request timeouts, and a real leader move. Cover both idempotent and non-idempotent producers where applicable, and disable client telemetry in these tests so its requests do not affect the shared backoff counter.

Validation:

- Confirmed the equal-epoch regression fails on unmodified master: six Produce attempts in about 59 ms, zero backoff calls, with five retries and a 50 ms backoff.
- `go test -race -run '^TestIssue1412' -count=20 -timeout=2m .` in `pkg/kfake`.
- `go test -timeout=5m ./...` and `go test -race -timeout=5m ./...` in `pkg/kfake`.
- `go test -timeout=5m ./...` in the root module against kfake configured as Kafka 4.1.
- `golangci-lint run --timeout=5m ./pkg/kgo/...` in the root module and `golangci-lint run --timeout=5m ./...` in `pkg/kfake`.

Fixes #1412.
