### PR TITLE
kfake: stop claiming any first sequence is accepted after a topic delete

### DIFF
--- a/pkg/kfake/20_delete_topics.go
+++ b/pkg/kfake/20_delete_topics.go
@@ -103,11 +103,11 @@ func (c *Cluster) handleDeleteTopics(creq *clientReq) (kmsg.Response, error) {
 			delete(c.data.tcfgs, td.topic)
 			delete(c.data.tnorms, normalizeTopicName(td.topic))
 			// Producer state is per-log and dies with the topic: a
-			// recreated topic rehydrates empty state, accepting any
-			// first sequence (the 2.5+ broker semantics we model).
-			// Transactional REGISTRATIONS survive (the coordinator is
-			// name-keyed on a real broker); endTx re-resolves current
-			// partition data when writing markers.
+			// recreated topic rehydrates empty state, and handleProduce
+			// decides what each version accepts from a producer it has
+			// no state for. Transactional REGISTRATIONS survive (the
+			// coordinator is name-keyed on a real broker); endTx
+			// re-resolves current partition data when writing markers.
 			for _, pidinf := range c.pids.ids {
 				delete(pidinf.windows, td.topic)
 			}


### PR DESCRIPTION
The delete-topics comment said a recreated topic accepts any first sequence, the 2.5+ semantics. Since #1417 the uncapped cluster models KAFKA-15591 and accepts only a first sequence of zero on a never-written partition, and clusters capped below 2.5 reject a continued sequence. The comment now points at handleProduce, which holds the per-version rule. Comment only.