### PR TITLE
kgo: never skip records when resetting after OFFSET_OUT_OF_RANGE

### DIFF
--- a/pkg/kfake/source_ooor_reset_test.go
+++ b/pkg/kfake/source_ooor_reset_test.go
@@ -1,0 +1,317 @@
+package kfake
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+// TestOutOfRangeBelowStartResetsToStart drops a consumer below the log start
+// and requires it to resume at the log start. The surviving records are
+// stamped older than the last one consumed - a producer with a fast clock,
+// then a normal one - which is what broke the old reset: listing by the last
+// consumed millisecond matched nothing, so we listed the end and skipped
+// every record still in the log.
+func TestOutOfRangeBelowStartResetsToStart(t *testing.T) {
+	t.Parallel()
+
+	const (
+		topic  = "ooor-below-start"
+		nrecs  = 10
+		nfirst = 5
+		delTo  = 7
+	)
+
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Every record is its own batch. The first five are stamped an hour
+	// ahead of the rest, so a reset by the fifth record's timestamp finds
+	// nothing once only the later records remain.
+	pcl := newPlainClient(t, c)
+	ahead := time.Now().Add(time.Hour)
+	now := time.Now()
+	for i := range nrecs {
+		r := &kgo.Record{Topic: topic, Value: fmt.Appendf(nil, "v%d", i), Timestamp: ahead}
+		if i >= nfirst {
+			r.Timestamp = now
+		}
+		if err := pcl.ProduceSync(ctx, r).FirstErr(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cl := newPlainClient(t, c,
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.FetchMaxWait(100*time.Millisecond),
+	)
+
+	// One poll takes the first five and leaves the rest buffered. The
+	// source does not fetch again while it holds a buffer, so nothing is
+	// in flight for the rest of the setup.
+	fs := cl.PollRecords(ctx, nfirst)
+	if err := fs.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if n := fs.NumRecords(); n != nfirst {
+		t.Fatalf("polled %d records, want %d", n, nfirst)
+	}
+
+	// Pausing drops the buffered remainder, leaving the cursor at offset 5
+	// with the fifth record's timestamp.
+	cl.PauseFetchTopics(topic)
+	verifyZeroRecords(t, cl, time.Second)
+
+	// Delete through offset 7: the cursor is now below the log start, and
+	// every record that survives is one we have not consumed.
+	req := kmsg.NewPtrDeleteRecordsRequest()
+	rt := kmsg.NewDeleteRecordsRequestTopic()
+	rt.Topic = topic
+	rp := kmsg.NewDeleteRecordsRequestTopicPartition()
+	rp.Partition = 0
+	rp.Offset = delTo
+	rt.Partitions = append(rt.Partitions, rp)
+	req.Topics = append(req.Topics, rt)
+	resp, err := req.RequestWith(ctx, pcl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := resp.Topics[0].Partitions[0].ErrorCode; code != 0 {
+		t.Fatalf("delete records: %v", kerr.ErrorForCode(code))
+	}
+
+	cl.ResumeFetchTopics(topic)
+
+	got := collectRecords(t, cl, nrecs-delTo, 8*time.Second)
+	for i, r := range got {
+		if want := int64(delTo + i); r.Offset != want {
+			t.Errorf("record %d is offset %d, want %d", i, r.Offset, want)
+		}
+	}
+}
+
+// TestOutOfRangePastEndResetsByTime answers one fetch past the end of an
+// intact log with OFFSET_OUT_OF_RANGE, as a broker that lost its tail would,
+// and requires the consumer to resume at the last record it consumed, found
+// by timestamp. Resuming at the log start would re-read the log; resuming at
+// the end would skip anything written after the loss.
+func TestOutOfRangePastEndResetsByTime(t *testing.T) {
+	t.Parallel()
+
+	const (
+		topic = "ooor-past-end"
+		nrecs = 10
+	)
+
+	c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+	ti := c.TopicInfo(topic)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Timestamps one second apart, so the last consumed record is the
+	// only one at its timestamp.
+	pcl := newPlainClient(t, c)
+	base := time.Now().Add(-time.Hour)
+	for i := range nrecs {
+		r := &kgo.Record{Topic: topic, Value: fmt.Appendf(nil, "v%d", i), Timestamp: base.Add(time.Duration(i) * time.Second)}
+		if err := pcl.ProduceSync(ctx, r).FirstErr(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The first fetch at offset 10 is answered out of range with the
+	// watermarks unset, which is what Kafka sends. Every other fetch
+	// passes through.
+	var fired atomic.Bool
+	c.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		c.KeepControl()
+		req := kreq.(*kmsg.FetchRequest)
+		if len(req.Topics) != 1 || len(req.Topics[0].Partitions) != 1 ||
+			req.Topics[0].Partitions[0].FetchOffset != nrecs || fired.Swap(true) {
+			return nil, nil, false
+		}
+		resp := req.ResponseKind().(*kmsg.FetchResponse)
+		rt := kmsg.NewFetchResponseTopic()
+		rt.Topic = topic
+		rt.TopicID = ti.TopicID
+		rp := kmsg.NewFetchResponseTopicPartition()
+		rp.Partition = 0
+		rp.ErrorCode = kerr.OffsetOutOfRange.Code
+		rp.HighWatermark = -1
+		rp.LastStableOffset = -1
+		rp.LogStartOffset = -1
+		rt.Partitions = append(rt.Partitions, rp)
+		resp.Topics = append(resp.Topics, rt)
+		return resp, nil, true
+	})
+
+	cl := newPlainClient(t, c,
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+		kgo.DisableFetchSessions(),
+		kgo.FetchMaxWait(100*time.Millisecond),
+	)
+	collectRecords(t, cl, nrecs, 8*time.Second)
+
+	// The reset lists by the last consumed timestamp and finds record 9,
+	// which we read a second time.
+	got := collectRecords(t, cl, 1, 8*time.Second)
+	if got[0].Offset != nrecs-1 {
+		t.Fatalf("resumed at offset %d, want %d", got[0].Offset, nrecs-1)
+	}
+}
+
+// TestOutOfRangeInRangeNeverSkipsForward answers one fetch with
+// OFFSET_OUT_OF_RANGE while the cursor sits inside an intact log, with the log
+// end above it, and requires the reset to resume where the cursor was. A
+// by-time answer ahead of us would skip the records in between; no by-time
+// answer at all used to take the log end and skip the rest of the log.
+// Everything from our offset on is unread.
+func TestOutOfRangeInRangeNeverSkipsForward(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nrecs    = 12
+		nconsume = 10
+	)
+
+	for _, test := range []struct {
+		name   string
+		byTime int64
+		want   int64
+	}{
+		{name: "ahead", byTime: 11, want: nconsume},
+		{name: "none", byTime: -1, want: nconsume},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			topic := "ooor-in-range-" + test.name
+
+			c := newCluster(t, NumBrokers(1), SeedTopics(1, topic))
+			ti := c.TopicInfo(topic)
+			epoch := c.PartitionInfo(topic, 0).Epoch
+
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			// Timestamps one second apart, so the last consumed record is
+			// the only one at its timestamp.
+			pcl := newPlainClient(t, c)
+			base := time.Now().Add(-time.Hour)
+			for i := range nrecs {
+				r := &kgo.Record{Topic: topic, Value: fmt.Appendf(nil, "v%d", i), Timestamp: base.Add(time.Duration(i) * time.Second)}
+				if err := pcl.ProduceSync(ctx, r).FirstErr(); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// The fetch at offset 10 is answered out of range once, with
+			// the watermarks unset, which is what Kafka sends.
+			var fired atomic.Bool
+			c.ControlKey(int16(kmsg.Fetch), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+				c.KeepControl()
+				req := kreq.(*kmsg.FetchRequest)
+				if len(req.Topics) != 1 || len(req.Topics[0].Partitions) != 1 ||
+					req.Topics[0].Partitions[0].FetchOffset != nconsume || fired.Swap(true) {
+					return nil, nil, false
+				}
+				resp := req.ResponseKind().(*kmsg.FetchResponse)
+				rt := kmsg.NewFetchResponseTopic()
+				rt.Topic = topic
+				rt.TopicID = ti.TopicID
+				rp := kmsg.NewFetchResponseTopicPartition()
+				rp.Partition = 0
+				rp.ErrorCode = kerr.OffsetOutOfRange.Code
+				rp.HighWatermark = -1
+				rp.LastStableOffset = -1
+				rp.LogStartOffset = -1
+				rt.Partitions = append(rt.Partitions, rp)
+				resp.Topics = append(resp.Topics, rt)
+				return resp, nil, true
+			})
+
+			// The reset lists the start, the end, and the last consumed
+			// millisecond. We answer the by-time list; the start (0) and
+			// the end (12) are served for real.
+			var listed atomic.Bool
+			c.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+				c.KeepControl()
+				req := kreq.(*kmsg.ListOffsetsRequest)
+				var byTime bool
+				for _, rt := range req.Topics {
+					for _, rp := range rt.Partitions {
+						byTime = byTime || rp.Timestamp != -1 && rp.Timestamp != -2
+					}
+				}
+				if !byTime {
+					return nil, nil, false
+				}
+				listed.Store(true)
+				resp := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+				for _, rt := range req.Topics {
+					st := kmsg.NewListOffsetsResponseTopic()
+					st.Topic = rt.Topic
+					for _, rp := range rt.Partitions {
+						sp := kmsg.NewListOffsetsResponseTopicPartition()
+						sp.Partition = rp.Partition
+						sp.ErrorCode = 0
+						sp.Timestamp = -1
+						sp.Offset = test.byTime
+						sp.LeaderEpoch = epoch
+						st.Partitions = append(st.Partitions, sp)
+					}
+					resp.Topics = append(resp.Topics, st)
+				}
+				return resp, nil, true
+			})
+
+			cl := newPlainClient(t, c,
+				kgo.ConsumeTopics(topic),
+				kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+				kgo.DisableFetchSessions(),
+				kgo.FetchMaxWait(100*time.Millisecond),
+			)
+
+			// One poll takes ten of the twelve records and leaves the rest
+			// buffered. The source does not fetch again while it holds a
+			// buffer, so nothing is in flight for the rest of the setup.
+			fs := cl.PollRecords(ctx, nconsume)
+			if err := fs.Err(); err != nil {
+				t.Fatal(err)
+			}
+			if n := fs.NumRecords(); n != nconsume {
+				t.Fatalf("polled %d records, want %d", n, nconsume)
+			}
+
+			// Pausing drops the buffered remainder, leaving the cursor at
+			// offset 10 with the tenth record's timestamp and the log end
+			// at 12.
+			cl.PauseFetchTopics(topic)
+			verifyZeroRecords(t, cl, time.Second)
+
+			cl.ResumeFetchTopics(topic)
+
+			got := collectRecords(t, cl, 1, 8*time.Second)
+			if !fired.Load() {
+				t.Fatal("the fetch at the cursor was never answered out of range")
+			}
+			if !listed.Load() {
+				t.Fatal("the reset never listed by the last consumed millisecond")
+			}
+			if got[0].Offset != test.want {
+				t.Fatalf("resumed at offset %d, want %d", got[0].Offset, test.want)
+			}
+		})
+	}
+}

--- a/pkg/kgo/config.go
+++ b/pkg/kgo/config.go
@@ -1616,13 +1616,13 @@ func ConsumeStartOffset(offset Offset) ConsumerOpt {
 // earliest offset. If using this option, it is strongly recommended to also
 // set ConsumeStartOffset.
 //
-// This option is *only* used if a consumer seeds OffsetOutOfRange on the
-// *first* fetch of a partition. If the consumer has consumed the partition at
-// all and sees the error, it will automatically reset to the first offset
-// after the timestamp of the last successfully consumed offset. If data loss
-// occurred such that even the last successfully consumed offset is lost, the
-// client automatically resets to the new current end offset. If you want to
-// disable offset resetting entirely, you can use [NoResetOffset].
+// This option is *only* used if a consumer sees OffsetOutOfRange before it
+// has consumed anything from a partition. Once a partition has been consumed,
+// OffsetOutOfRange resets to the nearest offset that still exists: the log
+// start if the consumer fell below it, otherwise the first offset at or after
+// the last consumed record's timestamp, never ahead of where the consumer
+// was, and never past the log end. If you want to disable offset resetting
+// entirely, you can use [NoResetOffset].
 //
 // If you use an exact or relative offsets and the offset ends up out of range,
 // the client chooses the nearest of either the log start offset or the log end

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -2490,7 +2490,11 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 			}
 
 			offset := poffset(&rPartition)
-			end := func() int64 { return poffset(&resp2.Topics[i].Partitions[j]) }
+			epoch := rPartition.LeaderEpoch
+			end := func() (int64, int32) {
+				p := &resp2.Topics[i].Partitions[j]
+				return poffset(p), p.LeaderEpoch
+			}
 
 			// We ensured the resp2 shape is as we want and has no
 			// error, so resp2 lookups are safe.
@@ -2500,35 +2504,35 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 				// our end offset request: anything after the
 				// end offset *now* is after our milli.
 				if offset == -1 {
-					offset = end()
+					offset, epoch = end()
 				}
 			} else if loadPart.at >= 0 {
 				// If an exact offset, we listed start and end.
 				// We validate the offset is within bounds.
-				end := end()
+				end, endEpoch := end()
 				want := loadPart.at + loadPart.relative
 				if want >= offset {
-					offset = want
+					offset, epoch = want, -1
 				}
 				if want >= end {
-					offset = end
+					offset, epoch = end, endEpoch
 				}
 			} else if loadPart.at == -2 && loadPart.relative > 0 {
 				// Relative to the start: both start & end were
 				// issued, and we bound to the end.
-				offset += loadPart.relative
-				if end := end(); offset >= end {
-					offset = end
+				offset, epoch = offset+loadPart.relative, -1
+				if end, endEpoch := end(); offset >= end {
+					offset, epoch = end, endEpoch
 				}
 			} else if loadPart.at == -1 && loadPart.relative < 0 {
 				// Relative to the end: both start & end were
 				// issued, offset is currently the start, so we
 				// set to the end and then bound to the start.
-				start := offset
-				offset = end()
-				offset += loadPart.relative
+				start, startEpoch := offset, epoch
+				end, _ := end()
+				offset, epoch = end+loadPart.relative, -1
 				if offset <= start {
-					offset = start
+					offset, epoch = start, startEpoch
 				}
 			}
 			// Every arm above yields a non-negative offset from a
@@ -2555,7 +2559,7 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 				partition:   partition,
 				cursor:      topicPartition.cursor,
 				offset:      offset,
-				leaderEpoch: rPartition.LeaderEpoch,
+				leaderEpoch: epoch,
 				request:     loadPart,
 			})
 		}

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -1492,6 +1492,11 @@ type offsetLoadMap map[string]map[int32]offsetLoad
 // to directly use if a cursor had a preferred replica.
 type offsetLoad struct {
 	replica int32 // -1 means leader
+	// ooorMilli is non-zero when we are resetting a cursor that received
+	// OFFSET_OUT_OF_RANGE while consuming: the timestamp of the last
+	// record it consumed. The offset itself is the one that was out of
+	// range. See listOffsetsForBrokerLoad.
+	ooorMilli int64
 	Offset
 }
 
@@ -2330,14 +2335,98 @@ func (l *loadedOffsets) addAll(as []loadedOffset) loadedOffsets {
 	return *l
 }
 
+// alignListResps prunes two ListOffsets responses to the topics and partitions
+// they have in common, sorted, so that the same index in either response is the
+// same partition. A partition erroring in one keeps that error in both.
+func alignListResps(a, b *kmsg.ListOffsetsResponse) {
+	for _, r := range []*kmsg.ListOffsetsResponse{
+		a,
+		b,
+	} {
+		ts := r.Topics
+		sort.Slice(ts, func(i, j int) bool {
+			return ts[i].Topic < ts[j].Topic
+		})
+		for i := range ts {
+			ps := ts[i].Partitions
+			sort.Slice(ps, func(i, j int) bool {
+				return ps[i].Partition < ps[j].Partition
+			})
+		}
+	}
+
+	lt := a.Topics
+	rt := b.Topics
+	lkeept := lt[:0]
+	rkeept := rt[:0]
+	// Over each response, we only keep the topic if the topics match.
+	for len(lt) > 0 && len(rt) > 0 {
+		if lt[0].Topic < rt[0].Topic {
+			lt = lt[1:]
+			continue
+		}
+		if rt[0].Topic < lt[0].Topic {
+			rt = rt[1:]
+			continue
+		}
+		// As well, for topics that match, we only keep partitions that
+		// match. In this case, we also want both partitions to be
+		// error free, otherwise we keep an error on both. If one has
+		// old style offsets, both must.
+		lp := lt[0].Partitions
+		rp := rt[0].Partitions
+		lkeepp := lp[:0]
+		rkeepp := rp[:0]
+		for len(lp) > 0 && len(rp) > 0 {
+			if lp[0].Partition < rp[0].Partition {
+				lp = lp[1:]
+				continue
+			}
+			if rp[0].Partition < lp[0].Partition {
+				rp = rp[1:]
+				continue
+			}
+			if len(lp[0].OldStyleOffsets) > 0 && len(rp[0].OldStyleOffsets) == 0 ||
+				len(lp[0].OldStyleOffsets) == 0 && len(rp[0].OldStyleOffsets) > 0 {
+				lp = lp[1:]
+				rp = rp[1:]
+				continue
+			}
+			if lp[0].ErrorCode != 0 {
+				rp[0].ErrorCode = lp[0].ErrorCode
+			} else if rp[0].ErrorCode != 0 {
+				lp[0].ErrorCode = rp[0].ErrorCode
+			}
+			lkeepp = append(lkeepp, lp[0])
+			rkeepp = append(rkeepp, rp[0])
+			lp = lp[1:]
+			rp = rp[1:]
+		}
+		// Now we update the partitions in the topic we are keeping,
+		// and keep our topic.
+		lt[0].Partitions = lkeepp
+		rt[0].Partitions = rkeepp
+		lkeept = append(lkeept, lt[0])
+		rkeept = append(rkeept, rt[0])
+		lt = lt[1:]
+		rt = rt[1:]
+	}
+	// Finally, update each response with the topics we kept. The shapes
+	// and indices are the same.
+	a.Topics = lkeept
+	b.Topics = rkeept
+}
+
 func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, load offsetLoadMap, tps *topicsPartitions, results chan<- loadedOffsets) {
 	loaded := loadedOffsets{broker: broker.meta.NodeID, loadType: loadTypeList}
 
-	req1, req2 := load.buildListReq(cl.cfg.isolationLevel)
+	req1, req2, req3 := load.buildListReq(cl.cfg.isolationLevel)
 	var (
 		wg     sync.WaitGroup
 		kresp2 kmsg.Response
 		err2   error
+		kresp3 kmsg.Response
+		err3   error
 	)
 	if req2 != nil {
 		wg.Add(1)
@@ -2346,12 +2435,22 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 			kresp2, err2 = broker.waitResp(ctx, req2)
 		}()
 	}
+	if req3 != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			kresp3, err3 = broker.waitResp(ctx, req3)
+		}()
+	}
 	kresp, err := broker.waitResp(ctx, req1)
 	wg.Wait()
-	if err != nil || err2 != nil {
-		if err == nil {
-			err = err2
-		}
+	if err == nil {
+		err = err2
+	}
+	if err == nil {
+		err = err3
+	}
+	if err != nil {
 		results <- loaded.addAll(load.errToLoaded(err))
 		return
 	}
@@ -2364,86 +2463,18 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 	// shapes of both responses match, and the topic & partition at each
 	// index matches. Anything that does not match is skipped (and would be
 	// a bug from Kafka), and we at the end return UnknownTopicOrPartition.
-	var resp2 *kmsg.ListOffsetsResponse
+	// With a by-time req as well, three pairwise passes leave all three
+	// responses the same shape: the last pass prunes the first response
+	// down to whatever the by-time pass removed from the second.
+	var resp2, resp3 *kmsg.ListOffsetsResponse
 	if req2 != nil {
 		resp2 = kresp2.(*kmsg.ListOffsetsResponse)
-		for _, r := range []*kmsg.ListOffsetsResponse{
-			resp,
-			resp2,
-		} {
-			ts := r.Topics
-			sort.Slice(ts, func(i, j int) bool {
-				return ts[i].Topic < ts[j].Topic
-			})
-			for i := range ts {
-				ps := ts[i].Partitions
-				sort.Slice(ps, func(i, j int) bool {
-					return ps[i].Partition < ps[j].Partition
-				})
-			}
-		}
-
-		lt := resp.Topics
-		rt := resp2.Topics
-		lkeept := lt[:0]
-		rkeept := rt[:0]
-		// Over each response, we only keep the topic if the topics match.
-		for len(lt) > 0 && len(rt) > 0 {
-			if lt[0].Topic < rt[0].Topic {
-				lt = lt[1:]
-				continue
-			}
-			if rt[0].Topic < lt[0].Topic {
-				rt = rt[1:]
-				continue
-			}
-			// As well, for topics that match, we only keep
-			// partitions that match. In this case, we also want
-			// both partitions to be error free, otherwise we keep
-			// an error on both. If one has old style offsets,
-			// both must.
-			lp := lt[0].Partitions
-			rp := rt[0].Partitions
-			lkeepp := lp[:0]
-			rkeepp := rp[:0]
-			for len(lp) > 0 && len(rp) > 0 {
-				if lp[0].Partition < rp[0].Partition {
-					lp = lp[1:]
-					continue
-				}
-				if rp[0].Partition < lp[0].Partition {
-					rp = rp[1:]
-					continue
-				}
-				if len(lp[0].OldStyleOffsets) > 0 && len(rp[0].OldStyleOffsets) == 0 ||
-					len(lp[0].OldStyleOffsets) == 0 && len(rp[0].OldStyleOffsets) > 0 {
-					lp = lp[1:]
-					rp = rp[1:]
-					continue
-				}
-				if lp[0].ErrorCode != 0 {
-					rp[0].ErrorCode = lp[0].ErrorCode
-				} else if rp[0].ErrorCode != 0 {
-					lp[0].ErrorCode = rp[0].ErrorCode
-				}
-				lkeepp = append(lkeepp, lp[0])
-				rkeepp = append(rkeepp, rp[0])
-				lp = lp[1:]
-				rp = rp[1:]
-			}
-			// Now we update the partitions in the topic we are
-			// keeping, and keep our topic.
-			lt[0].Partitions = lkeepp
-			rt[0].Partitions = rkeepp
-			lkeept = append(lkeept, lt[0])
-			rkeept = append(rkeept, rt[0])
-			lt = lt[1:]
-			rt = rt[1:]
-		}
-		// Finally, update each response with the topics we kept. The
-		// shapes and indices are the same.
-		resp.Topics = lkeept
-		resp2.Topics = rkeept
+		alignListResps(resp, resp2)
+	}
+	if req3 != nil {
+		resp3 = kresp3.(*kmsg.ListOffsetsResponse)
+		alignListResps(resp2, resp3)
+		alignListResps(resp, resp2)
 	}
 
 	poffset := func(p *kmsg.ListOffsetsResponseTopicPartition) int64 {
@@ -2495,10 +2526,37 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 				p := &resp2.Topics[i].Partitions[j]
 				return poffset(p), p.LeaderEpoch
 			}
+			third := func() (int64, int32) {
+				p := &resp3.Topics[i].Partitions[j]
+				return poffset(p), p.LeaderEpoch
+			}
 
 			// We ensured the resp2 shape is as we want and has no
 			// error, so resp2 lookups are safe.
-			if loadPart.afterMilli {
+			if loadPart.ooorMilli != 0 {
+				// We were consuming at loadPart.at and fell out of range. We resume by the last consumed
+				// timestamp, never ahead of where we were, bounded within the log. Below the start, every record
+				// left is one we never consumed, so we resume at the start. Past the end, the broker lost data,
+				// and the timestamp is our best guess at where we were. In range means the log lost data and
+				// regrew under us: by-time re-reads what replaced our records rather than skipping them. If the
+				// by-time answer is ahead of us, the records from our offset up to it are stamped older than our
+				// last record; we never read them, so we keep our offset. If there is no by-time answer, every
+				// record left is stamped older than our last record, and we keep our offset for the same reason.
+				n := loadPart.at
+				start, startEpoch := offset, epoch
+				end, endEpoch := end()
+				byTime, byTimeEpoch := third()
+				offset, epoch = n, -1
+				if byTime >= 0 && byTime < n {
+					offset, epoch = byTime, byTimeEpoch
+				}
+				if offset < start {
+					offset, epoch = start, startEpoch
+				}
+				if offset > end {
+					offset, epoch = end, endEpoch
+				}
+			} else if loadPart.afterMilli {
 				// If after a milli, if the milli is after the
 				// end of a partition, the offset is -1. We use
 				// our end offset request: anything after the
@@ -2537,9 +2595,10 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 			}
 			// Every arm above yields a non-negative offset from a
 			// well-behaved broker: by-time listings exist only for
-			// afterMilli, whose -1 is replaced by the end listing,
-			// and the start/end/exact arms bound within the
-			// responses. A negative offset here means the broker
+			// afterMilli and for a reset after consuming, whose -1
+			// is replaced by the end listing and by the offset we
+			// were at, and the start/end/exact arms bound within
+			// the responses. A negative offset here means the broker
 			// violated the protocol; clamping to 0 (the old
 			// behavior) would silently re-consume the partition
 			// from the start. Surface the misbehavior and retry
@@ -2670,13 +2729,15 @@ func (*Client) loadEpochsForBrokerLoad(ctx context.Context, broker *broker, load
 
 // In general this returns one request, but if the user is using exact offsets
 // rather than start/end, then we issue both the start and end requests to
-// ensure the user's requested offset is within bounds.
-func (o offsetLoadMap) buildListReq(isolationLevel int8) (r1, r2 *kmsg.ListOffsetsRequest) {
+// ensure the user's requested offset is within bounds. A load resetting after
+// an out of range fetch also issues a third request, listing by the
+// millisecond of the last record the cursor consumed.
+func (o offsetLoadMap) buildListReq(isolationLevel int8) (r1, r2, r3 *kmsg.ListOffsetsRequest) {
 	r1 = kmsg.NewPtrListOffsetsRequest()
 	r1.ReplicaID = -1
 	r1.IsolationLevel = isolationLevel
 	r1.Topics = make([]kmsg.ListOffsetsRequestTopic, 0, len(o))
-	var createEnd bool
+	var createEnd, createByTime bool
 	for topic, partitions := range o {
 		parts := make([]kmsg.ListOffsetsRequestTopicPartition, 0, len(partitions))
 		for partition, offset := range partitions {
@@ -2692,12 +2753,19 @@ func (o offsetLoadMap) buildListReq(isolationLevel int8) (r1, r2 *kmsg.ListOffse
 			// If we are using a relative offset, we potentially
 			// issue the end request because relative may shift us
 			// too far in the other direction.
+			//
+			// If we are resetting after falling out of range while
+			// consuming, we issue the by-time list as well: we
+			// resume by time, bounded by the start and the end.
 			timestamp := offset.at
 			if offset.afterMilli {
 				createEnd = true
 			} else if timestamp >= 0 || timestamp == -2 && offset.relative > 0 || timestamp == -1 && offset.relative < 0 {
 				timestamp = -2
 				createEnd = true
+			}
+			if offset.ooorMilli != 0 {
+				createByTime = true
 			}
 			p := kmsg.NewListOffsetsRequestTopicPartition()
 			p.Partition = partition
@@ -2728,7 +2796,31 @@ func (o offsetLoadMap) buildListReq(isolationLevel int8) (r1, r2 *kmsg.ListOffse
 		}
 	}
 
-	return r1, r2
+	// A reset after consuming also lists by the last consumed timestamp.
+	// The request keeps every partition in the batch, because
+	// alignListResps prunes a partition that is missing from any one
+	// response. Partitions that are not resetting list the end again,
+	// which we ignore.
+	if createByTime {
+		r3 = kmsg.NewPtrListOffsetsRequest()
+		*r3 = *r1
+		r3.Topics = slices.Clone(r1.Topics)
+		for i := range r1.Topics {
+			l := &r3.Topics[i]
+			r := &r1.Topics[i]
+			*l = *r
+			l.Partitions = slices.Clone(r.Partitions)
+			for i := range l.Partitions {
+				p := &l.Partitions[i]
+				p.Timestamp = -1
+				if milli := o[r.Topic][p.Partition].ooorMilli; milli != 0 {
+					p.Timestamp = milli
+				}
+			}
+		}
+	}
+
+	return r1, r2, r3
 }
 
 func (o offsetLoadMap) buildEpochReq() *kmsg.OffsetForLeaderEpochRequest {

--- a/pkg/kgo/consumer.go
+++ b/pkg/kgo/consumer.go
@@ -2102,7 +2102,7 @@ func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool, 
 		}
 	}
 
-	var reloads listOrEpochLoads
+	var reloads, followUps listOrEpochLoads
 	defer func() {
 		if !reloads.isEmpty() {
 			s.incWorker()
@@ -2136,8 +2136,12 @@ func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool, 
 	for received != issued {
 		loaded := <-results
 		received++
-		reloads.mergeFrom(s.handleListOrEpochResults(loaded))
+		reload, followUp := s.handleListOrEpochResults(loaded)
+		reloads.mergeFrom(reload)
+		followUps.mergeFrom(followUp)
 	}
+
+	followUps.loadWithSession(s, "reset by time after an undefined epoch offset")
 }
 
 // Called within a consumer session, this function handles results from list
@@ -2158,7 +2162,7 @@ func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool, 
 // is not much else we can do. RequestWith already retries, but returns when
 // the retry limit is hit. We will backoff 1s and then allow RequestWith to
 // continue requesting and backing off.
-func (s *consumerSession) handleListOrEpochResults(loaded loadedOffsets) (reloads listOrEpochLoads) {
+func (s *consumerSession) handleListOrEpochResults(loaded loadedOffsets) (reloads, followUps listOrEpochLoads) {
 	// This function can be running twice concurrently, so we need to guard
 	// listOrEpochLoadsLoading and usingCursors. For simplicity, we just
 	// guard this entire function.
@@ -2225,6 +2229,9 @@ func (s *consumerSession) handleListOrEpochResults(loaded loadedOffsets) (reload
 		case load.err == nil:
 			use()
 
+		case errors.Is(load.err, errResetAfterUndefinedEpoch):
+			followUps.addLoad(load.topic, load.partition, loadTypeList, load.request)
+
 		default: // from ErrorCode in a response, or broker request err, or request is canceled as our session is ending
 			reloads.addLoad(load.topic, load.partition, loaded.loadType, load.request)
 			if !kerr.IsRetriable(load.err) && !isRetryableBrokerErr(load.err) && !isDialNonTimeoutErr(load.err) && !isContextErr(load.err) { // non-retryable response error; signal such in a response
@@ -2242,7 +2249,7 @@ func (s *consumerSession) handleListOrEpochResults(loaded loadedOffsets) (reload
 		}
 	}
 
-	return reloads
+	return reloads, followUps
 }
 
 // Splits the loads into per-broker loads, mapping each partition to the broker
@@ -2689,24 +2696,23 @@ func (*Client) loadEpochsForBrokerLoad(ctx context.Context, broker *broker, load
 			var err error
 			switch {
 			case rPartition.EndOffset < 0:
-				// KIP-320 UNDEFINED_EPOCH_OFFSET: a conformant broker
-				// answers endOffset -1 (and leaderEpoch -1) when its
-				// leader-epoch cache holds no record of the requested
-				// epoch - an empty or freshly-truncated cache, an unclean
-				// election to a replica with no epoch history, or an epoch
-				// newer than anything in the log. This is NOT data loss; the
-				// broker simply cannot tell us a truncation point. The old
-				// `EndOffset < offset` arm treated the -1 sentinel as
-				// "truncated to offset -1", surfacing a spurious ErrDataLoss
-				// and pinning the cursor at -1. Instead carry the sentinel
-				// through so the next fetch hits OFFSET_OUT_OF_RANGE and
-				// resets via the configured ConsumeResetOffset (or, under
-				// NoResetOffset, surfaces OOOR rather than a bogus data-loss
-				// error) - the same reset path the cursor already took,
-				// minus the false alarm. Matches the Java client, which
-				// resets per policy on this sentinel rather than comparing
-				// -1 against the validating position.
-				offset = rPartition.EndOffset
+				// KIP-320 UNDEFINED_EPOCH_OFFSET: the broker has no record of the epoch we asked about. Its epoch
+				// cache is empty, or ends before the epoch we consumed at: an unclean election to a replica
+				// without history, or a leader that diverged from the one we consumed from. Asking again gets
+				// the same answer, since a leader's cache only gains the epochs it writes itself. That is not
+				// data loss, but we can no longer trust our offset, so we reset exactly as an out of range fetch
+				// after consuming does: by the last consumed timestamp, never ahead of where we were.
+				loaded.add(loadedOffset{
+					topic:     topic,
+					partition: partition,
+					err:       errResetAfterUndefinedEpoch,
+					request: offsetLoad{
+						replica:   -1,
+						ooorMilli: loadPart.ooorMilli,
+						Offset:    NewOffset().At(offset),
+					},
+				})
+				continue
 			case rPartition.EndOffset < offset:
 				err = &ErrDataLoss{topic, partition, offset, loadPart.epoch, rPartition.EndOffset, rPartition.LeaderEpoch}
 				offset = rPartition.EndOffset

--- a/pkg/kgo/errors.go
+++ b/pkg/kgo/errors.go
@@ -244,6 +244,10 @@ var (
 	// broker misbehavior surfaces in polls; the load is still retried.
 	errNegativeListedOffset = errors.New("broker replied to a ListOffsets request with an invalid negative offset")
 
+	// errResetAfterUndefinedEpoch is our own signal to reset a cursor by
+	// time after an epoch validation could not answer.
+	errResetAfterUndefinedEpoch = errors.New("resetting by time after an undefined epoch offset")
+
 	errFetchNoProgress = errors.New("fetch response contained record batches but none contained or exceeded the requested offset")
 
 	// Injected as a fake errored fetch when an OffsetFetch response

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -204,6 +204,16 @@ type cursorOffset struct {
 	hwm int64
 }
 
+// lastConsumedMilli returns the millisecond of the last record we consumed,
+// or zero if we have consumed nothing. Resetting after an out of range fetch
+// resumes by this millisecond.
+func (o *cursorOffset) lastConsumedMilli() int64 {
+	if o.lastConsumedTime.IsZero() {
+		return 0
+	}
+	return o.lastConsumedTime.UnixMilli()
+}
+
 // use, for fetch requests, freezes a view of the cursorOffset.
 func (c *cursor) use() *cursorOffsetNext {
 	// A source using a cursor has exclusive access to the use field by
@@ -1384,11 +1394,10 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				addList := func(replica int32, log bool) {
 					if s.cl.cfg.resetOffset.noReset {
 						keep = true
-					} else if partOffset.offset >= 0 && !c.lastConsumedTime.IsZero() {
+					} else if !c.lastConsumedTime.IsZero() {
 						// We were consuming and the log changed under us, so rather than follow the reset policy
 						// we resume by the last consumed timestamp, bounded within the log and never ahead of
-						// where we were; see listOffsetsForBrokerLoad. A cursor pinned at -1 by an epoch
-						// validation has no offset to bound and takes the reset policy below.
+						// where we were; see listOffsetsForBrokerLoad.
 						reloadOffsets.addLoad(topic, partition, loadTypeList, offsetLoad{
 							replica:   replica,
 							ooorMilli: c.lastConsumedTime.UnixMilli(),
@@ -1444,6 +1453,9 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 					if kip320 {
 						reloadOffsets.addLoad(topic, partition, loadTypeEpoch, offsetLoad{
 							replica: -1,
+							// If the validation answers UNDEFINED_EPOCH_OFFSET, the reset it issues is by the last
+							// consumed timestamp; see loadEpochsForBrokerLoad.
+							ooorMilli: c.lastConsumedMilli(),
 							Offset: Offset{
 								at:    partOffset.offset,
 								epoch: partOffset.lastConsumedEpoch,
@@ -1470,6 +1482,9 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				if partOffset.lastConsumedEpoch >= 0 {
 					reloadOffsets.addLoad(topic, partition, loadTypeEpoch, offsetLoad{
 						replica: -1,
+						// If the validation answers UNDEFINED_EPOCH_OFFSET, the reset it issues is by the last
+						// consumed timestamp; see loadEpochsForBrokerLoad.
+						ooorMilli: c.lastConsumedMilli(),
 						Offset: Offset{
 							at:    partOffset.offset,
 							epoch: partOffset.lastConsumedEpoch,

--- a/pkg/kgo/source.go
+++ b/pkg/kgo/source.go
@@ -1384,10 +1384,15 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				addList := func(replica int32, log bool) {
 					if s.cl.cfg.resetOffset.noReset {
 						keep = true
-					} else if !c.lastConsumedTime.IsZero() {
+					} else if partOffset.offset >= 0 && !c.lastConsumedTime.IsZero() {
+						// We were consuming and the log changed under us, so rather than follow the reset policy
+						// we resume by the last consumed timestamp, bounded within the log and never ahead of
+						// where we were; see listOffsetsForBrokerLoad. A cursor pinned at -1 by an epoch
+						// validation has no offset to bound and takes the reset policy below.
 						reloadOffsets.addLoad(topic, partition, loadTypeList, offsetLoad{
-							replica: replica,
-							Offset:  NewOffset().AfterMilli(c.lastConsumedTime.UnixMilli()),
+							replica:   replica,
+							ooorMilli: c.lastConsumedTime.UnixMilli(),
+							Offset:    NewOffset().At(partOffset.offset),
 						})
 						if log {
 							s.cl.cfg.logger.Log(LogLevelWarn, "received OFFSET_OUT_OF_RANGE, resetting to the nearest offset; either you were consuming too slowly and the broker has deleted the segment you were in the middle of consuming, or the broker has lost data and has not yet transferred leadership",

--- a/pkg/kgo/topics_and_partitions.go
+++ b/pkg/kgo/topics_and_partitions.go
@@ -686,6 +686,10 @@ func (old *topicPartition) migrateCursorTo( //nolint:revive // old/new naming ma
 		old.cursor.use()
 		css.reloadOffsets.addLoad(old.cursor.topic, old.cursor.partition, loadTypeEpoch, offsetLoad{
 			replica: -1,
+			// If the validation answers UNDEFINED_EPOCH_OFFSET, the reset it
+			// issues is by the last consumed timestamp; see
+			// loadEpochsForBrokerLoad.
+			ooorMilli: old.cursor.lastConsumedMilli(),
 			Offset: Offset{
 				at:    old.cursor.offset,
 				epoch: old.cursor.lastConsumedEpoch,


### PR DESCRIPTION
An OFFSET_OUT_OF_RANGE while consuming can skip records that are still in the log. It comes from resetting by timestamp alone.

### What the reset does today

`source.go` resets to `AfterMilli(lastConsumedTime)`. The broker answers with the earliest offset at or after `logStartOffset` whose record timestamp is at or after ours (`UnifiedLog.searchOffsetInLocalLog` passes `logStartOffset` as the starting offset; `FileRecords.searchForTimestamp` scans forward for the first record at or after it), or -1 if there is none. On -1 we substitute the end listing.

Timestamps are producer-set CreateTime, so offset order does not imply timestamp order.

### The rule

With N the offset that was out of range, start and end the log bounds, and byTime the by-time answer:

```
x = byTime if byTime >= 0 else N
resume = clamp(min(x, N), start, end)
```

| N vs the log | by-time | today | now |
|---|---|---|---|
| below the start | any | first survivor as new as ours, **skipping the rest**; -1 → **the end, skipping the backlog** | the start |
| in range (the log lost data and regrew under us) | at or below N | by-time | by-time: one duplicate on an intact log, the replacement records after a loss |
| in range | above N | by-time, **skipping N through byTime-1** | N |
| in range | -1 | **the end, skipping N through end** | N |
| past the end | a record | by-time | by-time |
| past the end | -1 | the end | the end |

Below the start there is nothing to guess at: everything that still exists is something we never consumed. Past the end the offsets diverged and by-time is the best guess at where we were. In range after an OOOR means the end moved up past us, which is loss then regrowth, so by-time re-reads the replacements rather than skipping them. And by-time is never allowed ahead of N, because everything from N on is unread.

### The change

One round of three listings: start, end, by-time. `buildListReq` returns a third request when a load carries `ooorMilli`, `listOffsetsForBrokerLoad` aligns the three responses pairwise, and the first resolution arm applies the rule. Three listings in one round everywhere, against two today.

### Second commit

The bounding arm always took the leader epoch from the first response even when it took the offset from the second. A cursor at the end offset with the start's epoch gets validated on the next leader change, OffsetForLeaderEpoch answers the end of that old epoch, and we raise `ErrDataLoss` and rewind to it. The epoch now comes from whichever listing supplied the offset; an offset we kept rather than listed gets -1.

### Third commit

An OffsetForLeaderEpoch validation that answers UNDEFINED_EPOCH_OFFSET used to pin the cursor at -1 so the next fetch would fail and reset. That fetch existed only to fail, it sent a negative offset, and it discarded the offset we were at, which the rule above needs. The validation now issues the reset load directly, and epoch loads carry the cursor's last consumed timestamp for it.

### Tests

`TestOutOfRangeBelowStartResetsToStart`: five records stamped an hour ahead, five normal, consume five, delete through 7, require 7/8/9. Before the fix it consumes none of the three.

`TestOutOfRangePastEndResetsByTime`: one fetch past the end answered OOOR; require resuming at the last consumed record.

`TestOutOfRangeInRangeNeverSkipsForward`: N in range with the end above it; a by-time answer above N and a by-time answer of -1 both resume at N.

Note that kfake fills in `LogStartOffset` on an OOOR fetch response, which Kafka does not: `handleOffsetOutOfRangeError` falls to the error-only `LogReadResult` for non-tiered topics, so the field is -1. Nothing here relies on it.
