### PR TITLE
kgo: Avoid ptr escape on call to errors.As in isDecompressErr when err is nil

### DIFF
--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -426,6 +426,9 @@ func (e *errDecompress) Error() string {
 func (e *errDecompress) Unwrap() error { return e.err }
 
 func isDecompressErr(err error) bool {
+	if err == nil {
+		return false
+	}
 	var ed *errDecompress
 	return errors.As(err, &ed)
 }

--- a/pkg/kgo/errors_classify_test.go
+++ b/pkg/kgo/errors_classify_test.go
@@ -28,3 +28,29 @@ func TestUnexpectedEOFRetriable(t *testing.T) {
 		t.Error("first-read io.EOF should stay non-retryable")
 	}
 }
+
+func TestIsDecompressErr(t *testing.T) {
+	t.Parallel()
+
+	// A direct errDecompress should be recognized.
+	direct := &errDecompress{err: io.ErrUnexpectedEOF}
+	if !isDecompressErr(direct) {
+		t.Error("direct *errDecompress not detected")
+	}
+
+	// A wrapped errDecompress should be recognized through the chain.
+	wrapped := fmt.Errorf("process failed: %w", direct)
+	if !isDecompressErr(wrapped) {
+		t.Error("wrapped *errDecompress not detected")
+	}
+
+	// A non-decompress error must not match.
+	if isDecompressErr(io.ErrUnexpectedEOF) {
+		t.Error("plain io.ErrUnexpectedEOF falsely detected as decompress error")
+	}
+
+	// nil must not match.
+	if isDecompressErr(nil) {
+		t.Error("nil falsely detected as decompress error")
+	}
+}


### PR DESCRIPTION
Current version of "isDecompressErr" escapes a pointer to the heap:

```
func isDecompressErr(err error) bool {
	var ed *errDecompress
	return errors.As(err, &ed)
}

pkg/kgo/errors.go:429:6:   flow: {heap} ← &ed:
pkg/kgo/errors.go:429:6:     from &ed (address-of) at pkg/kgo/errors.go:430:24
pkg/kgo/errors.go:429:6:     from &ed (interface-converted) at pkg/kgo/errors.go:430:24
pkg/kgo/errors.go:429:6:     from errors.As(err, &ed) (call parameter) at pkg/kgo/errors.go:430:18
```

As this function is called frequently in [ProcessFetchPartition](https://github.com/twmb/franz-go/blob/6b0b6509f117452fe2812c68a5489f5429246b1a/pkg/kgo/source.go#L1722), the overhead adds up over time.


The fix avoids the allocation when err is _nil_ with a simple gate.